### PR TITLE
refactor: EdgeFilter の tags.values を Set<string> から string[] に変更（#78）

### DIFF
--- a/src/components/graph/EdgeFilterPanel.test.tsx
+++ b/src/components/graph/EdgeFilterPanel.test.tsx
@@ -19,7 +19,7 @@ describe('EdgeFilterPanel', () => {
     [...store.relationships].forEach((rel) => store.removeRelationship(rel.id));
     store.clearSelection();
     // edgeFilter をリセット
-    store.updateEdgeFilter({ tags: { mode: 'any', values: new Set() }, predicates: [] });
+    store.updateEdgeFilter({ tags: { mode: 'any', values: [] }, predicates: [] });
   });
 
   describe('タグなし状態', () => {
@@ -111,7 +111,7 @@ describe('EdgeFilterPanel', () => {
       await user.click(screen.getByText('解除'));
 
       const store = useGraphStore.getState();
-      expect(store.edgeFilter.tags.values.size).toBe(0);
+      expect(store.edgeFilter.tags.values.length).toBe(0);
       expect(store.edgeFilter.predicates).toEqual([]);
     });
 

--- a/src/components/graph/EdgeFilterPanel.tsx
+++ b/src/components/graph/EdgeFilterPanel.tsx
@@ -155,19 +155,17 @@ export const EdgeFilterPanel = memo(() => {
   }, [relationships]);
 
   // フィルタが適用されているかどうか
-  const isFiltered = edgeFilter.tags.values.size > 0 || edgeFilter.predicates.length > 0;
+  const isFiltered = edgeFilter.tags.values.length > 0 || edgeFilter.predicates.length > 0;
 
   /**
    * タグチェックボックスの変更ハンドラ
    * チェック時は tags.values にタグを追加、解除時は削除する
    */
   const handleTagToggle = useCallback((tag: string, checked: boolean) => {
-    const newValues = new Set(edgeFilter.tags.values);
-    if (checked) {
-      newValues.add(tag);
-    } else {
-      newValues.delete(tag);
-    }
+    const newValues = checked
+      // 重複排除して追加
+      ? [...new Set([...edgeFilter.tags.values, tag])]
+      : edgeFilter.tags.values.filter((v) => v !== tag);
     updateEdgeFilter({
       tags: { mode: edgeFilter.tags.mode, values: newValues },
     });
@@ -215,7 +213,7 @@ export const EdgeFilterPanel = memo(() => {
    */
   const handleReset = () => {
     updateEdgeFilter({
-      tags: { mode: 'any', values: new Set() },
+      tags: { mode: 'any', values: [] },
       predicates: [],
     });
   };
@@ -257,7 +255,7 @@ export const EdgeFilterPanel = memo(() => {
             {/* タグチェックボックス一覧（タグが多い場合はスクロール可能） */}
             <div className="space-y-1 max-h-48 overflow-y-auto mt-1">
               {allTags.map((tag) => {
-                const checked = edgeFilter.tags.values.has(tag);
+                const checked = edgeFilter.tags.values.includes(tag);
                 return (
                   <label
                     key={tag}

--- a/src/components/graph/EdgeFilterPanel.tsx
+++ b/src/components/graph/EdgeFilterPanel.tsx
@@ -157,6 +157,10 @@ export const EdgeFilterPanel = memo(() => {
   // フィルタが適用されているかどうか
   const isFiltered = edgeFilter.tags.values.length > 0 || edgeFilter.predicates.length > 0;
 
+  // タグチェックボックスのO(1)ルックアップ用Set
+  // allTags.map 内で includes(O(n)) を避けるためにメモ化する
+  const selectedTagSet = useMemo(() => new Set(edgeFilter.tags.values), [edgeFilter.tags.values]);
+
   /**
    * タグチェックボックスの変更ハンドラ
    * チェック時は tags.values にタグを追加、解除時は削除する
@@ -255,7 +259,7 @@ export const EdgeFilterPanel = memo(() => {
             {/* タグチェックボックス一覧（タグが多い場合はスクロール可能） */}
             <div className="space-y-1 max-h-48 overflow-y-auto mt-1">
               {allTags.map((tag) => {
-                const checked = edgeFilter.tags.values.includes(tag);
+                const checked = selectedTagSet.has(tag);
                 return (
                   <label
                     key={tag}

--- a/src/lib/graph-utils.test.ts
+++ b/src/lib/graph-utils.test.ts
@@ -533,7 +533,7 @@ describe('graph-utils', () => {
   describe('matchesEdgeFilter: エッジフィルタ判定', () => {
     /** フィルタなし（初期値）を表す EdgeFilter */
     const noFilter: EdgeFilter = {
-      tags: { mode: 'any', values: new Set() },
+      tags: { mode: 'any', values: [] },
       predicates: [],
     };
 
@@ -553,7 +553,7 @@ describe('graph-utils', () => {
         // 前提条件: 関係タグ ['友人', '同級生']、フィルタタグ ['同級生']
         const rel = makeRel({ tags: ['友人', '同級生'] });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set(['同級生']) },
+          tags: { mode: 'any', values: ['同級生'] },
           predicates: [],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(true);
@@ -563,7 +563,7 @@ describe('graph-utils', () => {
         // 前提条件: 関係タグ ['友人']、フィルタタグ ['上司', '部下']
         const rel = makeRel({ tags: ['友人'] });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set(['上司', '部下']) },
+          tags: { mode: 'any', values: ['上司', '部下'] },
           predicates: [],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -572,7 +572,7 @@ describe('graph-utils', () => {
       it('関係のタグが空でフィルタにタグが指定されている場合は除外される', () => {
         const rel = makeRel({ tags: [] });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set(['上司']) },
+          tags: { mode: 'any', values: ['上司'] },
           predicates: [],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -584,7 +584,7 @@ describe('graph-utils', () => {
         // 前提条件: 関係タグ ['上司', '同級生', '友人']、フィルタタグ ['上司', '同級生']
         const rel = makeRel({ tags: ['上司', '同級生', '友人'] });
         const filter: EdgeFilter = {
-          tags: { mode: 'all', values: new Set(['上司', '同級生']) },
+          tags: { mode: 'all', values: ['上司', '同級生'] },
           predicates: [],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(true);
@@ -594,7 +594,7 @@ describe('graph-utils', () => {
         // 前提条件: 関係タグ ['上司']、フィルタタグ ['上司', '同級生']（'同級生'がない）
         const rel = makeRel({ tags: ['上司'] });
         const filter: EdgeFilter = {
-          tags: { mode: 'all', values: new Set(['上司', '同級生']) },
+          tags: { mode: 'all', values: ['上司', '同級生'] },
           predicates: [],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -605,7 +605,7 @@ describe('graph-utils', () => {
       it('closeness_gte: 閾値以上なら通過する', () => {
         const rel = makeRel({ symmetric: { closeness: 0.8, trust: null, tension: null, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'closeness_gte', value: 0.5 }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(true);
@@ -614,7 +614,7 @@ describe('graph-utils', () => {
       it('closeness_gte: 閾値未満なら除外される', () => {
         const rel = makeRel({ symmetric: { closeness: 0.3, trust: null, tension: null, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'closeness_gte', value: 0.5 }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -623,7 +623,7 @@ describe('graph-utils', () => {
       it('closeness_gte: closenessがnullなら除外される', () => {
         const rel = makeRel({ symmetric: { closeness: null, trust: null, tension: null, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'closeness_gte', value: 0.0 }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -632,7 +632,7 @@ describe('graph-utils', () => {
       it('trust_gte: 閾値以上なら通過する', () => {
         const rel = makeRel({ symmetric: { closeness: null, trust: 0.7, tension: null, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'trust_gte', value: 0.5 }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(true);
@@ -641,7 +641,7 @@ describe('graph-utils', () => {
       it('tension_gte: 閾値未満なら除外される', () => {
         const rel = makeRel({ symmetric: { closeness: null, trust: null, tension: 0.2, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'tension_gte', value: 0.5 }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -650,7 +650,7 @@ describe('graph-utils', () => {
       it('secrecy_gte: 閾値以上なら通過する', () => {
         const rel = makeRel({ symmetric: { closeness: null, trust: null, tension: null, secrecy: 0.6, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'secrecy_gte', value: 0.5 }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(true);
@@ -659,7 +659,7 @@ describe('graph-utils', () => {
       it('has_kinship: kinshipが設定されていれば通過する', () => {
         const rel = makeRel({ symmetric: { closeness: null, trust: null, tension: null, secrecy: null, kinship: 'parent' } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'has_kinship' }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(true);
@@ -668,7 +668,7 @@ describe('graph-utils', () => {
       it('has_kinship: kinshipがnullなら除外される', () => {
         const rel = makeRel({ symmetric: { closeness: null, trust: null, tension: null, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [{ type: 'has_kinship' }],
         };
         expect(matchesEdgeFilter(rel, filter)).toBe(false);
@@ -678,7 +678,7 @@ describe('graph-utils', () => {
         // closeness=0.8（OK）、trust=null（NG for trust_gte=0.5）
         const rel = makeRel({ symmetric: { closeness: 0.8, trust: null, tension: null, secrecy: null, kinship: null } });
         const filter: EdgeFilter = {
-          tags: { mode: 'any', values: new Set() },
+          tags: { mode: 'any', values: [] },
           predicates: [
             { type: 'closeness_gte', value: 0.5 },
             { type: 'trust_gte', value: 0.5 },
@@ -709,7 +709,7 @@ describe('graph-utils', () => {
       });
 
       const filter: EdgeFilter = {
-        tags: { mode: 'any', values: new Set(['上司']) },
+        tags: { mode: 'any', values: ['上司'] },
         predicates: [{ type: 'closeness_gte', value: 0.5 }],
       };
 
@@ -737,7 +737,7 @@ describe('graph-utils', () => {
         makeRel({ id: 'rel-友人', sourcePersonId: 'p3', targetPersonId: 'p4', tags: ['友人'] }),
       ];
       const filter: EdgeFilter = {
-        tags: { mode: 'any', values: new Set(['上司']) },
+        tags: { mode: 'any', values: ['上司'] },
         predicates: [],
       };
 
@@ -763,7 +763,7 @@ describe('graph-utils', () => {
         }),
       ];
       const filter: EdgeFilter = {
-        tags: { mode: 'any', values: new Set() },
+        tags: { mode: 'any', values: [] },
         predicates: [{ type: 'closeness_gte', value: 0.5 }],
       };
 

--- a/src/lib/graph-utils.ts
+++ b/src/lib/graph-utils.ts
@@ -59,13 +59,16 @@ function getPairKey(idA: string, idB: string): string {
 export function matchesEdgeFilter(relationship: RelationshipV9, filter: EdgeFilter): boolean {
   // タグフィルタ: values が空なら全通過
   if (filter.tags.values.length > 0) {
+    // O(1)ルックアップのためにSetへ変換（配列のincludesはO(n)）
+    const filterTagSet = new Set(filter.tags.values);
+    const relTagSet = new Set(relationship.tags);
     if (filter.tags.mode === 'any') {
       // いずれか1つのタグが一致すればOK
-      const hasMatch = relationship.tags.some((tag) => filter.tags.values.includes(tag));
+      const hasMatch = relationship.tags.some((tag) => filterTagSet.has(tag));
       if (!hasMatch) return false;
     } else {
       // 全てのフィルタタグが relationship.tags に含まれる必要がある
-      const allMatch = filter.tags.values.every((tag) => relationship.tags.includes(tag));
+      const allMatch = filter.tags.values.every((tag) => relTagSet.has(tag));
       if (!allMatch) return false;
     }
   }

--- a/src/lib/graph-utils.ts
+++ b/src/lib/graph-utils.ts
@@ -58,14 +58,14 @@ function getPairKey(idA: string, idB: string): string {
  */
 export function matchesEdgeFilter(relationship: RelationshipV9, filter: EdgeFilter): boolean {
   // タグフィルタ: values が空なら全通過
-  if (filter.tags.values.size > 0) {
+  if (filter.tags.values.length > 0) {
     if (filter.tags.mode === 'any') {
       // いずれか1つのタグが一致すればOK
-      const hasMatch = relationship.tags.some((tag) => filter.tags.values.has(tag));
+      const hasMatch = relationship.tags.some((tag) => filter.tags.values.includes(tag));
       if (!hasMatch) return false;
     } else {
       // 全てのフィルタタグが relationship.tags に含まれる必要がある
-      const allMatch = [...filter.tags.values].every((tag) => relationship.tags.includes(tag));
+      const allMatch = filter.tags.values.every((tag) => relationship.tags.includes(tag));
       if (!allMatch) return false;
     }
   }

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -75,7 +75,7 @@ describe('useGraphStore', () => {
     // sidePanelOpenもリセット
     store.setSidePanelOpen(true);
     // edgeFilterもリセット
-    store.updateEdgeFilter({ tags: { mode: 'any', values: new Set() }, predicates: [] });
+    store.updateEdgeFilter({ tags: { mode: 'any', values: [] }, predicates: [] });
   });
 
   describe('初期状態', () => {
@@ -2206,7 +2206,7 @@ describe('useGraphStore', () => {
       const { result } = renderHook(() => useGraphStore());
 
       expect(result.current.edgeFilter.tags.mode).toBe('any');
-      expect(result.current.edgeFilter.tags.values.size).toBe(0);
+      expect(result.current.edgeFilter.tags.values.length).toBe(0);
       expect(result.current.edgeFilter.predicates).toEqual([]);
     });
 
@@ -2215,11 +2215,11 @@ describe('useGraphStore', () => {
 
       act(() => {
         result.current.updateEdgeFilter({
-          tags: { mode: 'any', values: new Set(['上司', '部下']) },
+          tags: { mode: 'any', values: ['上司', '部下'] },
         });
       });
 
-      expect(result.current.edgeFilter.tags.values).toEqual(new Set(['上司', '部下']));
+      expect(result.current.edgeFilter.tags.values).toEqual(['上司', '部下']);
       expect(result.current.edgeFilter.predicates).toEqual([]);
     });
 
@@ -2233,7 +2233,7 @@ describe('useGraphStore', () => {
       });
 
       expect(result.current.edgeFilter.predicates).toEqual([{ type: 'closeness_gte', value: 0.5 }]);
-      expect(result.current.edgeFilter.tags.values.size).toBe(0);
+      expect(result.current.edgeFilter.tags.values.length).toBe(0);
     });
 
     it('updateEdgeFilter: パッチ更新は既存のフィールドを保持する', () => {
@@ -2251,13 +2251,13 @@ describe('useGraphStore', () => {
       // tags のみ更新し、predicates が変わっていないことを確認する
       act(() => {
         result.current.updateEdgeFilter({
-          tags: { mode: 'all', values: new Set(['上司']) },
+          tags: { mode: 'all', values: ['上司'] },
         });
       });
 
       // タグフィールドが更新されている
       expect(result.current.edgeFilter.tags.mode).toBe('all');
-      expect(result.current.edgeFilter.tags.values).toEqual(new Set(['上司']));
+      expect(result.current.edgeFilter.tags.values).toEqual(['上司']);
       // predicates はパッチ更新によって変更されていない
       expect(result.current.edgeFilter.predicates).toEqual([{ type: 'closeness_gte', value: 0.5 }]);
     });
@@ -2267,7 +2267,7 @@ describe('useGraphStore', () => {
 
       act(() => {
         result.current.updateEdgeFilter({
-          tags: { mode: 'all', values: new Set(['友人']) },
+          tags: { mode: 'all', values: ['友人'] },
         });
       });
 

--- a/src/types/relationship.ts
+++ b/src/types/relationship.ts
@@ -204,7 +204,7 @@ export type EdgePredicate =
 export type EdgeFilter = {
   tags: {
     mode: 'any' | 'all';
-    values: Set<string>;
+    values: string[];
   };
   predicates: EdgePredicate[];
 };
@@ -213,7 +213,7 @@ export type EdgeFilter = {
  * エッジフィルタの初期値（全エッジを表示）
  */
 export const INITIAL_EDGE_FILTER: EdgeFilter = {
-  tags: { mode: 'any', values: new Set() },
+  tags: { mode: 'any', values: [] },
   predicates: [],
 };
 

--- a/src/types/relationship.ts
+++ b/src/types/relationship.ts
@@ -198,7 +198,7 @@ export type EdgePredicate =
  * タグフィルタ（ANY/ALL モード）と述語フィルタの組み合わせで関係を絞り込む
  *
  * @property tags.mode - 'any': いずれかのタグが一致すればOK / 'all': 全タグが一致する必要あり
- * @property tags.values - フィルタ対象のタグ集合（空の場合はタグ絞り込みなし）
+ * @property tags.values - フィルタ対象の重複なしタグ配列（空の場合はタグ絞り込みなし）
  * @property predicates - 追加述語フィルタ（全て通過する必要あり）
  */
 export type EdgeFilter = {


### PR DESCRIPTION
## Summary

- `EdgeFilter.tags.values` の型を `Set<string>` → `string[]` に変更し、JSON シリアライゼーション安全性を確保
- 重複排除はタグ追加時に `new Set([...existing, tag])` で実施
- レンダリング時の `.includes` による O(n²) ルックアップを `useMemo` + `Set.has` で O(1) に改善

## Test plan

- [ ] `npm run lint` — 警告ゼロ確認
- [ ] `npm run type-check` — 型エラーゼロ確認
- [ ] `npm test` — 全817テスト通過確認
- [ ] `npm run build` — ビルド成功確認
- [ ] EdgeFilterPanel でタグのON/OFFが正常動作することを手動確認

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * グラフビューのエッジフィルター機能において、タグフィルター処理の内部実装を最適化しました。これにより、フィルター判定の処理が効率化されます。

* **Tests**
  * エッジフィルターパネルおよびグラフユーティリティ関連のテストスイートを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->