### PR TITLE
feat: PairSelectionPanelにv9定型フィールドのUIを追加 (#75)

### DIFF
--- a/src/components/panel/PairSelectionPanel.test.tsx
+++ b/src/components/panel/PairSelectionPanel.test.tsx
@@ -1459,7 +1459,7 @@ describe('PairSelectionPanel', () => {
       );
 
       expect(screen.getByText('タグから派生')).toBeInTheDocument();
-      expect(screen.queryByRole('textbox', { name: /エッジの色/ })).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('エッジの色')).not.toBeInTheDocument();
     });
 
     it('「上書きする」ボタンをクリックするとカラーピッカーが現れる', async () => {

--- a/src/components/panel/PairSelectionPanel.test.tsx
+++ b/src/components/panel/PairSelectionPanel.test.tsx
@@ -9,6 +9,7 @@ import { ReactFlowProvider } from '@xyflow/react';
 import { PairSelectionPanel } from './PairSelectionPanel';
 import { useGraphStore } from '@/stores/useGraphStore';
 import type { Person } from '@/types/person';
+import type { RelationshipV9 } from '@/types/relationship';
 
 // React Flowのモック
 vi.mock('@xyflow/react', async () => {
@@ -681,6 +682,864 @@ describe('PairSelectionPanel', () => {
         // colorOverrideは登録時にnullになっている
         expect(state.relationships[0].colorOverride).toBeNull();
       });
+    });
+  });
+
+  // ─── v9 定型フィールドのUI（issue #75）───────────────────────────────────────
+
+  /**
+   * symmetric フィールドのテスト用ベースとなる既存関係（closeness=nullのデフォルト状態）
+   */
+  const baseRelationship: RelationshipV9 = {
+    id: 'rel-v9',
+    sourcePersonId: person1.id,
+    targetPersonId: person2.id,
+    isDirected: true,
+    symmetric: { closeness: null, trust: null, tension: null, secrecy: null, kinship: null },
+    forward: { label: '友人', affection: null, awareness: null, role: null },
+    reverse: { label: '友人', affection: null, awareness: null, role: null },
+    tags: [],
+    narrative: { summary: null, notes: null, turningPoints: [] },
+    colorOverride: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  describe('定型フィールドUI（symmetric）', () => {
+    beforeEach(() => {
+      useGraphStore.setState({
+        persons: [person1, person2],
+        relationships: [baseRelationship],
+        selectedPersonIds: [person1.id, person2.id],
+      });
+    });
+
+    it('「定型フィールド」アコーディオンを展開するとclosenessスライダーが表示される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      // 「定型フィールド」アコーディオンを展開
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      // closenessスライダーが表示される
+      await waitFor(() => {
+        expect(screen.getByRole('slider', { name: '親密度' })).toBeInTheDocument();
+      });
+    });
+
+    it('symmetric.closeness===nullのとき、「未設定」チェックがONでスライダーがdisabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => {
+        // 「未設定」チェックがON
+        const checkbox = screen.getByRole('checkbox', { name: '親密度を未設定' });
+        expect(checkbox).toBeChecked();
+        // スライダーはdisabled
+        const slider = screen.getByRole('slider', { name: '親密度' });
+        expect(slider).toBeDisabled();
+      });
+    });
+
+    it('symmetric.closeness===0.5のとき、スライダーが0.5に初期化され「未設定」チェックがOFF', async () => {
+      // closeness=0.5 の関係を設定
+      useGraphStore.setState({
+        relationships: [{ ...baseRelationship, symmetric: { ...baseRelationship.symmetric, closeness: 0.5 } }],
+      });
+
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => {
+        const checkbox = screen.getByRole('checkbox', { name: '親密度を未設定' });
+        expect(checkbox).not.toBeChecked();
+        const slider = screen.getByRole('slider', { name: '親密度' }) as HTMLInputElement;
+        expect(slider).not.toBeDisabled();
+        expect(Number(slider.value)).toBe(0.5);
+      });
+    });
+
+    it('「未設定」チェックをOFFにしてclosenessを0.7に設定し更新するとsymmetric.closeness===0.7が保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('checkbox', { name: '親密度を未設定' }));
+
+      // 「未設定」チェックをOFF → スライダーが有効になる
+      const checkbox = screen.getByRole('checkbox', { name: '親密度を未設定' });
+      await user.click(checkbox);
+
+      // スライダーを0.7に設定（range inputはfireEventで直接変更する）
+      const { fireEvent } = await import('@testing-library/react');
+      const slider = screen.getByRole('slider', { name: '親密度' });
+      fireEvent.change(slider, { target: { value: '0.7' } });
+
+      // 更新ボタンをクリック
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      await user.click(updateButton);
+
+      await waitFor(() => {
+        const state = useGraphStore.getState();
+        expect(state.relationships[0].symmetric.closeness).toBe(0.7);
+      });
+    });
+
+    it('trustスライダーの値を0.6に設定して更新するとsymmetric.trust===0.6が保存される', async () => {
+      const user = userEvent.setup();
+      const { fireEvent } = await import('@testing-library/react');
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('checkbox', { name: '信頼度を未設定' }));
+
+      await user.click(screen.getByRole('checkbox', { name: '信頼度を未設定' }));
+      fireEvent.change(screen.getByRole('slider', { name: '信頼度' }), { target: { value: '0.6' } });
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].symmetric.trust).toBe(0.6);
+      });
+    });
+
+    it('tensionスライダーの値を0.4に設定して更新するとsymmetric.tension===0.4が保存される', async () => {
+      const user = userEvent.setup();
+      const { fireEvent } = await import('@testing-library/react');
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('checkbox', { name: '緊張・対立度を未設定' }));
+
+      await user.click(screen.getByRole('checkbox', { name: '緊張・対立度を未設定' }));
+      fireEvent.change(screen.getByRole('slider', { name: '緊張・対立度' }), { target: { value: '0.4' } });
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].symmetric.tension).toBe(0.4);
+      });
+    });
+
+    it('secrecyスライダーの値を0.9に設定して更新するとsymmetric.secrecy===0.9が保存される', async () => {
+      const user = userEvent.setup();
+      const { fireEvent } = await import('@testing-library/react');
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('checkbox', { name: '秘匿性を未設定' }));
+
+      await user.click(screen.getByRole('checkbox', { name: '秘匿性を未設定' }));
+      fireEvent.change(screen.getByRole('slider', { name: '秘匿性' }), { target: { value: '0.9' } });
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].symmetric.secrecy).toBe(0.9);
+      });
+    });
+
+    it('kinshipセレクトで「兄弟・姉妹」を選ぶとsymmetric.kinship===siblingが保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('combobox', { name: '血縁・親族' }));
+
+      await user.selectOptions(screen.getByRole('combobox', { name: '血縁・親族' }), 'sibling');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].symmetric.kinship).toBe('sibling');
+      });
+    });
+
+    it('kinshipセレクトで「（血縁なし）」を選ぶとsymmetric.kinship===nullが保存される', async () => {
+      // まずkinshipをsiblingに設定
+      useGraphStore.setState({
+        relationships: [{ ...baseRelationship, symmetric: { ...baseRelationship.symmetric, kinship: 'sibling' } }],
+      });
+
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('combobox', { name: '血縁・親族' }));
+
+      await user.selectOptions(screen.getByRole('combobox', { name: '血縁・親族' }), '');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].symmetric.kinship).toBeNull();
+      });
+    });
+  });
+
+  describe('定型フィールドUI（方向プロパティ）', () => {
+    beforeEach(() => {
+      useGraphStore.setState({
+        persons: [person1, person2],
+        relationships: [baseRelationship],
+        selectedPersonIds: [person1.id, person2.id],
+      });
+    });
+
+    it('「定型フィールド」アコーディオンを展開するとaffectionスライダーが表示される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => {
+        // person1→person2方向のaffectionスライダー
+        expect(screen.getByRole('slider', { name: `${person1.name}→${person2.name} 好悪` })).toBeInTheDocument();
+      });
+    });
+
+    it('forward.affectionがnullのとき、「未設定」チェックがONでスライダーがdisabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => {
+        const checkbox = screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` });
+        expect(checkbox).toBeChecked();
+        const slider = screen.getByRole('slider', { name: `${person1.name}→${person2.name} 好悪` });
+        expect(slider).toBeDisabled();
+      });
+    });
+
+    it('person1→person2方向のaffectionを0.8に設定して更新するとforward.affection===0.8が保存される', async () => {
+      const user = userEvent.setup();
+      const { fireEvent } = await import('@testing-library/react');
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` }));
+
+      await user.click(screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` }));
+      fireEvent.change(screen.getByRole('slider', { name: `${person1.name}→${person2.name} 好悪` }), { target: { value: '0.8' } });
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].forward.affection).toBe(0.8);
+      });
+    });
+
+    it('isReversed=trueの関係では、UI上のperson1→person2の入力がstored reverse.affectionにマップされる', async () => {
+      // person2 → person1 方向の関係（isReversed=true になる）
+      useGraphStore.setState({
+        relationships: [{
+          ...baseRelationship,
+          sourcePersonId: person2.id,
+          targetPersonId: person1.id,
+          forward: { label: '上司', affection: null, awareness: null, role: null },
+          reverse: { label: null, affection: null, awareness: null, role: null },
+        }],
+      });
+
+      const user = userEvent.setup();
+      const { fireEvent } = await import('@testing-library/react');
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` }));
+
+      // UI上の person1→person2 方向を入力（isReversed=true なので stored の reverse に入る）
+      await user.click(screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` }));
+      fireEvent.change(screen.getByRole('slider', { name: `${person1.name}→${person2.name} 好悪` }), { target: { value: '0.5' } });
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        const rel = useGraphStore.getState().relationships[0];
+        // isReversed=true なので stored.reverse が person1→person2 側にマップされる
+        expect(rel.reverse.affection).toBe(0.5);
+        // stored.forward は変更されない
+        expect(rel.forward.affection).toBeNull();
+      });
+    });
+
+    it('awarenessセレクトで「認知済み」を選ぶとforward.awareness===knownが保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('combobox', { name: `${person1.name}→${person2.name} 認知状況` }));
+
+      await user.selectOptions(
+        screen.getByRole('combobox', { name: `${person1.name}→${person2.name} 認知状況` }),
+        'known'
+      );
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].forward.awareness).toBe('known');
+      });
+    });
+
+    it('roleテキスト入力で「上司」を入れて更新するとforward.role===上司が保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByLabelText(`${person1.name}→${person2.name} 役割`));
+
+      await user.type(screen.getByLabelText(`${person1.name}→${person2.name} 役割`), '上司');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].forward.role).toBe('上司');
+      });
+    });
+
+    it('person2→person1方向のroleテキストを「部下」にして更新するとreverse.role===部下が保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByLabelText(`${person2.name}→${person1.name} 役割`));
+
+      await user.type(screen.getByLabelText(`${person2.name}→${person1.name} 役割`), '部下');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].reverse.role).toBe('部下');
+      });
+    });
+  });
+
+  describe('タグ入力UI（v9）', () => {
+    beforeEach(() => {
+      useGraphStore.setState({
+        persons: [person1, person2],
+        relationships: [baseRelationship],
+        selectedPersonIds: [person1.id, person2.id],
+      });
+    });
+
+    it('タグ入力フィールドが表示される', () => {
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      expect(screen.getByPlaceholderText(/タグを追加/)).toBeInTheDocument();
+    });
+
+    it('タグを入力してEnterを押すとチップとして追加される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const tagInput = screen.getByPlaceholderText(/タグを追加/);
+      await user.type(tagInput, '親友');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText('親友')).toBeInTheDocument();
+      });
+    });
+
+    it('追加されたタグチップの「×」をクリックするとタグが削除される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const tagInput = screen.getByPlaceholderText(/タグを追加/);
+      await user.type(tagInput, '親友');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => screen.getByText('親友'));
+
+      // タグ削除ボタンをクリック
+      const deleteButton = screen.getByRole('button', { name: '親友を削除' });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText('親友')).not.toBeInTheDocument();
+      });
+    });
+
+    it('重複するタグは追加されない', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const tagInput = screen.getByPlaceholderText(/タグを追加/);
+      await user.type(tagInput, '親友');
+      await user.keyboard('{Enter}');
+      await user.type(tagInput, '親友');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        // 「親友」チップが1つだけ存在する
+        const chips = screen.getAllByText('親友');
+        expect(chips).toHaveLength(1);
+      });
+    });
+
+    it('IME変換中（isComposing=true）のEnterではタグが追加されない', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const tagInput = screen.getByPlaceholderText(/タグを追加/);
+      await user.type(tagInput, '親友{Enter}');
+
+      // userEventはデフォルトでisComposing=falseなので通常の追加が起きる（IME開始イベントを送る方法なし）
+      // 代わりにキーボードイベントを手動でdispatchしてisComposing=trueを確認する
+      const { fireEvent } = await import('@testing-library/react');
+      await user.clear(tagInput);
+      await user.type(tagInput, 'ライバル');
+      // isComposing=trueのEnterキーイベントを発火
+      fireEvent.keyDown(tagInput, { key: 'Enter', code: 'Enter', isComposing: true, nativeEvent: { isComposing: true } });
+
+      // isComposing=trueのEnterでは追加されない
+      await waitFor(() => {
+        expect(screen.queryByText('ライバル')).not.toBeInTheDocument();
+      });
+    });
+
+    it('datalistにSUGGESTED_TAGSの候補が含まれる', () => {
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      // datalistが存在することを確認
+      const datalist = document.getElementById('tag-suggestions');
+      expect(datalist).toBeInTheDocument();
+      expect(datalist?.querySelector('option[value="親友"]')).toBeInTheDocument();
+      expect(datalist?.querySelector('option[value="ライバル"]')).toBeInTheDocument();
+    });
+
+    it('タグを追加して更新ボタンをクリックするとtagsがストアに保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const tagInput = screen.getByPlaceholderText(/タグを追加/);
+      await user.type(tagInput, '幼馴染');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => screen.getByText('幼馴染'));
+
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].tags).toContain('幼馴染');
+      });
+    });
+
+    it('既存のタグが初期値としてチップ表示される', () => {
+      useGraphStore.setState({
+        relationships: [{ ...baseRelationship, tags: ['幼馴染', '親友'] }],
+      });
+
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      expect(screen.getByText('幼馴染')).toBeInTheDocument();
+      expect(screen.getByText('親友')).toBeInTheDocument();
+    });
+  });
+
+  describe('narrativeフィールドUI（v9）', () => {
+    beforeEach(() => {
+      useGraphStore.setState({
+        persons: [person1, person2],
+        relationships: [baseRelationship],
+        selectedPersonIds: [person1.id, person2.id],
+      });
+    });
+
+    it('「物語的情報」アコーディオンを展開するとsummary textareaが表示される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('関係の概要')).toBeInTheDocument();
+        expect(screen.getByLabelText('メモ・補足')).toBeInTheDocument();
+      });
+    });
+
+    it('summaryに「幼馴染で高校まで同じ学校」を入力して更新するとnarrative.summaryに保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByLabelText('関係の概要'));
+
+      await user.type(screen.getByLabelText('関係の概要'), '幼馴染で高校まで同じ学校');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].narrative.summary).toBe('幼馴染で高校まで同じ学校');
+      });
+    });
+
+    it('notesに「仲違い後に和解した経緯あり」を入力して更新するとnarrative.notesに保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByLabelText('メモ・補足'));
+
+      await user.type(screen.getByLabelText('メモ・補足'), '仲違い後に和解した経緯あり');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].narrative.notes).toBe('仲違い後に和解した経緯あり');
+      });
+    });
+
+    it('「+ ターニングポイントを追加」を押すと空行が追加される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      await user.click(screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      await waitFor(() => {
+        // at と note の入力フィールドが表示される
+        expect(screen.getByPlaceholderText(/時期・時点/)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/出来事/)).toBeInTheDocument();
+      });
+    });
+
+    it('ターニングポイントのatとnoteを入力して更新するとnarrative.turningPointsに保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      await user.click(screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      await waitFor(() => screen.getByPlaceholderText(/時期・時点/));
+
+      await user.type(screen.getByPlaceholderText(/時期・時点/), '高校入学時');
+      await user.type(screen.getByPlaceholderText(/出来事/), '初めて出会った');
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        const turningPoints = useGraphStore.getState().relationships[0].narrative.turningPoints;
+        expect(turningPoints).toHaveLength(1);
+        expect(turningPoints[0].at).toBe('高校入学時');
+        expect(turningPoints[0].note).toBe('初めて出会った');
+      });
+    });
+
+    it('atもnoteも空のターニングポイント行は保存から除外される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      // 空行を追加してそのまま更新
+      await user.click(screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        const turningPoints = useGraphStore.getState().relationships[0].narrative.turningPoints;
+        expect(turningPoints).toHaveLength(0);
+      });
+    });
+
+    it('ターニングポイント行の削除ボタンをクリックするとその行が消える', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      await user.click(screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      await waitFor(() => screen.getByPlaceholderText(/時期・時点/));
+
+      // 削除ボタンをクリック
+      await user.click(screen.getByRole('button', { name: 'このターニングポイントを削除' }));
+
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText(/時期・時点/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('既存のnarrative.summaryが初期値としてtextareaに反映される', async () => {
+      useGraphStore.setState({
+        relationships: [{
+          ...baseRelationship,
+          narrative: { summary: '幼馴染で高校まで同じ学校', notes: null, turningPoints: [] },
+        }],
+      });
+
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      await user.click(accordion);
+
+      await waitFor(() => {
+        const summaryInput = screen.getByLabelText('関係の概要') as HTMLTextAreaElement;
+        expect(summaryInput.value).toBe('幼馴染で高校まで同じ学校');
+      });
+    });
+  });
+
+  describe('colorOverrideフィールドUI（v9）', () => {
+    beforeEach(() => {
+      useGraphStore.setState({
+        persons: [person1, person2],
+        relationships: [baseRelationship],
+        selectedPersonIds: [person1.id, person2.id],
+      });
+    });
+
+    it('colorOverride===nullのとき「タグから派生」と表示されカラーピッカーが非表示', () => {
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      expect(screen.getByText('タグから派生')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: /エッジの色/ })).not.toBeInTheDocument();
+    });
+
+    it('「上書きする」ボタンをクリックするとカラーピッカーが現れる', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      await user.click(screen.getByRole('button', { name: '色を上書きする' }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('エッジの色')).toBeInTheDocument();
+      });
+    });
+
+    it('カラーピッカーで色を設定して更新するとcolorOverrideに保存される', async () => {
+      const user = userEvent.setup();
+      const { fireEvent } = await import('@testing-library/react');
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      await user.click(screen.getByRole('button', { name: '色を上書きする' }));
+
+      await waitFor(() => screen.getByLabelText('エッジの色'));
+
+      fireEvent.change(screen.getByLabelText('エッジの色'), { target: { value: '#ff0000' } });
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].colorOverride).toBe('#ff0000');
+      });
+    });
+
+    it('「クリア」ボタンでcolorOverrideがnullに戻る', async () => {
+      useGraphStore.setState({
+        relationships: [{ ...baseRelationship, colorOverride: '#ff0000' }],
+      });
+
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      // 既存のcolorOverrideがある場合はピッカーが表示されている
+      await waitFor(() => screen.getByLabelText('エッジの色'));
+
+      await user.click(screen.getByRole('button', { name: '色をクリア' }));
+      await user.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(useGraphStore.getState().relationships[0].colorOverride).toBeNull();
+      });
+    });
+
+    it('既存のcolorOverrideがある場合、カラーピッカーが最初から表示される', () => {
+      useGraphStore.setState({
+        relationships: [{ ...baseRelationship, colorOverride: '#0000ff' }],
+      });
+
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      expect(screen.getByLabelText('エッジの色')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/panel/PairSelectionPanel.test.tsx
+++ b/src/components/panel/PairSelectionPanel.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactFlowProvider } from '@xyflow/react';
 import { PairSelectionPanel } from './PairSelectionPanel';
@@ -723,7 +723,7 @@ describe('PairSelectionPanel', () => {
       );
 
       // 「定型フィールド」アコーディオンを展開
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       // closenessスライダーが表示される
@@ -740,7 +740,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => {
@@ -766,7 +766,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => {
@@ -786,7 +786,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('checkbox', { name: '親密度を未設定' }));
@@ -796,7 +796,6 @@ describe('PairSelectionPanel', () => {
       await user.click(checkbox);
 
       // スライダーを0.7に設定（range inputはfireEventで直接変更する）
-      const { fireEvent } = await import('@testing-library/react');
       const slider = screen.getByRole('slider', { name: '親密度' });
       fireEvent.change(slider, { target: { value: '0.7' } });
 
@@ -812,14 +811,13 @@ describe('PairSelectionPanel', () => {
 
     it('trustスライダーの値を0.6に設定して更新するとsymmetric.trust===0.6が保存される', async () => {
       const user = userEvent.setup();
-      const { fireEvent } = await import('@testing-library/react');
       render(
         <ReactFlowProvider>
           <PairSelectionPanel persons={[person1, person2]} />
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('checkbox', { name: '信頼度を未設定' }));
@@ -835,14 +833,13 @@ describe('PairSelectionPanel', () => {
 
     it('tensionスライダーの値を0.4に設定して更新するとsymmetric.tension===0.4が保存される', async () => {
       const user = userEvent.setup();
-      const { fireEvent } = await import('@testing-library/react');
       render(
         <ReactFlowProvider>
           <PairSelectionPanel persons={[person1, person2]} />
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('checkbox', { name: '緊張・対立度を未設定' }));
@@ -858,14 +855,13 @@ describe('PairSelectionPanel', () => {
 
     it('secrecyスライダーの値を0.9に設定して更新するとsymmetric.secrecy===0.9が保存される', async () => {
       const user = userEvent.setup();
-      const { fireEvent } = await import('@testing-library/react');
       render(
         <ReactFlowProvider>
           <PairSelectionPanel persons={[person1, person2]} />
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('checkbox', { name: '秘匿性を未設定' }));
@@ -887,7 +883,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('combobox', { name: '血縁・親族' }));
@@ -913,7 +909,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('combobox', { name: '血縁・親族' }));
@@ -944,7 +940,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => {
@@ -961,7 +957,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => {
@@ -974,14 +970,13 @@ describe('PairSelectionPanel', () => {
 
     it('person1→person2方向のaffectionを0.8に設定して更新するとforward.affection===0.8が保存される', async () => {
       const user = userEvent.setup();
-      const { fireEvent } = await import('@testing-library/react');
       render(
         <ReactFlowProvider>
           <PairSelectionPanel persons={[person1, person2]} />
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` }));
@@ -1008,14 +1003,13 @@ describe('PairSelectionPanel', () => {
       });
 
       const user = userEvent.setup();
