### PR TITLE
fix: グラフ全体が収まる画像エクスポート機能を実装

### DIFF
--- a/src/lib/capture-utils.test.ts
+++ b/src/lib/capture-utils.test.ts
@@ -9,6 +9,7 @@ import {
   downloadImage,
   copyImageToClipboard,
   openXPost,
+  calculateImageDimensions,
 } from './capture-utils';
 
 describe('capture-utils', () => {
@@ -163,6 +164,54 @@ describe('capture-utils', () => {
         '_blank',
         'noopener,noreferrer'
       );
+    });
+  });
+
+  describe('calculateImageDimensions', () => {
+    it('ノードが狭い範囲にある場合、最小サイズ (1024x768) を返すこと', () => {
+      // ノード境界が 500x400（パディング込みで 700x560）の場合
+      const nodesBounds = { width: 500, height: 400 };
+
+      const result = calculateImageDimensions(nodesBounds);
+
+      // 最小サイズが適用されること
+      expect(result.width).toBe(1024);
+      expect(result.height).toBe(768);
+    });
+
+    it('ノードが広範囲にある場合、パディング付きサイズを返すこと', () => {
+      // ノード境界が 1500x1000（パディング込みで 2100x1400）の場合
+      const nodesBounds = { width: 1500, height: 1000 };
+
+      const result = calculateImageDimensions(nodesBounds);
+
+      // パディング20%を含むサイズが返されること
+      // width: 1500 * (1 + 0.2 * 2) = 1500 * 1.4 = 2100
+      // height: 1000 * (1 + 0.2 * 2) = 1000 * 1.4 = 1400
+      expect(result.width).toBe(2100);
+      expect(result.height).toBe(1400);
+    });
+
+    it('ノードが非常に広範囲にある場合、最大サイズ (4096x3072) を超えないこと', () => {
+      // ノード境界が 5000x4000（パディング込みで 7000x5600）の場合
+      const nodesBounds = { width: 5000, height: 4000 };
+
+      const result = calculateImageDimensions(nodesBounds);
+
+      // 最大サイズが適用されること
+      expect(result.width).toBe(4096);
+      expect(result.height).toBe(3072);
+    });
+
+    it('パディング付きサイズが切り上げられること', () => {
+      // ノード境界が 1001x801（パディング込みで 1401.4x1121.4）の場合
+      const nodesBounds = { width: 1001, height: 801 };
+
+      const result = calculateImageDimensions(nodesBounds);
+
+      // Math.ceilで切り上げられること
+      expect(result.width).toBe(1402); // 1001 * 1.4 = 1401.4 → 1402
+      expect(result.height).toBe(1122); // 801 * 1.4 = 1121.4 → 1122
     });
   });
 });


### PR DESCRIPTION
## 概要

共有の画像化時にグラフ全体が入らない問題を修正しました。

**原因**: 出力画像サイズが 1024x768px に固定されており、最小ズームが 0.5 に制限されていたため、ノードが広範囲に分散している場合（境界が 2048x1536px を超える場合）全体が収まりませんでした。

**解決策**: ノード境界のサイズに応じて出力画像のピクセルサイズを動的に計算する仕組みを実装しました。

## 変更内容

### `src/lib/capture-utils.ts`
- **`calculateImageDimensions`** 関数を新規追加（export）
  - 最小サイズ (1024x768) を保証（ノードが少ない場合も小さくなりすぎない）
  - 最大サイズ (4096x3072) で上限を設定（メモリ保護）
  - パディングを 10% → 20% に増やしてエッジラベルのはみ出しを防止
- **`getCaptureBounds`** を改修
  - 動的な `imageWidth` / `imageHeight` を返すように変更
  - 最小ズームを 0.5 → 0.01 に緩和し、広範囲のノードでも全体が収まるように改善
- **`captureCanvasAsPng`** / **`captureCanvasAsBlob`** を改修
  - 固定サイズではなく動的に計算されたサイズを使用

### `src/lib/capture-utils.test.ts`
- `calculateImageDimensions` のユニットテストを4ケース追加
  - ノードが狭い範囲にある場合 → 最小サイズ (1024x768) を返すこと
  - ノードが広範囲にある場合 → パディング付きサイズを返すこと
  - ノードが非常に広範囲にある場合 → 最大サイズ (4096x3072) を超えないこと
  - パディング付きサイズが切り上げられること

## テスト

### TDDサイクル
✅ **RED**: 失敗するテストを先に書く  
✅ **GREEN**: テストを通す最小限のコードを書く  
✅ **REFACTOR**: コードを整理する  

### 品質チェック結果
```bash
✅ Lint: エラー・警告なし
✅ 型チェック: エラーなし
✅ テスト: 419個すべて成功
```

## 手動確認の推奨

以下のシナリオで動作確認することをお勧めします：

- [ ] **ノードを広範囲に配置** → 共有ボタンをクリック → 画像プレビューで全ノードが含まれていることを確認
- [ ] **ノードが少ない場合** → 適切なサイズ（最小1024x768）で出力されることを確認
- [ ] **ノードが非常に多い場合** → 最大サイズ（4096x3072）を超えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * キャプチャ機能にダイナミック画像サイジングを実装。ノードのサイズに基づいて、パディングと最小/最大制約を適用した最適な画像寸法を自動計算します。

* **Tests**
  * 新しい画像サイズ計算ロジック向けにテストスイートを追加。4つのテストケースで動作を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->