### PR TITLE
fix: 関係クリック時のビューポートズーム改善

### DIFF
--- a/src/components/graph/SearchBar.tsx
+++ b/src/components/graph/SearchBar.tsx
@@ -12,7 +12,12 @@ import { Panel, useReactFlow } from '@xyflow/react';
 import { Search, User, Package, ArrowRight, ArrowLeftRight, Minus } from 'lucide-react';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { searchGraph, type SearchResult } from '@/lib/search-utils';
-import { getNodeCenter, VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils';
+import {
+  getNodeCenter,
+  VIEWPORT_ANIMATION_DURATION,
+  VIEWPORT_FIT_PADDING,
+  VIEWPORT_MAX_ZOOM,
+} from '@/lib/viewport-utils';
 
 /**
  * ノードアイコンコンポーネント
@@ -140,8 +145,8 @@ export default function SearchBar() {
       // ビューポートを2つのノードにフィット（両ノードが画面内に収まるようズーム調整）
       fitView({
         nodes: [{ id: sourcePersonId }, { id: targetPersonId }],
-        padding: 0.3,
-        maxZoom: 1,
+        padding: VIEWPORT_FIT_PADDING,
+        maxZoom: VIEWPORT_MAX_ZOOM,
         duration: VIEWPORT_ANIMATION_DURATION,
       });
 

--- a/src/components/panel/SingleSelectionPanel.test.tsx
+++ b/src/components/panel/SingleSelectionPanel.test.tsx
@@ -27,6 +27,11 @@ vi.mock('@xyflow/react', () => ({
 // 動的importのため型をimport
 import { useGraphStore } from '@/stores/useGraphStore';
 import { useReactFlow } from '@xyflow/react';
+import {
+  VIEWPORT_ANIMATION_DURATION,
+  VIEWPORT_FIT_PADDING,
+  VIEWPORT_MAX_ZOOM,
+} from '@/lib/viewport-utils';
 
 describe('SingleSelectionPanel - 関係クリック遷移', () => {
   const mockSetSelectedPersonIds = vi.fn();
@@ -164,48 +169,12 @@ describe('SingleSelectionPanel - 関係クリック遷移', () => {
     // fitViewが両ノードIDで呼ばれることを確認
     expect(mockFitView).toHaveBeenCalledWith({
       nodes: [{ id: 'person-1' }, { id: 'person-2' }],
-      padding: 0.3,
-      maxZoom: 1,
-      duration: 500,
+      padding: VIEWPORT_FIT_PADDING,
+      maxZoom: VIEWPORT_MAX_ZOOM,
+      duration: VIEWPORT_ANIMATION_DURATION,
     });
   });
 
-  it('ノードが見つからない場合、ビューポート移動は呼ばれない', async () => {
-    const user = userEvent.setup();
-
-    // ノードが見つからない
-    mockGetNode.mockReturnValue(undefined);
-
-    render(<SingleSelectionPanel person={testPerson} />);
-
-    // 関係行をクリック
-    const relationshipRow = screen.getByText('親友').closest('div[role="button"]') as HTMLElement;
-    await user.click(relationshipRow);
-
-    // setSelectedPersonIdsは呼ばれる
-    expect(mockSetSelectedPersonIds).toHaveBeenCalledWith(['person-1', 'person-2']);
-
-    // ビューポート移動は呼ばれない
-    expect(mockSetCenter).not.toHaveBeenCalled();
-  });
-
-  it('ノード位置に関わらずfitViewが正しく呼ばれる', async () => {
-    const user = userEvent.setup();
-
-    render(<SingleSelectionPanel person={testPerson} />);
-
-    // 関係行をクリック
-    const relationshipRow = screen.getByText('親友').closest('div[role="button"]') as HTMLElement;
-    await user.click(relationshipRow);
-
-    // fitViewが両ノードIDで呼ばれることを確認（ノード位置は関係なし）
-    expect(mockFitView).toHaveBeenCalledWith({
-      nodes: [{ id: 'person-1' }, { id: 'person-2' }],
-      padding: 0.3,
-      maxZoom: 1,
-      duration: 500,
-    });
-  });
 
   it('キーボード操作でもビューポートが2ノードにフィットする', async () => {
     const user = userEvent.setup();
@@ -222,9 +191,9 @@ describe('SingleSelectionPanel - 関係クリック遷移', () => {
     // fitViewが呼ばれることを確認
     expect(mockFitView).toHaveBeenCalledWith({
       nodes: [{ id: 'person-1' }, { id: 'person-2' }],
-      padding: 0.3,
-      maxZoom: 1,
-      duration: 500,
+      padding: VIEWPORT_FIT_PADDING,
+      maxZoom: VIEWPORT_MAX_ZOOM,
+      duration: VIEWPORT_ANIMATION_DURATION,
     });
   });
 });

--- a/src/components/panel/SingleSelectionPanel.tsx
+++ b/src/components/panel/SingleSelectionPanel.tsx
@@ -12,7 +12,11 @@ import { useReactFlow } from '@xyflow/react';
 import type { Person } from '@/types/person';
 import type { Relationship } from '@/types/relationship';
 import { getRelationshipFromPerspective } from '@/lib/relationship-utils';
-import { VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils';
+import {
+  VIEWPORT_ANIMATION_DURATION,
+  VIEWPORT_FIT_PADDING,
+  VIEWPORT_MAX_ZOOM,
+} from '@/lib/viewport-utils';
 
 /**
  * SingleSelectionPanelのプロパティ
@@ -107,8 +111,8 @@ export function SingleSelectionPanel({ person }: SingleSelectionPanelProps) {
                 // ビューポートを2つのノードにフィット（両ノードが画面内に収まるようズーム調整）
                 fitView({
                   nodes: [{ id: person.id }, { id: otherPerson.id }],
-                  padding: 0.3,
-                  maxZoom: 1,
+                  padding: VIEWPORT_FIT_PADDING,
+                  maxZoom: VIEWPORT_MAX_ZOOM,
                   duration: VIEWPORT_ANIMATION_DURATION,
                 });
               };

--- a/src/lib/viewport-utils.ts
+++ b/src/lib/viewport-utils.ts
@@ -20,6 +20,16 @@ export const DEFAULT_NODE_HEIGHT = 120;
 export const VIEWPORT_ANIMATION_DURATION = 500;
 
 /**
+ * fitViewのパディング（ノード周囲の余白比率）
+ */
+export const VIEWPORT_FIT_PADDING = 0.3;
+
+/**
+ * fitViewの最大ズーム倍率
+ */
+export const VIEWPORT_MAX_ZOOM = 1;
+
+/**
  * ノードの中心座標を計算する
  * @param node - React Flowのノード
  * @returns ノードの中心座標 { x, y }


### PR DESCRIPTION
## Summary
サイドパネルや検索バーから関係（エッジ）をクリックすると、`setCenter`で2ノードの中間点に移動していましたが、ズームレベルが変更されないため、ズームイン状態ではエッジのラベルだけが大写しになり、接続先のノードが画面外に出てしまう問題を修正しました。

`setCenter`を`fitView`に置き換えることで、両端のノードが常に画面内に収まるよう自動的にズームレベルが調整されるようになりました。

## 変更内容
- **SingleSelectionPanel.tsx**: 関係クリック時のビューポート移動処理を`setCenter`から`fitView`に変更
- **SearchBar.tsx**: 検索バーからの関係選択時のビューポート移動処理を同様に変更
- **テストファイル**: `fitView`のモックを追加し、テストを修正

## fitViewのパラメータ
```typescript
fitView({
  nodes: [{ id: nodeId1 }, { id: nodeId2 }],
  padding: 0.3,      // ノード周囲に30%の余白
  maxZoom: 1,        // 最大ズーム100%（過度なズームインを防止）
  duration: 500,     // アニメーション時間
})
```

## Test plan
- [x] サイドパネルで人物を1人選択し、関係一覧から関係をクリック → 両端のノードが画面内に表示される
- [x] 検索バーで関係を検索して選択 → 同様に両端ノードが表示される
- [x] ズームインした状態から関係をクリック → ズームアウトされて両ノードが見える
- [x] ズームアウトした状態から関係をクリック → 適切にズームインされる（ただしmaxZoom: 1を超えない）
- [x] \`npm run lint && npm run type-check && npm test\` がすべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * グラフ内の関係をクリック時の視点調整機能を改善。2つのノードが適切に表示されるよう、より洗練されたズーム・パンアニメーションを実装しました。

* **テスト**
  * 視点調整機能に関するテストケースを更新し、新しい動作を反映させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->