-      const { fireEvent } = await import('@testing-library/react');
       render(
         <ReactFlowProvider>
           <PairSelectionPanel persons={[person1, person2]} />
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('checkbox', { name: `${person1.name}→${person2.name} 好悪を未設定` }));
@@ -1042,7 +1036,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('combobox', { name: `${person1.name}→${person2.name} 認知状況` }));
@@ -1066,7 +1060,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByLabelText(`${person1.name}→${person2.name} 役割`));
@@ -1087,7 +1081,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /定型フィールド/ });
+      const accordion = screen.getByText('定型フィールド');
       await user.click(accordion);
 
       await waitFor(() => screen.getByLabelText(`${person2.name}→${person1.name} 役割`));
@@ -1194,7 +1188,6 @@ describe('PairSelectionPanel', () => {
 
       // userEventはデフォルトでisComposing=falseなので通常の追加が起きる（IME開始イベントを送る方法なし）
       // 代わりにキーボードイベントを手動でdispatchしてisComposing=trueを確認する
-      const { fireEvent } = await import('@testing-library/react');
       await user.clear(tagInput);
       await user.type(tagInput, 'ライバル');
       // isComposing=trueのEnterキーイベントを発火
@@ -1274,7 +1267,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => {
@@ -1291,7 +1284,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => screen.getByLabelText('関係の概要'));
@@ -1312,7 +1305,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => screen.getByLabelText('メモ・補足'));
@@ -1333,7 +1326,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
@@ -1355,7 +1348,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
@@ -1384,7 +1377,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
@@ -1407,7 +1400,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
@@ -1439,7 +1432,7 @@ describe('PairSelectionPanel', () => {
         </ReactFlowProvider>
       );
 
-      const accordion = screen.getByRole('button', { name: /物語的情報/ });
+      const accordion = screen.getByText('物語的情報');
       await user.click(accordion);
 
       await waitFor(() => {
@@ -1486,7 +1479,6 @@ describe('PairSelectionPanel', () => {
 
     it('カラーピッカーで色を設定して更新するとcolorOverrideに保存される', async () => {
       const user = userEvent.setup();
-      const { fireEvent } = await import('@testing-library/react');
       render(
         <ReactFlowProvider>
           <PairSelectionPanel persons={[person1, person2]} />

--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -1,12 +1,18 @@
 /**
  * PairSelectionPanelコンポーネント
  * 2人の人物が選択されている場合に表示されるパネル
- * v9プロパティグラフ方式対応：レイヤー選択・重みスライダーを廃止
+ *
+ * v9プロパティグラフ方式対応:
+ * - プライマリ行: タイプ選択 + forward/reverse ラベル + タグ chip 入力
+ * - 定型フィールド（アコーディオン）: closeness/trust/tension/secrecy/kinship + affection/awareness/role（方向別）
+ * - 物語的情報（アコーディオン）: summary/notes/turningPoints
+ * - colorOverride: カラーピッカー（null のとき「タグから派生」表示）
  */
 
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import { nanoid } from 'nanoid';
 import { useReactFlow } from '@xyflow/react';
 import { ArrowRight, ArrowLeft, ArrowLeftRight, Minus } from 'lucide-react';
 import { BidirectionalArrow } from '@/components/icons/BidirectionalArrow';
@@ -15,11 +21,10 @@ import { MAX_RELATIONSHIP_LABEL_LENGTH } from '@/lib/validation-constants';
 import { getRelationshipDisplayType } from '@/lib/relationship-utils';
 import { getNodeCenter, VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils';
 import type { Person } from '@/types/person';
-import type { RelationshipType } from '@/types/relationship';
+import type { RelationshipType, KinshipKind, AwarenessKind } from '@/types/relationship';
+import { SUGGESTED_TAGS } from '@/types/relationship';
 
-/**
- * PairSelectionPanelのプロパティ
- */
+/** PairSelectionPanelのプロパティ */
 type PairSelectionPanelProps = {
   /** 選択されている2人の人物 */
   persons: [Person, Person];
@@ -36,10 +41,8 @@ function getDirectionIndicator(type: RelationshipType, isReversed: boolean): str
     return '↔';
   }
   if (type === 'one-way') {
-    // isReversedがtrueの場合は左向き矢印、falseの場合は右向き矢印
     return isReversed ? '←' : '→';
   }
-  // undirectedの場合は方向インジケーターなし
   return '';
 }
 
@@ -47,41 +50,20 @@ function getDirectionIndicator(type: RelationshipType, isReversed: boolean): str
  * 関係タイプと種別に応じたプレースホルダーを返す
  */
 function getPlaceholder(type: RelationshipType, isReverse = false, hasItem = false): string {
-  // 物が含まれている場合のプレースホルダー
   if (hasItem) {
-    if (type === 'one-way') {
-      return '例: 所有、使用';
-    }
-    if (type === 'bidirectional') {
-      return '例: 所有、使用';
-    }
-    if (type === 'dual-directed') {
-      return isReverse ? '例: 使用' : '例: 所有';
-    }
-    if (type === 'undirected') {
-      return '例: 所有、使用';
-    }
+    if (type === 'one-way') return '例: 所有、使用';
+    if (type === 'bidirectional') return '例: 所有、使用';
+    if (type === 'dual-directed') return isReverse ? '例: 使用' : '例: 所有';
+    if (type === 'undirected') return '例: 所有、使用';
   }
-
-  // 人物間のプレースホルダー（従来通り）
-  if (type === 'one-way') {
-    return '例: 片想い、憧れ';
-  }
-  if (type === 'bidirectional') {
-    return '例: 友人、親子、同僚';
-  }
-  if (type === 'dual-directed') {
-    return isReverse ? '例: 無関心、嫌い' : '例: 好き、憧れ';
-  }
-  if (type === 'undirected') {
-    return '例: 同一人物、別名';
-  }
+  if (type === 'one-way') return '例: 片想い、憧れ';
+  if (type === 'bidirectional') return '例: 友人、親子、同僚';
+  if (type === 'dual-directed') return isReverse ? '例: 無関心、嫌い' : '例: 好き、憧れ';
+  if (type === 'undirected') return '例: 同一人物、別名';
   return '例: 関係を入力';
 }
 
-/**
- * 人物/物のミニアイコンを表示するヘルパーコンポーネント
- */
+/** 人物/物のミニアイコンを表示するヘルパーコンポーネント */
 function PersonMiniIcon({ person }: { person: Person }) {
   const kind = person.kind ?? 'person';
   const isItem = kind === 'item';
@@ -103,9 +85,255 @@ function PersonMiniIcon({ person }: { person: Person }) {
   );
 }
 
+// ─── v9 ヘルパーコンポーネント ───────────────────────────────────────────────
+
 /**
- * 2人選択パネルコンポーネント
+ * null 値を持てる数値スライダーコンポーネント
+ * 「未設定」チェックボックスで null ⇔ 数値を切り替える
  */
+type NullableSliderProps = {
+  /** スライダーのラベル（aria-label としても使用） */
+  label: string;
+  /** 現在の数値（未設定の場合は null） */
+  value: number | null;
+  /** スライダーの最小値 */
+  min: number;
+  /** スライダーの最大値 */
+  max: number;
+  /** スライダーのステップ */
+  step: number;
+  /** null のときのスライダーデフォルト値 */
+  defaultValue: number;
+  /** 値変更コールバック（未設定解除時に呼ばれる） */
+  onValueChange: (value: number) => void;
+  /** null トグルコールバック（true=未設定, false=値あり） */
+  onNullToggle: (isNull: boolean) => void;
+};
+
+function NullableSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  defaultValue,
+  onValueChange,
+  onNullToggle,
+}: NullableSliderProps) {
+  const isNull = value === null;
+  const sliderId = `slider-${label}`;
+  const checkboxId = `nullable-${label}`;
+  // 未設定時にスライダーが表示する内部値（デフォルト値か現在値）
+  const displayValue = value ?? defaultValue;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs font-medium text-gray-700">
+        <label htmlFor={sliderId}>{label}</label>
+        <div className="flex items-center gap-1.5">
+          {!isNull && (
+            <span className="text-[10px] text-gray-500">{displayValue.toFixed(2)}</span>
+          )}
+          <label htmlFor={checkboxId} className="flex items-center gap-0.5 text-[10px] text-gray-500 cursor-pointer">
+            <input
+              id={checkboxId}
+              type="checkbox"
+              checked={isNull}
+              onChange={(e) => onNullToggle(e.target.checked)}
+              aria-label={`${label}を未設定`}
+              className="w-3 h-3"
+            />
+            未設定
+          </label>
+        </div>
+      </div>
+      <input
+        id={sliderId}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={displayValue}
+        disabled={isNull}
+        onChange={(e) => onValueChange(Number(e.target.value))}
+        aria-label={label}
+        className="w-full disabled:opacity-40"
+      />
+    </div>
+  );
+}
+
+/** ターニングポイントの行（ローカルステート用） */
+type TurningPointRow = {
+  id: string;
+  at: string;
+  note: string;
+};
+
+/**
+ * ターニングポイント動的リストエディタ
+ * 行の追加・削除・編集を提供する
+ */
+type TurningPointsEditorProps = {
+  value: TurningPointRow[];
+  onChange: (rows: TurningPointRow[]) => void;
+};
+
+function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
+  const handleAdd = () => {
+    onChange([...value, { id: nanoid(), at: '', note: '' }]);
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(value.filter((row) => row.id !== id));
+  };
+
+  const handleChange = (id: string, field: 'at' | 'note', text: string) => {
+    onChange(value.map((row) => (row.id === id ? { ...row, [field]: text } : row)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <span className="text-xs font-medium text-gray-700">ターニングポイント</span>
+      {value.map((row) => (
+        <div key={row.id} className="flex gap-1 items-start">
+          <input
+            type="text"
+            value={row.at}
+            onChange={(e) => handleChange(row.id, 'at', e.target.value)}
+            placeholder="時期・時点"
+            className="w-24 shrink-0 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <input
+            type="text"
+            value={row.note}
+            onChange={(e) => handleChange(row.id, 'note', e.target.value)}
+            placeholder="出来事"
+            className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={() => handleRemove(row.id)}
+            aria-label="このターニングポイントを削除"
+            className="shrink-0 text-gray-400 hover:text-red-500 text-xs px-1 py-1"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="text-xs text-blue-600 hover:text-blue-800 hover:underline"
+      >
+        + ターニングポイントを追加
+      </button>
+    </div>
+  );
+}
+
+/**
+ * タグ chip 入力コンポーネント
+ * SUGGESTED_TAGS を datalist として提供し、chip形式でタグを表示・削除する
+ */
+type TagChipInputProps = {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  suggestions: readonly string[];
+};
+
+function TagChipInput({ value, onChange, suggestions }: TagChipInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const addTag = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag || value.includes(tag)) return;
+    onChange([...value, tag]);
+    setInputValue('');
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      // IME変換中のEnterは無視（日本語入力の変換確定時の誤動作を防ぐ）
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      addTag(inputValue);
+    }
+  };
+
+  const datalistId = 'tag-suggestions';
+
+  return (
+    <div className="space-y-2">
+      {/* 既存タグのチップ表示 */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {value.map((tag) => (
+            <span
+              key={tag}
+              className="flex items-center gap-0.5 px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded-full"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                aria-label={`${tag}を削除`}
+                className="hover:text-blue-600 ml-0.5"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      {/* タグ入力フィールド */}
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        list={datalistId}
+        placeholder="タグを追加（Enter で確定）"
+        className="w-full px-3 py-1.5 text-xs border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+      />
+      <datalist id={datalistId}>
+        {suggestions.map((s) => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
+    </div>
+  );
+}
+
+// ─── KinshipKind / AwarenessKind の日本語ラベル ──────────────────────────────
+
+const KINSHIP_OPTIONS: { value: KinshipKind; label: string }[] = [
+  { value: null, label: '（血縁なし）' },
+  { value: 'parent', label: '親' },
+  { value: 'child', label: '子' },
+  { value: 'sibling', label: '兄弟・姉妹' },
+  { value: 'spouse', label: '配偶者' },
+  { value: 'partner', label: 'パートナー' },
+  { value: 'grandparent', label: '祖父母' },
+  { value: 'grandchild', label: '孫' },
+  { value: 'cousin', label: 'いとこ' },
+  { value: 'relative', label: '親族（その他）' },
+];
+
+const AWARENESS_OPTIONS: { value: AwarenessKind; label: string }[] = [
+  { value: null, label: '（未設定）' },
+  { value: 'known', label: '認知済み' },
+  { value: 'unknown', label: '未認知' },
+  { value: 'suspected', label: '疑惑あり' },
+];
+
+// ─── PairSelectionPanel 本体 ─────────────────────────────────────────────────
+
+/** 2人選択パネルコンポーネント */
 export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
   const relationships = useGraphStore((state) => state.relationships);
   const addRelationship = useGraphStore((state) => state.addRelationship);
@@ -138,24 +366,21 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
     [existingRelationship, person2.id]
   );
 
-  // フォーム状態（初期値を関数で設定）
+  // ────── プライマリフィールドのフォーム状態 ──────
+
   const [relationshipType, setRelationshipType] = useState<RelationshipType>(() => {
-    if (existingRelationship) {
-      return getRelationshipDisplayType(existingRelationship);
-    }
+    if (existingRelationship) return getRelationshipDisplayType(existingRelationship);
     return 'bidirectional';
   });
 
   /**
    * isReversedを考慮してsource→target方向のラベルを返す
-   * - one-way: ラベルは常に forward.label に格納されているため isReversed に関わらず forward を参照する
-   * - 他のタイプ: isReversed=false なら forward.label、isReversed=true なら reverse.label
+   * one-way: ラベルは常に forward.label に格納されているため isReversed に関わらず forward を参照する
    */
   const [sourceToTargetLabel, setSourceToTargetLabel] = useState(() => {
     if (existingRelationship) {
       const displayType = getRelationshipDisplayType(existingRelationship);
       if (displayType === 'one-way') {
-        // one-way のラベルは常に forward.label に保存されている
         return existingRelationship.forward.label ?? existingRelationship.reverse.label ?? '';
       }
       return isReversed
@@ -167,31 +392,93 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
 
   /**
    * isReversedを考慮してtarget→source方向のラベルを返す
-   * - one-way: 逆方向ラベルは存在しないため常に空文字
-   * - 他のタイプ: isReversed=false なら reverse.label、isReversed=true なら forward.label
+   * one-way: 逆方向ラベルは存在しないため常に空文字
    */
   const [targetToSourceLabel, setTargetToSourceLabel] = useState(() => {
     if (existingRelationship) {
       const displayType = getRelationshipDisplayType(existingRelationship);
-      if (displayType === 'one-way') {
-        return '';
-      }
+      if (displayType === 'one-way') return '';
       return isReversed
         ? (existingRelationship.forward.label ?? '')
         : (existingRelationship.reverse.label ?? '');
     }
     return '';
   });
+
   const [isTypePickerOpen, setIsTypePickerOpen] = useState(false);
 
+  // ────── タグ ──────
+
+  const [tags, setTags] = useState<string[]>(() => existingRelationship?.tags ?? []);
+
+  // ────── symmetric フィールド ──────
+
+  // 各スライダーは「value」と「isNull」を分離して管理する
+  const [closeness, setCloseness] = useState<number>(() => existingRelationship?.symmetric.closeness ?? 0.5);
+  const [closenessIsNull, setClosenessIsNull] = useState<boolean>(() => existingRelationship?.symmetric.closeness === null || !existingRelationship);
+  const [trust, setTrust] = useState<number>(() => existingRelationship?.symmetric.trust ?? 0.5);
+  const [trustIsNull, setTrustIsNull] = useState<boolean>(() => existingRelationship?.symmetric.trust === null || !existingRelationship);
+  const [tension, setTension] = useState<number>(() => existingRelationship?.symmetric.tension ?? 0.5);
+  const [tensionIsNull, setTensionIsNull] = useState<boolean>(() => existingRelationship?.symmetric.tension === null || !existingRelationship);
+  const [secrecy, setSecrecy] = useState<number>(() => existingRelationship?.symmetric.secrecy ?? 0.5);
+  const [secrecyIsNull, setSecrecyIsNull] = useState<boolean>(() => existingRelationship?.symmetric.secrecy === null || !existingRelationship);
+  const [kinship, setKinship] = useState<KinshipKind>(() => existingRelationship?.symmetric.kinship ?? null);
+
+  // ────── 方向プロパティ（person1→person2 方向 = UI の fwd ）──────
+  // isReversed が false → stored.forward が UI fwd
+  // isReversed が true  → stored.reverse が UI fwd
+
+  /**
+   * 既存関係から「UI の person1→person2」に対応する stored DirectionalProps を返す
+   */
+  const getStoredFwdProps = () => {
+    if (!existingRelationship) return { affection: null, awareness: null, role: null };
+    return isReversed ? existingRelationship.reverse : existingRelationship.forward;
+  };
+
+  /**
+   * 既存関係から「UI の person2→person1」に対応する stored DirectionalProps を返す
+   */
+  const getStoredRevProps = () => {
+    if (!existingRelationship) return { affection: null, awareness: null, role: null };
+    return isReversed ? existingRelationship.forward : existingRelationship.reverse;
+  };
+
+  // person1→person2 方向の affection
+  const [fwdAffection, setFwdAffection] = useState<number>(() => getStoredFwdProps().affection ?? 0);
+  const [fwdAffectionIsNull, setFwdAffectionIsNull] = useState<boolean>(() => getStoredFwdProps().affection === null || !existingRelationship);
+  // person1→person2 方向の awareness / role
+  const [fwdAwareness, setFwdAwareness] = useState<AwarenessKind>(() => getStoredFwdProps().awareness ?? null);
+  const [fwdRole, setFwdRole] = useState<string>(() => getStoredFwdProps().role ?? '');
+
+  // person2→person1 方向の affection
+  const [revAffection, setRevAffection] = useState<number>(() => getStoredRevProps().affection ?? 0);
+  const [revAffectionIsNull, setRevAffectionIsNull] = useState<boolean>(() => getStoredRevProps().affection === null || !existingRelationship);
+  // person2→person1 方向の awareness / role
+  const [revAwareness, setRevAwareness] = useState<AwarenessKind>(() => getStoredRevProps().awareness ?? null);
+  const [revRole, setRevRole] = useState<string>(() => getStoredRevProps().role ?? '');
+
+  // ────── narrative ──────
+
+  const [narrativeSummary, setNarrativeSummary] = useState<string>(() => existingRelationship?.narrative.summary ?? '');
+  const [narrativeNotes, setNarrativeNotes] = useState<string>(() => existingRelationship?.narrative.notes ?? '');
+  const [turningPoints, setTurningPoints] = useState<TurningPointRow[]>(() =>
+    (existingRelationship?.narrative.turningPoints ?? []).map((tp) => ({ id: nanoid(), ...tp }))
+  );
+
+  // ────── colorOverride ──────
+
+  const [colorOverride, setColorOverride] = useState<string | null>(() => existingRelationship?.colorOverride ?? null);
+  const [colorPickerEnabled, setColorPickerEnabled] = useState<boolean>(() => existingRelationship?.colorOverride !== null && existingRelationship?.colorOverride !== undefined);
+
+  // ────── フォーム同期 useEffect ──────
+
   // existingRelationshipまたはisReversedの変化に応じてフォーム状態を再同期
-  // - undo/redo、関係の削除/追加
   useEffect(() => {
     if (existingRelationship) {
       const displayType = getRelationshipDisplayType(existingRelationship);
       setRelationshipType(displayType);
 
-      // one-way のラベルは常に forward.label に保存されているため isReversed に関わらず参照する
       if (displayType === 'one-way') {
         setSourceToTargetLabel(
           existingRelationship.forward.label ?? existingRelationship.reverse.label ?? ''
@@ -205,11 +492,64 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
           isReversed ? (existingRelationship.forward.label ?? '') : (existingRelationship.reverse.label ?? '')
         );
       }
+
+      // tags
+      setTags(existingRelationship.tags);
+
+      // symmetric
+      const sym = existingRelationship.symmetric;
+      setCloseness(sym.closeness ?? 0.5);
+      setClosenessIsNull(sym.closeness === null);
+      setTrust(sym.trust ?? 0.5);
+      setTrustIsNull(sym.trust === null);
+      setTension(sym.tension ?? 0.5);
+      setTensionIsNull(sym.tension === null);
+      setSecrecy(sym.secrecy ?? 0.5);
+      setSecrecyIsNull(sym.secrecy === null);
+      setKinship(sym.kinship);
+
+      // 方向プロパティ（isReversed を考慮）
+      const fwd = isReversed ? existingRelationship.reverse : existingRelationship.forward;
+      const rev = isReversed ? existingRelationship.forward : existingRelationship.reverse;
+
+      setFwdAffection(fwd.affection ?? 0);
+      setFwdAffectionIsNull(fwd.affection === null);
+      setFwdAwareness(fwd.awareness ?? null);
+      setFwdRole(fwd.role ?? '');
+
+      setRevAffection(rev.affection ?? 0);
+      setRevAffectionIsNull(rev.affection === null);
+      setRevAwareness(rev.awareness ?? null);
+      setRevRole(rev.role ?? '');
+
+      // narrative
+      setNarrativeSummary(existingRelationship.narrative.summary ?? '');
+      setNarrativeNotes(existingRelationship.narrative.notes ?? '');
+      setTurningPoints(
+        existingRelationship.narrative.turningPoints.map((tp) => ({ id: nanoid(), ...tp }))
+      );
+
+      // colorOverride
+      setColorOverride(existingRelationship.colorOverride);
+      setColorPickerEnabled(existingRelationship.colorOverride !== null);
     } else {
       // 既存関係がない場合はフォームをリセット
       setRelationshipType('bidirectional');
       setSourceToTargetLabel('');
       setTargetToSourceLabel('');
+      setTags([]);
+      setCloseness(0.5); setClosenessIsNull(true);
+      setTrust(0.5); setTrustIsNull(true);
+      setTension(0.5); setTensionIsNull(true);
+      setSecrecy(0.5); setSecrecyIsNull(true);
+      setKinship(null);
+      setFwdAffection(0); setFwdAffectionIsNull(true);
+      setFwdAwareness(null); setFwdRole('');
+      setRevAffection(0); setRevAffectionIsNull(true);
+      setRevAwareness(null); setRevRole('');
+      setNarrativeSummary(''); setNarrativeNotes('');
+      setTurningPoints([]);
+      setColorOverride(null); setColorPickerEnabled(false);
     }
   }, [existingRelationship, isReversed]);
 
@@ -219,7 +559,6 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
 
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
-      // ドロップダウンまたはトグルボタンの外側をクリックした場合のみ閉じる
       const dropdown = document.querySelector('[data-dropdown="relationship-type"]');
       const toggleButton = document.querySelector('[data-toggle="relationship-type"]');
 
@@ -239,10 +578,7 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
     };
   }, [isTypePickerOpen]);
 
-  /**
-   * ノードを画面中央に移動する
-   * @param personId - 人物ID
-   */
+  /** ノードを画面中央に移動する */
   const focusNode = (personId: string) => {
     const node = getNode(personId);
     if (node) {
@@ -251,18 +587,13 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
     }
   };
 
-  /**
-   * 人物を単一選択する
-   * @param personId - 人物ID
-   */
+  /** 人物を単一選択する */
   const handleSelectPerson = (personId: string) => {
     selectPerson(personId);
     focusNode(personId);
   };
 
-  /**
-   * フォーム送信ハンドラ
-   */
+  /** フォーム送信ハンドラ */
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -275,24 +606,52 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
     let finalTargetToSourceLabel: string | null = null;
 
     if (relationshipType === 'bidirectional') {
-      // 双方向: isDirected=true, 両方に同じラベル
       finalTargetToSourceLabel = finalSourceToTargetLabel;
     } else if (relationshipType === 'one-way') {
-      // 片方向: isDirected=true, sourceToTargetLabelのみ
       finalTargetToSourceLabel = null;
     } else if (relationshipType === 'dual-directed') {
-      // 片方向×2: isDirected=true, 異なるラベル
       finalTargetToSourceLabel = targetToSourceLabel.trim();
     } else if (relationshipType === 'undirected') {
-      // 無方向: isDirected=false, 両方に同じラベル
       isDirected = false;
       finalTargetToSourceLabel = finalSourceToTargetLabel;
     }
 
+    // v9 フィールドの値をビルド
+    const symmetricPayload = {
+      closeness: closenessIsNull ? null : closeness,
+      trust: trustIsNull ? null : trust,
+      tension: tensionIsNull ? null : tension,
+      secrecy: secrecyIsNull ? null : secrecy,
+      kinship,
+    };
+
+    // UI fwd → stored forward/reverse の対応（isReversed を考慮）
+    // isReversed=false: UI fwd = stored forward, UI rev = stored reverse
+    // isReversed=true:  UI fwd = stored reverse, UI rev = stored forward
+    const uiFwdProps = {
+      affection: fwdAffectionIsNull ? null : fwdAffection,
+      awareness: fwdAwareness,
+      role: fwdRole.trim() || null,
+    };
+    const uiRevProps = {
+      affection: revAffectionIsNull ? null : revAffection,
+      awareness: revAwareness,
+      role: revRole.trim() || null,
+    };
+
+    const narrativePayload = {
+      summary: narrativeSummary.trim() || null,
+      notes: narrativeNotes.trim() || null,
+      // at も note も空の行は除外する
+      turningPoints: turningPoints
+        .filter((row) => row.at.trim() || row.note.trim())
+        .map(({ at, note }) => ({ at, note })),
+    };
+
+    const colorOverridePayload = colorPickerEnabled ? colorOverride : null;
+
     if (existingRelationship) {
       // 既存の関係を更新（isReversedを考慮して forward/reverse を正しく設定）
-      // one-way の場合: ラベルは常に forward に保存し、reverse は null にする
-      // isReversed=true の場合: stored.forward = person2→person1（= UI上のtarget→source）
       const forwardLabel =
         relationshipType === 'one-way'
           ? finalSourceToTargetLabel
@@ -302,10 +661,18 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
           ? null
           : isReversed ? finalSourceToTargetLabel : finalTargetToSourceLabel;
 
+      // stored forward / reverse を決定
+      const storedForwardProps = isReversed ? uiRevProps : uiFwdProps;
+      const storedReverseProps = isReversed ? uiFwdProps : uiRevProps;
+
       updateRelationship(existingRelationship.id, {
         isDirected,
-        forward: { ...existingRelationship.forward, label: forwardLabel },
-        reverse: { ...existingRelationship.reverse, label: reverseLabel },
+        symmetric: { ...existingRelationship.symmetric, ...symmetricPayload },
+        forward: { ...existingRelationship.forward, label: forwardLabel, ...storedForwardProps },
+        reverse: { ...existingRelationship.reverse, label: reverseLabel, ...storedReverseProps },
+        tags,
+        narrative: narrativePayload,
+        colorOverride: colorOverridePayload,
       });
     } else {
       // 新規の関係を追加（v9形式）
@@ -313,12 +680,12 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
         sourcePersonId: person1.id,
         targetPersonId: person2.id,
         isDirected,
-        forward: { label: finalSourceToTargetLabel, affection: null, awareness: null, role: null },
-        reverse: { label: finalTargetToSourceLabel, affection: null, awareness: null, role: null },
-        symmetric: { closeness: null, trust: null, tension: null, secrecy: null, kinship: null },
-        tags: [],
-        narrative: { summary: null, notes: null, turningPoints: [] },
-        colorOverride: null,
+        symmetric: symmetricPayload,
+        forward: { label: finalSourceToTargetLabel, ...uiFwdProps },
+        reverse: { label: finalTargetToSourceLabel, ...uiRevProps },
+        tags,
+        narrative: narrativePayload,
+        colorOverride: colorOverridePayload,
       });
     }
   };
@@ -339,9 +706,9 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
   return (
     <div className="flex flex-col h-full">
       {/* 関係追加/編集フォーム */}
-      <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-4 flex flex-col">
+      <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
         {/* フォーム上部: タイトルと選択解除ボタン */}
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between">
           <h2 className="text-sm font-semibold text-gray-700">2人を選択中</h2>
           <button
             type="button"
@@ -352,8 +719,9 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
             ✕ 選択解除
           </button>
         </div>
+
         {/* 2人の人物情報表示 + 関係タイプ選択 */}
-        <div className="mb-4 flex items-center justify-center gap-3 text-gray-700">
+        <div className="flex items-center justify-center gap-3 text-gray-700">
           {/* 人物/物1のアイコン */}
           <div
             role="button"
@@ -407,73 +775,46 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
                 className="absolute top-full left-1/2 -translate-x-1/2 mt-2 bg-white border border-gray-300 rounded-md shadow-lg p-1 flex gap-1 z-10"
                 data-dropdown="relationship-type"
               >
-                {/* 片方向 (one-way): isReversed の状態に合わせて矢印の向きを変える */}
                 <button
                   type="button"
-                  onClick={() => {
-                    setRelationshipType('one-way');
-                    setIsTypePickerOpen(false);
-                  }}
+                  onClick={() => { setRelationshipType('one-way'); setIsTypePickerOpen(false); }}
                   aria-pressed={relationshipType === 'one-way'}
                   aria-label="片方向"
                   className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
-                    relationshipType === 'one-way'
-                      ? 'bg-blue-100 ring-2 ring-blue-500'
-                      : 'hover:bg-gray-100'
+                    relationshipType === 'one-way' ? 'bg-blue-100 ring-2 ring-blue-500' : 'hover:bg-gray-100'
                   }`}
                 >
                   {isReversed ? <ArrowLeft className="w-6 h-6" /> : <ArrowRight className="w-6 h-6" />}
                 </button>
-
-                {/* 双方向 (bidirectional) */}
                 <button
                   type="button"
-                  onClick={() => {
-                    setRelationshipType('bidirectional');
-                    setIsTypePickerOpen(false);
-                  }}
+                  onClick={() => { setRelationshipType('bidirectional'); setIsTypePickerOpen(false); }}
                   aria-pressed={relationshipType === 'bidirectional'}
                   aria-label="双方向"
                   className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
-                    relationshipType === 'bidirectional'
-                      ? 'bg-blue-100 ring-2 ring-blue-500'
-                      : 'hover:bg-gray-100'
+                    relationshipType === 'bidirectional' ? 'bg-blue-100 ring-2 ring-blue-500' : 'hover:bg-gray-100'
                   }`}
                 >
                   <BidirectionalArrow className="w-6 h-6" />
                 </button>
-
-                {/* 片方向×2 (dual-directed) */}
                 <button
                   type="button"
-                  onClick={() => {
-                    setRelationshipType('dual-directed');
-                    setIsTypePickerOpen(false);
-                  }}
+                  onClick={() => { setRelationshipType('dual-directed'); setIsTypePickerOpen(false); }}
                   aria-pressed={relationshipType === 'dual-directed'}
                   aria-label="片方向×2"
                   className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
-                    relationshipType === 'dual-directed'
-                      ? 'bg-blue-100 ring-2 ring-blue-500'
-                      : 'hover:bg-gray-100'
+                    relationshipType === 'dual-directed' ? 'bg-blue-100 ring-2 ring-blue-500' : 'hover:bg-gray-100'
                   }`}
                 >
                   <ArrowLeftRight className="w-6 h-6" />
                 </button>
-
-                {/* 無方向 (undirected) */}
                 <button
                   type="button"
-                  onClick={() => {
-                    setRelationshipType('undirected');
-                    setIsTypePickerOpen(false);
-                  }}
+                  onClick={() => { setRelationshipType('undirected'); setIsTypePickerOpen(false); }}
                   aria-pressed={relationshipType === 'undirected'}
                   aria-label="無方向"
                   className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
-                    relationshipType === 'undirected'
-                      ? 'bg-blue-100 ring-2 ring-blue-500'
-                      : 'hover:bg-gray-100'
+                    relationshipType === 'undirected' ? 'bg-blue-100 ring-2 ring-blue-500' : 'hover:bg-gray-100'
                   }`}
                 >
                   <Minus className="w-6 h-6" />
@@ -515,16 +856,11 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
 
         {/* ラベル入力 */}
         {relationshipType === 'dual-directed' ? (
-          // dual-directed: 2つのラベル入力セット
           <>
-            <div className="mb-4">
-              <label
-                htmlFor="relationship-label"
-                className="block text-sm font-medium text-gray-700 mb-2"
-              >
+            <div>
+              <label htmlFor="relationship-label" className="block text-sm font-medium text-gray-700 mb-2">
                 関係のラベル
               </label>
-              {/* 方向インジケーター */}
               <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
                 <PersonMiniIcon person={person1} />
                 <span>→</span>
@@ -540,14 +876,10 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
                 className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
-            <div className="mb-4">
-              <label
-                htmlFor="reverse-relationship-label"
-                className="block text-sm font-medium text-gray-700 mb-2"
-              >
+            <div>
+              <label htmlFor="reverse-relationship-label" className="block text-sm font-medium text-gray-700 mb-2">
                 逆方向のラベル
               </label>
-              {/* 方向インジケーター */}
               <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
                 <PersonMiniIcon person={person1} />
                 <span>←</span>
@@ -565,15 +897,10 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
             </div>
           </>
         ) : (
-          // one-way / bidirectional / undirected: 単一ラベル入力
-          <div className="mb-4">
-            <label
-              htmlFor="relationship-label"
-              className="block text-sm font-medium text-gray-700 mb-2"
-            >
+          <div>
+            <label htmlFor="relationship-label" className="block text-sm font-medium text-gray-700 mb-2">
               関係のラベル
             </label>
-            {/* 関係タイプに応じたインジケーター */}
             {relationshipType !== 'undirected' && (
               <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
                 <PersonMiniIcon person={person1} />
@@ -592,6 +919,278 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
             />
           </div>
         )}
+
+        {/* タグ chip 入力（常時表示） */}
+        <TagChipInput
+          value={tags}
+          onChange={setTags}
+          suggestions={SUGGESTED_TAGS}
+        />
+
+        {/* ─── 定型フィールド アコーディオン ─── */}
+        <details className="border border-gray-200 rounded-md">
+          <summary className="flex items-center justify-between px-3 py-2 text-xs font-semibold text-gray-600 cursor-pointer select-none hover:bg-gray-50 list-none">
+            <button
+              type="button"
+              className="flex-1 text-left"
+              onClick={(e) => {
+                // detailsのsummaryをbuttonで包むとclickが2重になるため、
+                // detailsのtoggleに任せてbutton自身のデフォルト動作を抑制しない
+                e.currentTarget.closest('details')?.toggleAttribute('open');
+                e.preventDefault();
+              }}
+            >
+              定型フィールド
+            </button>
+          </summary>
+          <div className="px-3 pb-3 space-y-4 border-t border-gray-100 pt-3">
+
+            {/* 対称プロパティ */}
+            <div className="space-y-3">
+              <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">対称プロパティ</h4>
+              <NullableSlider
+                label="親密度"
+                value={closenessIsNull ? null : closeness}
+                min={0} max={1} step={0.05}
+                defaultValue={0.5}
+                onValueChange={setCloseness}
+                onNullToggle={setClosenessIsNull}
+              />
+              <NullableSlider
+                label="信頼度"
+                value={trustIsNull ? null : trust}
+                min={0} max={1} step={0.05}
+                defaultValue={0.5}
+                onValueChange={setTrust}
+                onNullToggle={setTrustIsNull}
+              />
+              <NullableSlider
+                label="緊張・対立度"
+                value={tensionIsNull ? null : tension}
+                min={0} max={1} step={0.05}
+                defaultValue={0.5}
+                onValueChange={setTension}
+                onNullToggle={setTensionIsNull}
+              />
+              <NullableSlider
+                label="秘匿性"
+                value={secrecyIsNull ? null : secrecy}
+                min={0} max={1} step={0.05}
+                defaultValue={0.5}
+                onValueChange={setSecrecy}
+                onNullToggle={setSecrecyIsNull}
+              />
+              {/* kinship セレクト */}
+              <div className="space-y-1">
+                <label htmlFor="kinship-select" className="block text-xs font-medium text-gray-700">
+                  血縁・親族
+                </label>
+                <select
+                  id="kinship-select"
+                  value={kinship ?? ''}
+                  onChange={(e) => setKinship((e.target.value as KinshipKind) || null)}
+                  aria-label="血縁・親族"
+                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                >
+                  {KINSHIP_OPTIONS.map((opt) => (
+                    <option key={opt.value ?? 'null'} value={opt.value ?? ''}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* 方向プロパティ: person1 → person2 */}
+            <div className="space-y-3">
+              <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                {person1.name}→{person2.name}
+              </h4>
+              <NullableSlider
+                label={`${person1.name}→${person2.name} 好悪`}
+                value={fwdAffectionIsNull ? null : fwdAffection}
+                min={-1} max={1} step={0.05}
+                defaultValue={0}
+                onValueChange={setFwdAffection}
+                onNullToggle={setFwdAffectionIsNull}
+              />
+              <div className="space-y-1">
+                <label
+                  htmlFor="fwd-awareness-select"
+                  className="block text-xs font-medium text-gray-700"
+                  id="fwd-awareness-label"
+                >
+                  {person1.name}→{person2.name} 認知状況
+                </label>
+                <select
+                  id="fwd-awareness-select"
+                  value={fwdAwareness ?? ''}
+                  onChange={(e) => setFwdAwareness((e.target.value as AwarenessKind) || null)}
+                  aria-label={`${person1.name}→${person2.name} 認知状況`}
+                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                >
+                  {AWARENESS_OPTIONS.map((opt) => (
+                    <option key={opt.value ?? 'null'} value={opt.value ?? ''}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1">
+                <label htmlFor="fwd-role-input" className="block text-xs font-medium text-gray-700">
+                  {person1.name}→{person2.name} 役割
+                </label>
+                <input
+                  id="fwd-role-input"
+                  type="text"
+                  value={fwdRole}
+                  onChange={(e) => setFwdRole(e.target.value)}
+                  aria-label={`${person1.name}→${person2.name} 役割`}
+                  placeholder="例: 上司、師匠"
+                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            {/* 方向プロパティ: person2 → person1 */}
+            <div className="space-y-3">
+              <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                {person2.name}→{person1.name}
+              </h4>
+              <NullableSlider
+                label={`${person2.name}→${person1.name} 好悪`}
+                value={revAffectionIsNull ? null : revAffection}
+                min={-1} max={1} step={0.05}
+                defaultValue={0}
+                onValueChange={setRevAffection}
+                onNullToggle={setRevAffectionIsNull}
+              />
+              <div className="space-y-1">
+                <label
+                  htmlFor="rev-awareness-select"
+                  className="block text-xs font-medium text-gray-700"
+                >
+                  {person2.name}→{person1.name} 認知状況
+                </label>
+                <select
+                  id="rev-awareness-select"
+                  value={revAwareness ?? ''}
+                  onChange={(e) => setRevAwareness((e.target.value as AwarenessKind) || null)}
+                  aria-label={`${person2.name}→${person1.name} 認知状況`}
+                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                >
+                  {AWARENESS_OPTIONS.map((opt) => (
+                    <option key={opt.value ?? 'null'} value={opt.value ?? ''}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1">
+                <label htmlFor="rev-role-input" className="block text-xs font-medium text-gray-700">
+                  {person2.name}→{person1.name} 役割
+                </label>
+                <input
+                  id="rev-role-input"
+                  type="text"
+                  value={revRole}
+                  onChange={(e) => setRevRole(e.target.value)}
+                  aria-label={`${person2.name}→${person1.name} 役割`}
+                  placeholder="例: 部下、弟子"
+                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+          </div>
+        </details>
+
+        {/* ─── 物語的情報 アコーディオン ─── */}
+        <details className="border border-gray-200 rounded-md">
+          <summary className="flex items-center justify-between px-3 py-2 text-xs font-semibold text-gray-600 cursor-pointer select-none hover:bg-gray-50 list-none">
+            <button
+              type="button"
+              className="flex-1 text-left"
+              onClick={(e) => {
+                e.currentTarget.closest('details')?.toggleAttribute('open');
+                e.preventDefault();
+              }}
+            >
+              物語的情報
+            </button>
+          </summary>
+          <div className="px-3 pb-3 space-y-3 border-t border-gray-100 pt-3">
+            {/* summary */}
+            <div className="space-y-1">
+              <label htmlFor="narrative-summary" className="block text-xs font-medium text-gray-700">
+                関係の概要
+              </label>
+              <textarea
+                id="narrative-summary"
+                value={narrativeSummary}
+                onChange={(e) => setNarrativeSummary(e.target.value)}
+                rows={3}
+                placeholder="関係の背景・物語的な概要を記述"
+                className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded resize-none focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            {/* notes */}
+            <div className="space-y-1">
+              <label htmlFor="narrative-notes" className="block text-xs font-medium text-gray-700">
+                メモ・補足
+              </label>
+              <textarea
+                id="narrative-notes"
+                value={narrativeNotes}
+                onChange={(e) => setNarrativeNotes(e.target.value)}
+                rows={2}
+                placeholder="メモや補足情報"
+                className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded resize-none focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            {/* turningPoints */}
+            <TurningPointsEditor value={turningPoints} onChange={setTurningPoints} />
+          </div>
+        </details>
+
+        {/* ─── colorOverride ─── */}
+        <div className="space-y-1">
+          <span className="block text-xs font-medium text-gray-700">エッジの色</span>
+          {colorPickerEnabled ? (
+            <div className="flex items-center gap-2">
+              <input
+                id="color-override-picker"
+                type="color"
+                value={colorOverride ?? '#6366f1'}
+                onChange={(e) => setColorOverride(e.target.value)}
+                aria-label="エッジの色"
+                className="w-8 h-8 rounded border border-gray-300 cursor-pointer p-0.5"
+              />
+              <button
+                type="button"
+                onClick={() => { setColorOverride(null); setColorPickerEnabled(false); }}
+                aria-label="色をクリア"
+                className="text-xs text-gray-500 hover:text-red-600 hover:underline"
+              >
+                クリア
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-500">タグから派生</span>
+              <button
+                type="button"
+                onClick={() => {
+                  setColorPickerEnabled(true);
+                  if (!colorOverride) setColorOverride('#6366f1');
+                }}
+                aria-label="色を上書きする"
+                className="text-xs text-blue-600 hover:text-blue-800 hover:underline"
+              >
+                上書きする
+              </button>
+            </div>
+          )}
+        </div>
 
         {/* 登録/更新ボタン */}
         <button

--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -110,7 +110,7 @@ type NullableSliderProps = {
   step: number;
   /** null のときのスライダーデフォルト値 */
   defaultValue: number;
-  /** 値変更コールバック（未設定解除時に呼ばれる） */
+  /** スライダーの値変更時に呼ばれるコールバック */
   onValueChange: (value: number) => void;
   /** null トグルコールバック（true=未設定, false=値あり） */
   onNullToggle: (isNull: boolean) => void;
@@ -203,12 +203,13 @@ function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
   return (
     <div className="space-y-2">
       <span className="text-xs font-medium text-gray-700">ターニングポイント</span>
-      {value.map((row) => (
+      {value.map((row, index) => (
         <div key={row.id} className="flex gap-1 items-start">
           <input
             type="text"
             value={row.at}
             onChange={(e) => handleChange(row.id, 'at', e.target.value)}
+            aria-label={`ターニングポイント${index + 1}の時期・時点`}
             placeholder="時期・時点"
             className="w-24 shrink-0 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
@@ -216,6 +217,7 @@ function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
             type="text"
             value={row.note}
             onChange={(e) => handleChange(row.id, 'note', e.target.value)}
+            aria-label={`ターニングポイント${index + 1}の出来事`}
             placeholder="出来事"
             className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
@@ -308,6 +310,7 @@ function TagChipInput({ value, onChange, suggestions, datalistId: datalistIdProp
         onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={handleKeyDown}
         list={datalistId}
+        aria-label="タグを追加"
         placeholder="タグを追加（Enter で確定）"
         className="w-full px-3 py-1.5 text-xs border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
       />

--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -11,7 +11,7 @@
 
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useId } from 'react';
 import { nanoid } from 'nanoid';
 import { useReactFlow } from '@xyflow/react';
 import { ArrowRight, ArrowLeft, ArrowLeftRight, Minus } from 'lucide-react';
@@ -23,6 +23,12 @@ import { getNodeCenter, VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils
 import type { Person } from '@/types/person';
 import type { RelationshipType, KinshipKind, AwarenessKind } from '@/types/relationship';
 import { SUGGESTED_TAGS } from '@/types/relationship';
+
+/**
+ * colorOverride が null のときのカラーピッカーデフォルト色
+ * Tailwind の indigo-500 (#6366f1) に相当する
+ */
+const DEFAULT_EDGE_COLOR = '#6366f1';
 
 /** PairSelectionPanelのプロパティ */
 type PairSelectionPanelProps = {
@@ -121,8 +127,10 @@ function NullableSlider({
   onNullToggle,
 }: NullableSliderProps) {
   const isNull = value === null;
-  const sliderId = `slider-${label}`;
-  const checkboxId = `nullable-${label}`;
+  // useId() でインスタンス固有の ID を生成し、ラベル文字列による重複 ID を防ぐ
+  const baseId = useId();
+  const sliderId = `${baseId}-slider`;
+  const checkboxId = `${baseId}-nullable`;
   // 未設定時にスライダーが表示する内部値（デフォルト値か現在値）
   const displayValue = value ?? defaultValue;
 
@@ -240,10 +248,15 @@ type TagChipInputProps = {
   value: string[];
   onChange: (tags: string[]) => void;
   suggestions: readonly string[];
+  /** datalist 要素の ID（省略時は useId() で生成） */
+  datalistId?: string;
 };
 
-function TagChipInput({ value, onChange, suggestions }: TagChipInputProps) {
+function TagChipInput({ value, onChange, suggestions, datalistId: datalistIdProp }: TagChipInputProps) {
   const [inputValue, setInputValue] = useState('');
+  // 呼び出し元から ID が渡されていれば使い、なければ useId() で一意な ID を生成する
+  const generatedId = useId();
+  const datalistId = datalistIdProp ?? `${generatedId}-tag-suggestions`;
 
   const addTag = (raw: string) => {
     const tag = raw.trim();
@@ -264,8 +277,6 @@ function TagChipInput({ value, onChange, suggestions }: TagChipInputProps) {
       addTag(inputValue);
     }
   };
-
-  const datalistId = 'tag-suggestions';
 
   return (
     <div className="space-y-2">
@@ -925,23 +936,13 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
           value={tags}
           onChange={setTags}
           suggestions={SUGGESTED_TAGS}
+          datalistId="tag-suggestions"
         />
 
         {/* ─── 定型フィールド アコーディオン ─── */}
         <details className="border border-gray-200 rounded-md">
           <summary className="flex items-center justify-between px-3 py-2 text-xs font-semibold text-gray-600 cursor-pointer select-none hover:bg-gray-50 list-none">
-            <button
-              type="button"
-              className="flex-1 text-left"
-              onClick={(e) => {
-                // detailsのsummaryをbuttonで包むとclickが2重になるため、
-                // detailsのtoggleに任せてbutton自身のデフォルト動作を抑制しない
-                e.currentTarget.closest('details')?.toggleAttribute('open');
-                e.preventDefault();
-              }}
-            >
-              定型フィールド
-            </button>
+            定型フィールド
           </summary>
           <div className="px-3 pb-3 space-y-4 border-t border-gray-100 pt-3">
 
@@ -1107,16 +1108,7 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
         {/* ─── 物語的情報 アコーディオン ─── */}
         <details className="border border-gray-200 rounded-md">
           <summary className="flex items-center justify-between px-3 py-2 text-xs font-semibold text-gray-600 cursor-pointer select-none hover:bg-gray-50 list-none">
-            <button
-              type="button"
-              className="flex-1 text-left"
-              onClick={(e) => {
-                e.currentTarget.closest('details')?.toggleAttribute('open');
-                e.preventDefault();
-              }}
-            >
-              物語的情報
-            </button>
+            物語的情報
           </summary>
           <div className="px-3 pb-3 space-y-3 border-t border-gray-100 pt-3">
             {/* summary */}
@@ -1160,7 +1152,7 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
               <input
                 id="color-override-picker"
                 type="color"
-                value={colorOverride ?? '#6366f1'}
+                value={colorOverride ?? DEFAULT_EDGE_COLOR}
                 onChange={(e) => setColorOverride(e.target.value)}
                 aria-label="エッジの色"
                 className="w-8 h-8 rounded border border-gray-300 cursor-pointer p-0.5"
@@ -1181,7 +1173,7 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
                 type="button"
                 onClick={() => {
                   setColorPickerEnabled(true);
-                  if (!colorOverride) setColorOverride('#6366f1');
+                  if (!colorOverride) setColorOverride(DEFAULT_EDGE_COLOR);
                 }}
                 aria-label="色を上書きする"
                 className="text-xs text-blue-600 hover:text-blue-800 hover:underline"


### PR DESCRIPTION
## Summary

- `PairSelectionPanel` に v9 プロパティグラフの全フィールドを編集するUIを追加
- `symmetric`（closeness/trust/tension/secrecy スライダー + kinship セレクト）
- 方向プロパティ（affection スライダー・awareness セレクト・role テキスト）× forward/reverse 両方向
- タグ入力（chip + datalist、IME対応、重複排除）
- narrative（summary/notes textarea + turningPoints 動的リスト）
- colorOverride カラーピッカー（null ⇔ 色コード切り替え）

## 実装の特徴

- スライダーに「未設定」チェックボックスを設け `null` と `0` を明確に区別
- `isReversed` に応じて UI「person1→person2」方向と stored `forward`/`reverse` を正しくスワップ
- `<details>/<summary>` ネイティブアコーディオン（新規依存なし）
- 内部ヘルパーコンポーネント（`NullableSlider`、`TagChipInput`、`TurningPointsEditor`）で可読性確保
- TDD で実装（新規テスト 35件追加、既存28件は全て継続パス）

## Test plan

- [x] `npm test` — 63件全パス（既存28件 + 新規35件）
- [x] `npm run type-check` — エラーなし
- [x] `npm run lint` — 警告ゼロ
- [x] CodeRabbit レビュー実施・指摘5件修正済み
- [ ] ブラウザ手動確認（新規タグ追加→保存→リロード後に永続化確認、isReversed関係での方向プロパティ確認）

## 関連 issue

Closes #75
コンポーネント分割・状態統合の技術的負債 → #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)