### PR TITLE
feat: LocalStorageをリセットする機能を追加

### DIFF
--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -95,6 +95,7 @@ export function SidePanel() {
           <h1 className="text-xl font-bold text-gray-900">人物相関図作る君</h1>
           {/* リセットボタン */}
           <button
+            type="button"
             onClick={handleReset}
             className="rounded p-1.5 text-gray-600 hover:bg-gray-100 hover:text-gray-900"
             aria-label="すべてのデータをリセット"

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -1890,6 +1890,16 @@ describe('useGraphStore', () => {
       });
       expect(result.current.sidePanelOpen).toBe(true);
 
+      // LocalStorageも初期値に更新されることを確認
+      const storedData = localStorage.getItem('relationship-chart-storage');
+      expect(storedData).toBeTruthy();
+      const parsedData = JSON.parse(storedData!);
+      expect(parsedData.state.persons).toEqual([]);
+      expect(parsedData.state.relationships).toEqual([]);
+      expect(parsedData.state.selectedPersonIds).toEqual([]);
+      expect(parsedData.state.forceEnabled).toBe(true);
+      expect(parsedData.state.sidePanelOpen).toBe(true);
+
       // Undo/Redo履歴もクリアされることを確認
       // リセット後にundoしても何も起こらない
       act(() => {
@@ -1920,6 +1930,13 @@ describe('useGraphStore', () => {
       expect(result.current.selectedPersonIds).toEqual([]);
       expect(result.current.forceEnabled).toBe(true);
       expect(result.current.sidePanelOpen).toBe(true);
+
+      // LocalStorageも初期値であることを確認
+      const storedData = localStorage.getItem('relationship-chart-storage');
+      expect(storedData).toBeTruthy();
+      const parsedData = JSON.parse(storedData!);
+      expect(parsedData.state.persons).toEqual([]);
+      expect(parsedData.state.relationships).toEqual([]);
     });
   });
 });

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -32,6 +32,18 @@ export const DEFAULT_FORCE_PARAMS: ForceParams = {
 };
 
 /**
+ * グラフストアの初期状態
+ */
+const INITIAL_STATE: GraphState = {
+  persons: [],
+  relationships: [],
+  forceEnabled: true,
+  selectedPersonIds: [],
+  forceParams: DEFAULT_FORCE_PARAMS,
+  sidePanelOpen: true,
+};
+
+/**
  * グラフストアの状態型
  */
 type GraphState = {
@@ -220,12 +232,7 @@ export const useGraphStore = create<GraphStore>()(
     temporal(
       (set) => ({
         // 初期状態
-        persons: [],
-        relationships: [],
-        forceEnabled: true, // デフォルトでforce-directedレイアウトを有効
-        selectedPersonIds: [], // 初期状態では何も選択されていない
-        forceParams: DEFAULT_FORCE_PARAMS, // デフォルトのforceパラメータ
-        sidePanelOpen: true, // デフォルトでサイドパネルを開く
+        ...INITIAL_STATE,
 
         // アクション
         addPerson: (person) =>
@@ -366,7 +373,7 @@ export const useGraphStore = create<GraphStore>()(
           })),
 
         resetAll: () => {
-          // 全状態を初期値にリセット
+          // 全状態を初期値にリセット（INITIAL_STATEと一致させること）
           set(() => ({
             persons: [],
             relationships: [],


### PR DESCRIPTION
## 概要

ユーザーが作成した人物相関図のデータを一括リセットする機能を追加しました（issue #28）。

## 変更内容

### 1. Zustandストアに`resetAll`アクションを追加
- すべてのデータと状態を初期値にリセットする`resetAll`アクションを実装
- リセット内容：
  - `persons: []`, `relationships: []`, `selectedPersonIds: []`
  - `forceEnabled: true`, `forceParams: DEFAULT_FORCE_PARAMS`, `sidePanelOpen: true`
- Zustandのpersistミドルウェアが自動的にLocalStorageも更新
- temporalミドルウェアのUndo/Redo履歴もクリア

### 2. SidePanelにリセットボタンを追加
- ヘッダーの「人物相関図作る君」タイトルの右側にリセットアイコンボタンを配置
- lucide-reactの`RotateCcw`アイコンを使用
- クリック時に確認ダイアログ（`window.confirm`）を表示
- 確認メッセージ：「すべてのデータを削除してリセットしてもよろしいですか？この操作は元に戻せません。」

### 3. テストケースを追加
- データが存在する状態からリセットすると全状態が初期値に戻ることを検証
- 空の状態でリセットしてもエラーにならないことを検証
- Undo/Redo履歴もクリアされることを検証

## テストプラン

- [x] `npm run type-check` - 型チェックが通ること
- [x] `npm run lint` - Lintエラー・警告がないこと
- [x] `npm test` - すべてのテストが通ること（329テスト合格）
- [x] ブラウザで手動確認：
  - 人物・関係を追加 → リセットボタン押下 → confirm表示 → OK → データがクリアされること
  - confirmでキャンセルした場合、データが保持されること
  - リセット後、ページリロードしてもデータが復元されないこと（LocalStorageもクリアされていること）

## 関連issue

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * グラフデータとUI状態全体をリセットする機能を追加しました。ユーザーはヘッダーのリセットボタンをクリックすると、確認ダイアログが表示され、すべてのデータを初期状態に戻すことができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->