### PR TITLE
feat: 右クリックコンテクストメニュー機能を追加 (#25)

### DIFF
--- a/src/components/graph/ContextMenu.test.tsx
+++ b/src/components/graph/ContextMenu.test.tsx
@@ -30,7 +30,9 @@ describe('ContextMenu', () => {
 
   beforeEach(() => {
     mockOnClose.mockClear();
-    defaultItems.forEach((item) => (item.onClick as ReturnType<typeof vi.fn>).mockClear());
+    for (const item of defaultItems) {
+      (item.onClick as ReturnType<typeof vi.fn>).mockClear();
+    }
   });
 
   it('指定された位置にメニューを表示する', () => {

--- a/src/components/graph/ContextMenu.tsx
+++ b/src/components/graph/ContextMenu.tsx
@@ -168,7 +168,7 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
     <div
       ref={menuRef}
       role="menu"
-      className="fixed z-50 bg-white border border-gray-300 rounded-md shadow-lg min-w-[200px]"
+      className="fixed z-50 bg-white border border-gray-300 rounded-md shadow-lg min-w-[200px] max-h-[400px] overflow-y-auto"
       style={{
         left: `${position.x}px`,
         top: `${position.y}px`,
@@ -199,6 +199,9 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
                 : 'text-gray-700 hover:bg-gray-100'
             }`}
             onClick={() => handleItemClick(item)}
+            onFocus={() => {
+              focusedIndexRef.current = currentInteractiveIndex;
+            }}
           >
             {/* 画像がある場合は画像を表示 */}
             {item.imageUrl ? (

--- a/src/components/graph/useContextMenu.ts
+++ b/src/components/graph/useContextMenu.ts
@@ -30,7 +30,7 @@ export type ContextMenuState =
  * メニューサイズの定数（位置補正用）
  */
 const MENU_WIDTH = 200;
-const MENU_HEIGHT = 200;
+const MAX_MENU_HEIGHT = 400; // スクロール可能な最大高さ
 
 /**
  * コンテキストメニューの状態管理フック
@@ -64,8 +64,8 @@ export function useContextMenu(
       }
 
       // 画面下端でメニューがはみ出す場合は上に補正
-      if (adjustedY + MENU_HEIGHT > window.innerHeight) {
-        adjustedY = window.innerHeight - MENU_HEIGHT;
+      if (adjustedY + MAX_MENU_HEIGHT > window.innerHeight) {
+        adjustedY = window.innerHeight - MAX_MENU_HEIGHT;
       }
 
       return { x: adjustedX, y: adjustedY };
@@ -137,13 +137,14 @@ export function useContextMenu(
    */
   const switchToAddRelationshipMode = useCallback(
     (sourceNodeId: string, position: { x: number; y: number }) => {
+      const adjustedPosition = adjustPosition(position.x, position.y);
       setContextMenu({
         type: 'add-relationship',
         sourceNodeId,
-        position,
+        position: adjustedPosition,
       });
     },
-    []
+    [adjustPosition]
   );
 
   return {


### PR DESCRIPTION
## 概要

ノード・エッジ・背景の右クリックに応じたコンテクストメニューを実装しました。

## 主な機能

### ノード右クリック
- **中心に表示**: ノードをビューポートの中心に移動
- **関係を追加**: まだ繋がっていないノードのリストを表示（画像付き）し、選択すると関係作成モーダルが開く
- **編集**: サイドパネルで編集フォームを表示
- **削除**: 確認ダイアログ後に削除

### エッジ右クリック
- **関係を編集**: 2人選択状態に遷移
- **関係を削除**: 確認ダイアログ後に削除

### 背景右クリック
- **ここに人物を追加**: クリック位置に人物登録モーダルを表示
- **選択をすべて解除**: 選択がある場合のみ表示

## 実装詳細

### 新規ファイル
- `src/components/graph/useContextMenu.ts`: メニュー状態管理フック
- `src/components/graph/useContextMenu.test.ts`: フックのテスト（7件）
- `src/components/graph/ContextMenu.tsx`: 汎用コンテキストメニューUIコンポーネント
- `src/components/graph/ContextMenu.test.tsx`: コンポーネントのテスト（17件）

### 主な機能
- 画面端での位置補正
- キーボードナビゲーション（ArrowUp/Down、Home/End、Enter/Escape）
- アクセシビリティ対応（role属性、自動フォーカス）
- メニュー外クリックで閉じる
- 画像付きメニュー項目（人物アイコン表示）
- モード切り替え機能（関係追加モード）

## スクリーンショット

### ノード右クリック
- 中心に表示
- 関係を追加（未接続ノードが存在する場合のみ表示）
- 編集
- 削除

### 関係追加モード
- 戻る
- まだ繋がっていないノードのリスト（画像 + 名前）

## テストプラン

- [x] ノード右クリックでメニューが表示される
- [x] エッジ右クリックでメニューが表示される
- [x] 背景右クリックでメニューが表示される
- [x] メニュー項目をクリックすると適切なアクションが実行される
- [x] Escキーでメニューが閉じる
- [x] メニュー外クリックでメニューが閉じる
- [x] ArrowUp/Downでフォーカス移動する
- [x] 画面端でメニューがはみ出さない
- [x] 「関係を追加」でノードリストが表示される
- [x] ノードリストに画像が表示される
- [x] 「戻る」でノードメニューに戻る

## 品質チェック

- ✅ **Lint**: エラー・警告なし
- ✅ **型チェック**: エラーなし
- ✅ **テスト**: 292件パス、12件スキップ
- ✅ **TDD**: すべてのテストを先に作成してから実装

## 関連issue

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * グラフに右クリックのコンテキストメニューを追加。ノード／エッジ／ペインと「関係追加」モードに対応。
  * メニューの画面位置補正と初期フォーカス管理を含むコンテキストメニュー状態管理を導入。

* **Accessibility**
  * キーボード操作（Escape、矢印、Home/End、Enter）と適切なフォーカス/役割属性を実装。

* **Tests**
  * コンテキストメニューと状態管理の包括的なテストスイートを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->