### PR TITLE
fix: IME変換中のCmd+Kショートカット競合を修正

### DIFF
--- a/src/components/graph/SearchBar.test.tsx
+++ b/src/components/graph/SearchBar.test.tsx
@@ -486,6 +486,67 @@ describe('SearchBar', () => {
         expect(selectPerson).toHaveBeenCalledWith('person1');
       });
     });
+
+    it('IME変換中のCmd+Kは無視される', async () => {
+      render(
+        <ReactFlowProvider>
+          <SearchBar />
+        </ReactFlowProvider>
+      );
+
+      const combobox = screen.getByRole('combobox') as HTMLInputElement;
+
+      // 検索クエリを入力
+      combobox.value = 'テスト';
+      combobox.blur(); // フォーカスを外す
+
+      // IME変換中のCmd+Kイベントをシミュレート
+      const composingCmdKEvent = new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+        isComposing: true,
+      });
+
+      window.dispatchEvent(composingCmdKEvent);
+
+      // フォーカスされないことを確認（IME変換中は無視される）
+      expect(combobox).not.toHaveFocus();
+    });
+
+    it('IME変換確定後のCmd+Kで検索入力フィールドにフォーカスする', async () => {
+      render(
+        <ReactFlowProvider>
+          <SearchBar />
+        </ReactFlowProvider>
+      );
+
+      const combobox = screen.getByRole('combobox') as HTMLInputElement;
+
+      // 検索クエリを入力
+      combobox.value = 'テスト';
+      combobox.blur(); // フォーカスを外す
+
+      // IME変換確定後のCmd+Kイベントをシミュレート
+      const normalCmdKEvent = new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+        isComposing: false,
+      });
+
+      window.dispatchEvent(normalCmdKEvent);
+
+      await waitFor(() => {
+        // フォーカスされることを確認
+        expect(combobox).toHaveFocus();
+        // 全選択されていることを確認
+        expect(combobox.selectionStart).toBe(0);
+        expect(combobox.selectionEnd).toBe(combobox.value.length);
+      });
+    });
   });
 
   describe('結果選択', () => {

--- a/src/components/graph/SearchBar.test.tsx
+++ b/src/components/graph/SearchBar.test.tsx
@@ -488,6 +488,7 @@ describe('SearchBar', () => {
     });
 
     it('IME変換中のCmd+Kは無視される', async () => {
+      const user = userEvent.setup();
       render(
         <ReactFlowProvider>
           <SearchBar />
@@ -496,9 +497,13 @@ describe('SearchBar', () => {
 
       const combobox = screen.getByRole('combobox') as HTMLInputElement;
 
-      // 検索クエリを入力
-      combobox.value = 'テスト';
-      combobox.blur(); // フォーカスを外す
+      // 事前に入力しておく
+      await user.type(combobox, 'テスト');
+      expect(combobox.value).toBe('テスト');
+
+      // フォーカスを外す
+      combobox.blur();
+      expect(combobox).not.toHaveFocus();
 
       // IME変換中のCmd+Kイベントをシミュレート
       const composingCmdKEvent = new KeyboardEvent('keydown', {
@@ -516,6 +521,7 @@ describe('SearchBar', () => {
     });
 
     it('IME変換確定後のCmd+Kで検索入力フィールドにフォーカスする', async () => {
+      const user = userEvent.setup();
       render(
         <ReactFlowProvider>
           <SearchBar />
@@ -524,9 +530,13 @@ describe('SearchBar', () => {
 
       const combobox = screen.getByRole('combobox') as HTMLInputElement;
 
-      // 検索クエリを入力
-      combobox.value = 'テスト';
-      combobox.blur(); // フォーカスを外す
+      // 事前に入力しておく
+      await user.type(combobox, 'テスト');
+      expect(combobox.value).toBe('テスト');
+
+      // フォーカスを外す
+      combobox.blur();
+      expect(combobox).not.toHaveFocus();
 
       // IME変換確定後のCmd+Kイベントをシミュレート
       const normalCmdKEvent = new KeyboardEvent('keydown', {

--- a/src/components/graph/SearchBar.tsx
+++ b/src/components/graph/SearchBar.tsx
@@ -103,6 +103,11 @@ export default function SearchBar() {
     function handleKeyDown(event: KeyboardEvent) {
       // Cmd+K (Mac) または Ctrl+K (Windows/Linux)
       if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        // IME変換中は無視（日本語入力のカタカナ変換などと競合しないようにする）
+        if (event.isComposing) {
+          return;
+        }
+
         event.preventDefault();
         if (inputRef.current) {
           inputRef.current.focus();


### PR DESCRIPTION
## Summary
- IME変換中にCmd+Kでカタカナ変換しようとすると、検索ショートカットが反応してしまう問題を修正
- SearchBar.tsxのキーボードショートカットリスナーに`event.isComposing`チェックを追加
- IME変換中のCmd+Kショートカットに関するテストケースを追加

## Test plan
- [x] テスト実行（22件中22件成功）
- [x] Lintチェック（エラー・警告なし）
- [x] 型チェック（エラーなし）
- [x] ビルド確認（成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)