### PR TITLE
feat: サイドパネルヘッダーに作者リンクを追加

### DIFF
--- a/src/components/graph/AuthorAttribution.test.tsx
+++ b/src/components/graph/AuthorAttribution.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * AuthorAttribution コンポーネントのテスト
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AuthorAttribution } from './AuthorAttribution';
+
+describe('AuthorAttribution', () => {
+  it('Xへのリンクが正しいURLで表示されること', () => {
+    render(<AuthorAttribution />);
+    const xLink = screen.getByRole('link', { name: /@mtane0412/i });
+    expect(xLink).toHaveAttribute('href', 'https://x.com/mtane0412');
+  });
+
+  it('GitHubへのリンクが正しいURLで表示されること', () => {
+    render(<AuthorAttribution />);
+    const githubLink = screen.getByRole('link', { name: /github/i });
+    expect(githubLink).toHaveAttribute(
+      'href',
+      'https://github.com/mtane0412/relationship-chart'
+    );
+  });
+
+  it('すべてのリンクがtarget="_blank"で新しいタブで開くこと', () => {
+    render(<AuthorAttribution />);
+    const links = screen.getAllByRole('link');
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  it('XとGitHubの2つのリンクが表示されること', () => {
+    render(<AuthorAttribution />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+  });
+});

--- a/src/components/graph/AuthorAttribution.tsx
+++ b/src/components/graph/AuthorAttribution.tsx
@@ -1,0 +1,44 @@
+/**
+ * 作者のリンクを表示するコンポーネント
+ * サイドパネルのヘッダー内にアイコンのみを表示する
+ */
+import { Github } from 'lucide-react';
+
+/**
+ * 作者のリンクを表示するコンポーネント（アイコンのみ）
+ */
+export function AuthorAttribution() {
+  return (
+    <div className="flex items-center gap-2">
+      {/* Xリンク */}
+      <a
+        href="https://x.com/mtane0412"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-gray-400 hover:text-gray-600 transition-colors"
+        aria-label="X (@mtane0412)"
+      >
+        {/* Xアイコン（インラインSVG） */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      </a>
+
+      {/* GitHubリンク */}
+      <a
+        href="https://github.com/mtane0412/relationship-chart"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-gray-400 hover:text-gray-600 transition-colors"
+        aria-label="GitHub Repository"
+      >
+        <Github size={16} />
+      </a>
+    </div>
+  );
+}

--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -10,6 +10,7 @@ import { DefaultPanel } from './DefaultPanel';
 import { SingleSelectionPanel } from './SingleSelectionPanel';
 import { PairSelectionPanel } from './PairSelectionPanel';
 import { MultipleSelectionInfo } from './MultipleSelectionInfo';
+import { AuthorAttribution } from '@/components/graph/AuthorAttribution';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { useDialogStore } from '@/stores/useDialogStore';
 
@@ -65,7 +66,11 @@ export function SidePanel() {
       {/* ヘッダー */}
       <div className="p-4 border-b border-gray-200">
         <div className="flex items-center justify-between">
-          <h1 className="text-xl font-bold text-gray-900">人物相関図作る君</h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-bold text-gray-900">人物相関図作る君</h1>
+            {/* 作者リンク */}
+            <AuthorAttribution />
+          </div>
           {/* リセットボタン */}
           <button
             type="button"


### PR DESCRIPTION
## 概要

サイドパネルの「人物相関図作る君」タイトルの右隣に、XとGitHubへのリンクアイコンを追加しました。

## 変更内容

### 新規ファイル

- **`src/components/graph/AuthorAttribution.tsx`**: 作者リンクコンポーネント
  - XとGitHubへのリンクアイコンを表示
  - `target="_blank" rel="noopener noreferrer"`で安全に新規タブで開く
  - アイコンのみのシンプルなデザイン

- **`src/components/graph/AuthorAttribution.test.tsx`**: テストファイル
  - リンクURLが正しいことを検証
  - セキュリティ属性（`target="_blank"`, `rel="noopener noreferrer"`）を検証
  - アクセシビリティ属性（`aria-label`）を検証

### 既存ファイルの変更

- **`src/components/panel/SidePanel.tsx`**:
  - ヘッダー内にAuthorAttributionコンポーネントを追加
  - タイトルとリンクアイコンを横並びで配置

## スクリーンショット

サイドパネルのヘッダー「人物相関図作る君」の右隣に、XとGitHubのアイコンが表示されます。

## テスト

✅ すべてのテストがパス（424 tests passed）  
✅ Lintチェック完了  
✅ 型チェック完了

## チェックリスト

- [x] CodeRabbit事前チェック完了
- [x] デバッグコード削除
- [x] エラーハンドリング実装（該当なし）
- [x] Magic number排除
- [x] アクセシビリティ確保（aria-label設定）
- [x] セキュリティ確保（target="_blank" rel="noopener noreferrer"）
- [x] Lintチェック完了
- [x] 型チェック完了
- [x] テスト実装・実行完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* アプリケーションのヘッダーに作成者アトリビューション機能を追加しました。XおよびGitHubプロフィールへのリンクが新たに利用できるようになります。

## テスト
* 新しいアトリビューション機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->