### PR TITLE
refactor: PairSelectionPanelのコンポーネント分割と状態統合 (#79)

### DIFF
--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -201,23 +201,23 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
       // tags
       setTags(existingRelationship.tags);
 
-      // symmetric（null はそのまま null として同期する）
+      // symmetric（undefined を防ぐため ?? null でフォールバック）
       const sym = existingRelationship.symmetric;
-      setCloseness(sym.closeness);
-      setTrust(sym.trust);
-      setTension(sym.tension);
-      setSecrecy(sym.secrecy);
+      setCloseness(sym.closeness ?? null);
+      setTrust(sym.trust ?? null);
+      setTension(sym.tension ?? null);
+      setSecrecy(sym.secrecy ?? null);
       setKinship(sym.kinship);
 
       // 方向プロパティ（isReversed を考慮）
       const fwd = isReversed ? existingRelationship.reverse : existingRelationship.forward;
       const rev = isReversed ? existingRelationship.forward : existingRelationship.reverse;
 
-      setFwdAffection(fwd.affection);
+      setFwdAffection(fwd.affection ?? null);
       setFwdAwareness(fwd.awareness ?? null);
       setFwdRole(fwd.role ?? '');
 
-      setRevAffection(rev.affection);
+      setRevAffection(rev.affection ?? null);
       setRevAwareness(rev.awareness ?? null);
       setRevRole(rev.role ?? '');
 
@@ -242,8 +242,12 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
       setTension(null);
       setSecrecy(null);
       setKinship(null);
-      setFwdAffection(null); setFwdAwareness(null); setFwdRole('');
-      setRevAffection(null); setRevAwareness(null); setRevRole('');
+      setFwdAffection(null);
+      setFwdAwareness(null);
+      setFwdRole('');
+      setRevAffection(null);
+      setRevAwareness(null);
+      setRevRole('');
       setNarrativeSummary(''); setNarrativeNotes('');
       setTurningPoints([]);
       setColorOverride(null); setColorPickerEnabled(false);

--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -11,11 +11,17 @@
 
 'use client';
 
-import { useState, useEffect, useMemo, useId } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { nanoid } from 'nanoid';
 import { useReactFlow } from '@xyflow/react';
 import { ArrowRight, ArrowLeft, ArrowLeftRight, Minus } from 'lucide-react';
 import { BidirectionalArrow } from '@/components/icons/BidirectionalArrow';
+import { NullableSlider } from '@/components/ui/NullableSlider';
+import { TagChipInput } from '@/components/ui/TagChipInput';
+import { TurningPointsEditor } from '@/components/panel/TurningPointsEditor';
+import type { TurningPointRow } from '@/components/panel/TurningPointsEditor';
+import { PersonMiniIcon } from '@/components/panel/PersonMiniIcon';
+import { getDirectionIndicator, getPlaceholder, KINSHIP_OPTIONS, AWARENESS_OPTIONS } from '@/components/panel/pairSelectionHelpers';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { MAX_RELATIONSHIP_LABEL_LENGTH } from '@/lib/validation-constants';
 import { getRelationshipDisplayType } from '@/lib/relationship-utils';
@@ -35,315 +41,6 @@ type PairSelectionPanelProps = {
   /** 選択されている2人の人物 */
   persons: [Person, Person];
 };
-
-/**
- * 表示用の方向インジケーターを返す
- * @param type - 関係タイプ
- * @param isReversed - 関係が逆向きかどうか
- * @returns 方向インジケーター文字列
- */
-function getDirectionIndicator(type: RelationshipType, isReversed: boolean): string {
-  if (type === 'bidirectional') {
-    return '↔';
-  }
-  if (type === 'one-way') {
-    return isReversed ? '←' : '→';
-  }
-  return '';
-}
-
-/**
- * 関係タイプと種別に応じたプレースホルダーを返す
- */
-function getPlaceholder(type: RelationshipType, isReverse = false, hasItem = false): string {
-  if (hasItem) {
-    if (type === 'one-way') return '例: 所有、使用';
-    if (type === 'bidirectional') return '例: 所有、使用';
-    if (type === 'dual-directed') return isReverse ? '例: 使用' : '例: 所有';
-    if (type === 'undirected') return '例: 所有、使用';
-  }
-  if (type === 'one-way') return '例: 片想い、憧れ';
-  if (type === 'bidirectional') return '例: 友人、親子、同僚';
-  if (type === 'dual-directed') return isReverse ? '例: 無関心、嫌い' : '例: 好き、憧れ';
-  if (type === 'undirected') return '例: 同一人物、別名';
-  return '例: 関係を入力';
-}
-
-/** 人物/物のミニアイコンを表示するヘルパーコンポーネント */
-function PersonMiniIcon({ person }: { person: Person }) {
-  const kind = person.kind ?? 'person';
-  const isItem = kind === 'item';
-  const borderRadius = isItem ? 'rounded-md' : 'rounded-full';
-
-  if (person.imageDataUrl) {
-    return (
-      <img
-        src={person.imageDataUrl}
-        alt={person.name}
-        className={`w-6 h-6 ${borderRadius} object-cover border border-gray-300`}
-      />
-    );
-  }
-  return (
-    <div className={`w-6 h-6 ${borderRadius} bg-gray-300 flex items-center justify-center text-gray-600 text-xs font-semibold border border-gray-300`}>
-      {person.name.charAt(0).toUpperCase() || '?'}
-    </div>
-  );
-}
-
-// ─── v9 ヘルパーコンポーネント ───────────────────────────────────────────────
-
-/**
- * null 値を持てる数値スライダーコンポーネント
- * 「未設定」チェックボックスで null ⇔ 数値を切り替える
- */
-type NullableSliderProps = {
-  /** スライダーのラベル（aria-label としても使用） */
-  label: string;
-  /** 現在の数値（未設定の場合は null） */
-  value: number | null;
-  /** スライダーの最小値 */
-  min: number;
-  /** スライダーの最大値 */
-  max: number;
-  /** スライダーのステップ */
-  step: number;
-  /** null のときのスライダーデフォルト値 */
-  defaultValue: number;
-  /** スライダーの値変更時に呼ばれるコールバック */
-  onValueChange: (value: number) => void;
-  /** null トグルコールバック（true=未設定, false=値あり） */
-  onNullToggle: (isNull: boolean) => void;
-};
-
-function NullableSlider({
-  label,
-  value,
-  min,
-  max,
-  step,
-  defaultValue,
-  onValueChange,
-  onNullToggle,
-}: NullableSliderProps) {
-  const isNull = value === null;
-  // useId() でインスタンス固有の ID を生成し、ラベル文字列による重複 ID を防ぐ
-  const baseId = useId();
-  const sliderId = `${baseId}-slider`;
-  const checkboxId = `${baseId}-nullable`;
-  // 未設定時にスライダーが表示する内部値（デフォルト値か現在値）
-  const displayValue = value ?? defaultValue;
-
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between text-xs font-medium text-gray-700">
-        <label htmlFor={sliderId}>{label}</label>
-        <div className="flex items-center gap-1.5">
-          {!isNull && (
-            <span className="text-[10px] text-gray-500">{displayValue.toFixed(2)}</span>
-          )}
-          <label htmlFor={checkboxId} className="flex items-center gap-0.5 text-[10px] text-gray-500 cursor-pointer">
-            <input
-              id={checkboxId}
-              type="checkbox"
-              checked={isNull}
-              onChange={(e) => onNullToggle(e.target.checked)}
-              aria-label={`${label}を未設定`}
-              className="w-3 h-3"
-            />
-            未設定
-          </label>
-        </div>
-      </div>
-      <input
-        id={sliderId}
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={displayValue}
-        disabled={isNull}
-        onChange={(e) => onValueChange(Number(e.target.value))}
-        aria-label={label}
-        className="w-full disabled:opacity-40"
-      />
-    </div>
-  );
-}
-
-/** ターニングポイントの行（ローカルステート用） */
-type TurningPointRow = {
-  id: string;
-  at: string;
-  note: string;
-};
-
-/**
- * ターニングポイント動的リストエディタ
- * 行の追加・削除・編集を提供する
- */
-type TurningPointsEditorProps = {
-  value: TurningPointRow[];
-  onChange: (rows: TurningPointRow[]) => void;
-};
-
-function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
-  const handleAdd = () => {
-    onChange([...value, { id: nanoid(), at: '', note: '' }]);
-  };
-
-  const handleRemove = (id: string) => {
-    onChange(value.filter((row) => row.id !== id));
-  };
-
-  const handleChange = (id: string, field: 'at' | 'note', text: string) => {
-    onChange(value.map((row) => (row.id === id ? { ...row, [field]: text } : row)));
-  };
-
-  return (
-    <div className="space-y-2">
-      <span className="text-xs font-medium text-gray-700">ターニングポイント</span>
-      {value.map((row, index) => (
-        <div key={row.id} className="flex gap-1 items-start">
-          <input
-            type="text"
-            value={row.at}
-            onChange={(e) => handleChange(row.id, 'at', e.target.value)}
-            aria-label={`ターニングポイント${index + 1}の時期・時点`}
-            placeholder="時期・時点"
-            className="w-24 shrink-0 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
-          />
-          <input
-            type="text"
-            value={row.note}
-            onChange={(e) => handleChange(row.id, 'note', e.target.value)}
-            aria-label={`ターニングポイント${index + 1}の出来事`}
-            placeholder="出来事"
-            className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
-          />
-          <button
-            type="button"
-            onClick={() => handleRemove(row.id)}
-            aria-label="このターニングポイントを削除"
-            className="shrink-0 text-gray-400 hover:text-red-500 text-xs px-1 py-1"
-          >
-            ✕
-          </button>
-        </div>
-      ))}
-      <button
-        type="button"
-        onClick={handleAdd}
-        className="text-xs text-blue-600 hover:text-blue-800 hover:underline"
-      >
-        + ターニングポイントを追加
-      </button>
-    </div>
-  );
-}
-
-/**
- * タグ chip 入力コンポーネント
- * SUGGESTED_TAGS を datalist として提供し、chip形式でタグを表示・削除する
- */
-type TagChipInputProps = {
-  value: string[];
-  onChange: (tags: string[]) => void;
-  suggestions: readonly string[];
-  /** datalist 要素の ID（省略時は useId() で生成） */
-  datalistId?: string;
-};
-
-function TagChipInput({ value, onChange, suggestions, datalistId: datalistIdProp }: TagChipInputProps) {
-  const [inputValue, setInputValue] = useState('');
-  // 呼び出し元から ID が渡されていれば使い、なければ useId() で一意な ID を生成する
-  const generatedId = useId();
-  const datalistId = datalistIdProp ?? `${generatedId}-tag-suggestions`;
-
-  const addTag = (raw: string) => {
-    const tag = raw.trim();
-    if (!tag || value.includes(tag)) return;
-    onChange([...value, tag]);
-    setInputValue('');
-  };
-
-  const removeTag = (tag: string) => {
-    onChange(value.filter((t) => t !== tag));
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      // IME変換中のEnterは無視（日本語入力の変換確定時の誤動作を防ぐ）
-      if (e.nativeEvent.isComposing) return;
-      e.preventDefault();
-      addTag(inputValue);
-    }
-  };
-
-  return (
-    <div className="space-y-2">
-      {/* 既存タグのチップ表示 */}
-      {value.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {value.map((tag) => (
-            <span
-              key={tag}
-              className="flex items-center gap-0.5 px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded-full"
-            >
-              {tag}
-              <button
-                type="button"
-                onClick={() => removeTag(tag)}
-                aria-label={`${tag}を削除`}
-                className="hover:text-blue-600 ml-0.5"
-              >
-                ×
-              </button>
-            </span>
-          ))}
-        </div>
-      )}
-      {/* タグ入力フィールド */}
-      <input
-        type="text"
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        list={datalistId}
-        aria-label="タグを追加"
-        placeholder="タグを追加（Enter で確定）"
-        className="w-full px-3 py-1.5 text-xs border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-      />
-      <datalist id={datalistId}>
-        {suggestions.map((s) => (
-          <option key={s} value={s} />
-        ))}
-      </datalist>
-    </div>
-  );
-}
-
-// ─── KinshipKind / AwarenessKind の日本語ラベル ──────────────────────────────
-
-const KINSHIP_OPTIONS: { value: KinshipKind; label: string }[] = [
-  { value: null, label: '（血縁なし）' },
-  { value: 'parent', label: '親' },
-  { value: 'child', label: '子' },
-  { value: 'sibling', label: '兄弟・姉妹' },
-  { value: 'spouse', label: '配偶者' },
-  { value: 'partner', label: 'パートナー' },
-  { value: 'grandparent', label: '祖父母' },
-  { value: 'grandchild', label: '孫' },
-  { value: 'cousin', label: 'いとこ' },
-  { value: 'relative', label: '親族（その他）' },
-];
-
-const AWARENESS_OPTIONS: { value: AwarenessKind; label: string }[] = [
-  { value: null, label: '（未設定）' },
-  { value: 'known', label: '認知済み' },
-  { value: 'unknown', label: '未認知' },
-  { value: 'suspected', label: '疑惑あり' },
-];
 
 // ─── PairSelectionPanel 本体 ─────────────────────────────────────────────────
 
@@ -427,15 +124,11 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
 
   // ────── symmetric フィールド ──────
 
-  // 各スライダーは「value」と「isNull」を分離して管理する
-  const [closeness, setCloseness] = useState<number>(() => existingRelationship?.symmetric.closeness ?? 0.5);
-  const [closenessIsNull, setClosenessIsNull] = useState<boolean>(() => existingRelationship?.symmetric.closeness === null || !existingRelationship);
-  const [trust, setTrust] = useState<number>(() => existingRelationship?.symmetric.trust ?? 0.5);
-  const [trustIsNull, setTrustIsNull] = useState<boolean>(() => existingRelationship?.symmetric.trust === null || !existingRelationship);
-  const [tension, setTension] = useState<number>(() => existingRelationship?.symmetric.tension ?? 0.5);
-  const [tensionIsNull, setTensionIsNull] = useState<boolean>(() => existingRelationship?.symmetric.tension === null || !existingRelationship);
-  const [secrecy, setSecrecy] = useState<number>(() => existingRelationship?.symmetric.secrecy ?? 0.5);
-  const [secrecyIsNull, setSecrecyIsNull] = useState<boolean>(() => existingRelationship?.symmetric.secrecy === null || !existingRelationship);
+  // 未設定を null で表現する（isNull フラグは廃止）
+  const [closeness, setCloseness] = useState<number | null>(() => existingRelationship?.symmetric.closeness ?? null);
+  const [trust, setTrust] = useState<number | null>(() => existingRelationship?.symmetric.trust ?? null);
+  const [tension, setTension] = useState<number | null>(() => existingRelationship?.symmetric.tension ?? null);
+  const [secrecy, setSecrecy] = useState<number | null>(() => existingRelationship?.symmetric.secrecy ?? null);
   const [kinship, setKinship] = useState<KinshipKind>(() => existingRelationship?.symmetric.kinship ?? null);
 
   // ────── 方向プロパティ（person1→person2 方向 = UI の fwd ）──────
@@ -458,16 +151,14 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
     return isReversed ? existingRelationship.forward : existingRelationship.reverse;
   };
 
-  // person1→person2 方向の affection
-  const [fwdAffection, setFwdAffection] = useState<number>(() => getStoredFwdProps().affection ?? 0);
-  const [fwdAffectionIsNull, setFwdAffectionIsNull] = useState<boolean>(() => getStoredFwdProps().affection === null || !existingRelationship);
+  // person1→person2 方向の affection（未設定を null で表現する）
+  const [fwdAffection, setFwdAffection] = useState<number | null>(() => getStoredFwdProps().affection ?? null);
   // person1→person2 方向の awareness / role
   const [fwdAwareness, setFwdAwareness] = useState<AwarenessKind>(() => getStoredFwdProps().awareness ?? null);
   const [fwdRole, setFwdRole] = useState<string>(() => getStoredFwdProps().role ?? '');
 
-  // person2→person1 方向の affection
-  const [revAffection, setRevAffection] = useState<number>(() => getStoredRevProps().affection ?? 0);
-  const [revAffectionIsNull, setRevAffectionIsNull] = useState<boolean>(() => getStoredRevProps().affection === null || !existingRelationship);
+  // person2→person1 方向の affection（未設定を null で表現する）
+  const [revAffection, setRevAffection] = useState<number | null>(() => getStoredRevProps().affection ?? null);
   // person2→person1 方向の awareness / role
   const [revAwareness, setRevAwareness] = useState<AwarenessKind>(() => getStoredRevProps().awareness ?? null);
   const [revRole, setRevRole] = useState<string>(() => getStoredRevProps().role ?? '');
@@ -510,29 +201,23 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
       // tags
       setTags(existingRelationship.tags);
 
-      // symmetric
+      // symmetric（null はそのまま null として同期する）
       const sym = existingRelationship.symmetric;
-      setCloseness(sym.closeness ?? 0.5);
-      setClosenessIsNull(sym.closeness === null);
-      setTrust(sym.trust ?? 0.5);
-      setTrustIsNull(sym.trust === null);
-      setTension(sym.tension ?? 0.5);
-      setTensionIsNull(sym.tension === null);
-      setSecrecy(sym.secrecy ?? 0.5);
-      setSecrecyIsNull(sym.secrecy === null);
+      setCloseness(sym.closeness);
+      setTrust(sym.trust);
+      setTension(sym.tension);
+      setSecrecy(sym.secrecy);
       setKinship(sym.kinship);
 
       // 方向プロパティ（isReversed を考慮）
       const fwd = isReversed ? existingRelationship.reverse : existingRelationship.forward;
       const rev = isReversed ? existingRelationship.forward : existingRelationship.reverse;
 
-      setFwdAffection(fwd.affection ?? 0);
-      setFwdAffectionIsNull(fwd.affection === null);
+      setFwdAffection(fwd.affection);
       setFwdAwareness(fwd.awareness ?? null);
       setFwdRole(fwd.role ?? '');
 
-      setRevAffection(rev.affection ?? 0);
-      setRevAffectionIsNull(rev.affection === null);
+      setRevAffection(rev.affection);
       setRevAwareness(rev.awareness ?? null);
       setRevRole(rev.role ?? '');
 
@@ -552,15 +237,13 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
       setSourceToTargetLabel('');
       setTargetToSourceLabel('');
       setTags([]);
-      setCloseness(0.5); setClosenessIsNull(true);
-      setTrust(0.5); setTrustIsNull(true);
-      setTension(0.5); setTensionIsNull(true);
-      setSecrecy(0.5); setSecrecyIsNull(true);
+      setCloseness(null);
+      setTrust(null);
+      setTension(null);
+      setSecrecy(null);
       setKinship(null);
-      setFwdAffection(0); setFwdAffectionIsNull(true);
-      setFwdAwareness(null); setFwdRole('');
-      setRevAffection(0); setRevAffectionIsNull(true);
-      setRevAwareness(null); setRevRole('');
+      setFwdAffection(null); setFwdAwareness(null); setFwdRole('');
+      setRevAffection(null); setRevAwareness(null); setRevRole('');
       setNarrativeSummary(''); setNarrativeNotes('');
       setTurningPoints([]);
       setColorOverride(null); setColorPickerEnabled(false);
@@ -630,12 +313,12 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
       finalTargetToSourceLabel = finalSourceToTargetLabel;
     }
 
-    // v9 フィールドの値をビルド
+    // v9 フィールドの値をビルド（null は未設定を表す）
     const symmetricPayload = {
-      closeness: closenessIsNull ? null : closeness,
-      trust: trustIsNull ? null : trust,
-      tension: tensionIsNull ? null : tension,
-      secrecy: secrecyIsNull ? null : secrecy,
+      closeness,
+      trust,
+      tension,
+      secrecy,
       kinship,
     };
 
@@ -643,12 +326,12 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
     // isReversed=false: UI fwd = stored forward, UI rev = stored reverse
     // isReversed=true:  UI fwd = stored reverse, UI rev = stored forward
     const uiFwdProps = {
-      affection: fwdAffectionIsNull ? null : fwdAffection,
+      affection: fwdAffection,
       awareness: fwdAwareness,
       role: fwdRole.trim() || null,
     };
     const uiRevProps = {
-      affection: revAffectionIsNull ? null : revAffection,
+      affection: revAffection,
       awareness: revAwareness,
       role: revRole.trim() || null,
     };
@@ -954,35 +637,31 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
               <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">対称プロパティ</h4>
               <NullableSlider
                 label="親密度"
-                value={closenessIsNull ? null : closeness}
+                value={closeness}
                 min={0} max={1} step={0.05}
                 defaultValue={0.5}
-                onValueChange={setCloseness}
-                onNullToggle={setClosenessIsNull}
+                onChange={setCloseness}
               />
               <NullableSlider
                 label="信頼度"
-                value={trustIsNull ? null : trust}
+                value={trust}
                 min={0} max={1} step={0.05}
                 defaultValue={0.5}
-                onValueChange={setTrust}
-                onNullToggle={setTrustIsNull}
+                onChange={setTrust}
               />
               <NullableSlider
                 label="緊張・対立度"
-                value={tensionIsNull ? null : tension}
+                value={tension}
                 min={0} max={1} step={0.05}
                 defaultValue={0.5}
-                onValueChange={setTension}
-                onNullToggle={setTensionIsNull}
+                onChange={setTension}
               />
               <NullableSlider
                 label="秘匿性"
-                value={secrecyIsNull ? null : secrecy}
+                value={secrecy}
                 min={0} max={1} step={0.05}
                 defaultValue={0.5}
-                onValueChange={setSecrecy}
-                onNullToggle={setSecrecyIsNull}
+                onChange={setSecrecy}
               />
               {/* kinship セレクト */}
               <div className="space-y-1">
@@ -1012,11 +691,10 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
               </h4>
               <NullableSlider
                 label={`${person1.name}→${person2.name} 好悪`}
-                value={fwdAffectionIsNull ? null : fwdAffection}
+                value={fwdAffection}
                 min={-1} max={1} step={0.05}
                 defaultValue={0}
-                onValueChange={setFwdAffection}
-                onNullToggle={setFwdAffectionIsNull}
+                onChange={setFwdAffection}
               />
               <div className="space-y-1">
                 <label
@@ -1063,11 +741,10 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
               </h4>
               <NullableSlider
                 label={`${person2.name}→${person1.name} 好悪`}
-                value={revAffectionIsNull ? null : revAffection}
+                value={revAffection}
                 min={-1} max={1} step={0.05}
                 defaultValue={0}
-                onValueChange={setRevAffection}
-                onNullToggle={setRevAffectionIsNull}
+                onChange={setRevAffection}
               />
               <div className="space-y-1">
                 <label

--- a/src/components/panel/PersonMiniIcon.tsx
+++ b/src/components/panel/PersonMiniIcon.tsx
@@ -29,7 +29,7 @@ export function PersonMiniIcon({ person }: { person: Person }) {
   }
   return (
     <div className={`w-6 h-6 ${borderRadius} bg-gray-300 flex items-center justify-center text-gray-600 text-xs font-semibold border border-gray-300`}>
-      {person.name.charAt(0).toUpperCase() || '?'}
+      {person.name?.charAt(0).toUpperCase() || '?'}
     </div>
   );
 }

--- a/src/components/panel/PersonMiniIcon.tsx
+++ b/src/components/panel/PersonMiniIcon.tsx
@@ -1,0 +1,35 @@
+/**
+ * PersonMiniIcon コンポーネント
+ * 人物/物のミニアイコンを表示するヘルパーコンポーネント
+ * 画像がある場合は画像を、ない場合はイニシャルを表示する
+ */
+
+'use client';
+
+import type { Person } from '@/types/person';
+
+/**
+ * 人物/物のミニアイコンを表示するコンポーネント
+ * - person: 通常の人物（丸型）
+ * - item: 物（角丸四角形）
+ */
+export function PersonMiniIcon({ person }: { person: Person }) {
+  const kind = person.kind ?? 'person';
+  const isItem = kind === 'item';
+  const borderRadius = isItem ? 'rounded-md' : 'rounded-full';
+
+  if (person.imageDataUrl) {
+    return (
+      <img
+        src={person.imageDataUrl}
+        alt={person.name}
+        className={`w-6 h-6 ${borderRadius} object-cover border border-gray-300`}
+      />
+    );
+  }
+  return (
+    <div className={`w-6 h-6 ${borderRadius} bg-gray-300 flex items-center justify-center text-gray-600 text-xs font-semibold border border-gray-300`}>
+      {person.name.charAt(0).toUpperCase() || '?'}
+    </div>
+  );
+}

--- a/src/components/panel/TurningPointsEditor.test.tsx
+++ b/src/components/panel/TurningPointsEditor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TurningPointsEditor } from './TurningPointsEditor';
 import type { TurningPointRow } from './TurningPointsEditor';
@@ -51,6 +51,8 @@ describe('TurningPointsEditor', () => {
       const [newRows] = onChange.mock.calls[0];
       expect(newRows).toHaveLength(1);
       expect(newRows[0]).toMatchObject({ at: '', note: '' });
+      // 新規行に id が自動生成されていることを確認
+      expect(newRows[0].id).toEqual(expect.any(String));
     });
 
     it('既存行がある場合、追加後も既存行が保持される', async () => {
@@ -72,6 +74,29 @@ describe('TurningPointsEditor', () => {
       const deleteButtons = screen.getAllByRole('button', { name: 'このターニングポイントを削除' });
       await userEvent.click(deleteButtons[0]);
       expect(onChange).toHaveBeenCalledWith([makeRow('r2', '2022年', '別れ')]);
+    });
+  });
+
+  describe('編集', () => {
+    it('「at」フィールドを変更すると onChange が更新された行を含む配列で呼ばれる', () => {
+      const rows = [makeRow('r1', '2020年', '出会い')];
+      const onChange = vi.fn();
+      render(<TurningPointsEditor value={rows} onChange={onChange} />);
+      const atInput = screen.getByRole('textbox', { name: 'ターニングポイント1の時期・時点' });
+      // 制御コンポーネントのため fireEvent.change で一括変更をシミュレート
+      fireEvent.change(atInput, { target: { value: '2021年' } });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith([{ id: 'r1', at: '2021年', note: '出会い' }]);
+    });
+
+    it('「note」フィールドを変更すると onChange が更新された行を含む配列で呼ばれる', () => {
+      const rows = [makeRow('r1', '2020年', '出会い')];
+      const onChange = vi.fn();
+      render(<TurningPointsEditor value={rows} onChange={onChange} />);
+      const noteInput = screen.getByRole('textbox', { name: 'ターニングポイント1の出来事' });
+      fireEvent.change(noteInput, { target: { value: '再会' } });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith([{ id: 'r1', at: '2020年', note: '再会' }]);
     });
   });
 });

--- a/src/components/panel/TurningPointsEditor.test.tsx
+++ b/src/components/panel/TurningPointsEditor.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * TurningPointsEditor コンポーネントのユニットテスト
+ * ターニングポイントの動的リスト編集（追加・削除・変更）を検証する
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TurningPointsEditor } from './TurningPointsEditor';
+import type { TurningPointRow } from './TurningPointsEditor';
+
+/** テスト用ターニングポイント行を生成するファクトリ */
+function makeRow(id: string, at: string, note: string): TurningPointRow {
+  return { id, at, note };
+}
+
+describe('TurningPointsEditor', () => {
+  describe('描画', () => {
+    it('「ターニングポイント」ラベルが表示される', () => {
+      render(<TurningPointsEditor value={[]} onChange={vi.fn()} />);
+      expect(screen.getByText('ターニングポイント')).toBeInTheDocument();
+    });
+
+    it('「+ ターニングポイントを追加」ボタンが表示される', () => {
+      render(<TurningPointsEditor value={[]} onChange={vi.fn()} />);
+      expect(screen.getByRole('button', { name: /ターニングポイントを追加/ })).toBeInTheDocument();
+    });
+
+    it('既存の行が表示される', () => {
+      const rows = [makeRow('r1', '2020年', '出会い'), makeRow('r2', '2022年', '別れ')];
+      render(<TurningPointsEditor value={rows} onChange={vi.fn()} />);
+      expect(screen.getByDisplayValue('2020年')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('出会い')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('2022年')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('別れ')).toBeInTheDocument();
+    });
+
+    it('各行に削除ボタンが表示される', () => {
+      const rows = [makeRow('r1', '2020年', '出会い')];
+      render(<TurningPointsEditor value={rows} onChange={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'このターニングポイントを削除' })).toBeInTheDocument();
+    });
+  });
+
+  describe('追加', () => {
+    it('追加ボタンをクリックすると onChange が新しい行を含む配列で呼ばれる', async () => {
+      const onChange = vi.fn();
+      render(<TurningPointsEditor value={[]} onChange={onChange} />);
+      await userEvent.click(screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const [newRows] = onChange.mock.calls[0];
+      expect(newRows).toHaveLength(1);
+      expect(newRows[0]).toMatchObject({ at: '', note: '' });
+    });
+
+    it('既存行がある場合、追加後も既存行が保持される', async () => {
+      const existing = [makeRow('r1', '2020年', '出会い')];
+      const onChange = vi.fn();
+      render(<TurningPointsEditor value={existing} onChange={onChange} />);
+      await userEvent.click(screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+      const [newRows] = onChange.mock.calls[0];
+      expect(newRows).toHaveLength(2);
+      expect(newRows[0]).toMatchObject({ id: 'r1', at: '2020年', note: '出会い' });
+    });
+  });
+
+  describe('削除', () => {
+    it('削除ボタンをクリックすると該当行が削除される', async () => {
+      const rows = [makeRow('r1', '2020年', '出会い'), makeRow('r2', '2022年', '別れ')];
+      const onChange = vi.fn();
+      render(<TurningPointsEditor value={rows} onChange={onChange} />);
+      const deleteButtons = screen.getAllByRole('button', { name: 'このターニングポイントを削除' });
+      await userEvent.click(deleteButtons[0]);
+      expect(onChange).toHaveBeenCalledWith([makeRow('r2', '2022年', '別れ')]);
+    });
+  });
+});

--- a/src/components/panel/TurningPointsEditor.tsx
+++ b/src/components/panel/TurningPointsEditor.tsx
@@ -1,0 +1,85 @@
+/**
+ * TurningPointsEditor コンポーネント
+ * ターニングポイントの動的リストを編集する
+ * 行の追加・削除・編集（時期・出来事）を提供する
+ */
+
+'use client';
+
+import { nanoid } from 'nanoid';
+
+/** ターニングポイントの行（ローカルステート用） */
+export type TurningPointRow = {
+  id: string;
+  at: string;
+  note: string;
+};
+
+/**
+ * TurningPointsEditor のプロパティ
+ */
+export type TurningPointsEditorProps = {
+  /** ターニングポイント行の配列 */
+  value: TurningPointRow[];
+  /** 変更時に呼ばれるコールバック */
+  onChange: (rows: TurningPointRow[]) => void;
+};
+
+/**
+ * ターニングポイント動的リストエディタ
+ * 行の追加・削除・編集を提供する
+ */
+export function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
+  const handleAdd = () => {
+    onChange([...value, { id: nanoid(), at: '', note: '' }]);
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(value.filter((row) => row.id !== id));
+  };
+
+  const handleChange = (id: string, field: 'at' | 'note', text: string) => {
+    onChange(value.map((row) => (row.id === id ? { ...row, [field]: text } : row)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <span className="text-xs font-medium text-gray-700">ターニングポイント</span>
+      {value.map((row, index) => (
+        <div key={row.id} className="flex gap-1 items-start">
+          <input
+            type="text"
+            value={row.at}
+            onChange={(e) => handleChange(row.id, 'at', e.target.value)}
+            aria-label={`ターニングポイント${index + 1}の時期・時点`}
+            placeholder="時期・時点"
+            className="w-24 shrink-0 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <input
+            type="text"
+            value={row.note}
+            onChange={(e) => handleChange(row.id, 'note', e.target.value)}
+            aria-label={`ターニングポイント${index + 1}の出来事`}
+            placeholder="出来事"
+            className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={() => handleRemove(row.id)}
+            aria-label="このターニングポイントを削除"
+            className="shrink-0 text-gray-400 hover:text-red-500 text-xs px-1 py-1"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="text-xs text-blue-600 hover:text-blue-800 hover:underline"
+      >
+        + ターニングポイントを追加
+      </button>
+    </div>
+  );
+}

--- a/src/components/panel/TurningPointsEditor.tsx
+++ b/src/components/panel/TurningPointsEditor.tsx
@@ -6,6 +6,7 @@
 
 'use client';
 
+import { useCallback } from 'react';
 import { nanoid } from 'nanoid';
 
 /** ターニングポイントの行（ローカルステート用） */
@@ -30,17 +31,17 @@ export type TurningPointsEditorProps = {
  * 行の追加・削除・編集を提供する
  */
 export function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
-  const handleAdd = () => {
+  const handleAdd = useCallback(() => {
     onChange([...value, { id: nanoid(), at: '', note: '' }]);
-  };
+  }, [value, onChange]);
 
-  const handleRemove = (id: string) => {
+  const handleRemove = useCallback((id: string) => {
     onChange(value.filter((row) => row.id !== id));
-  };
+  }, [value, onChange]);
 
-  const handleChange = (id: string, field: 'at' | 'note', text: string) => {
+  const handleChange = useCallback((id: string, field: 'at' | 'note', text: string) => {
     onChange(value.map((row) => (row.id === id ? { ...row, [field]: text } : row)));
-  };
+  }, [value, onChange]);
 
   return (
     <div className="space-y-2">

--- a/src/components/panel/pairSelectionHelpers.ts
+++ b/src/components/panel/pairSelectionHelpers.ts
@@ -1,0 +1,64 @@
+/**
+ * PairSelectionPanel 用ヘルパー関数・定数
+ * 方向インジケーター表示、プレースホルダー生成、KinshipKind/AwarenessKind の日本語ラベルを提供する
+ */
+
+import type { RelationshipType, KinshipKind, AwarenessKind } from '@/types/relationship';
+
+/**
+ * 表示用の方向インジケーターを返す
+ * @param type - 関係タイプ
+ * @param isReversed - 関係が逆向きかどうか
+ * @returns 方向インジケーター文字列
+ */
+export function getDirectionIndicator(type: RelationshipType, isReversed: boolean): string {
+  if (type === 'bidirectional') {
+    return '↔';
+  }
+  if (type === 'one-way') {
+    return isReversed ? '←' : '→';
+  }
+  return '';
+}
+
+/**
+ * 関係タイプと種別に応じたプレースホルダーを返す
+ * @param type - 関係タイプ
+ * @param isReverse - 逆方向かどうか
+ * @param hasItem - 物が含まれているかどうか
+ */
+export function getPlaceholder(type: RelationshipType, isReverse = false, hasItem = false): string {
+  if (hasItem) {
+    if (type === 'one-way') return '例: 所有、使用';
+    if (type === 'bidirectional') return '例: 所有、使用';
+    if (type === 'dual-directed') return isReverse ? '例: 使用' : '例: 所有';
+    if (type === 'undirected') return '例: 所有、使用';
+  }
+  if (type === 'one-way') return '例: 片想い、憧れ';
+  if (type === 'bidirectional') return '例: 友人、親子、同僚';
+  if (type === 'dual-directed') return isReverse ? '例: 無関心、嫌い' : '例: 好き、憧れ';
+  if (type === 'undirected') return '例: 同一人物、別名';
+  return '例: 関係を入力';
+}
+
+/** KinshipKind の日本語ラベル選択肢 */
+export const KINSHIP_OPTIONS: { value: KinshipKind; label: string }[] = [
+  { value: null, label: '（血縁なし）' },
+  { value: 'parent', label: '親' },
+  { value: 'child', label: '子' },
+  { value: 'sibling', label: '兄弟・姉妹' },
+  { value: 'spouse', label: '配偶者' },
+  { value: 'partner', label: 'パートナー' },
+  { value: 'grandparent', label: '祖父母' },
+  { value: 'grandchild', label: '孫' },
+  { value: 'cousin', label: 'いとこ' },
+  { value: 'relative', label: '親族（その他）' },
+];
+
+/** AwarenessKind の日本語ラベル選択肢 */
+export const AWARENESS_OPTIONS: { value: AwarenessKind; label: string }[] = [
+  { value: null, label: '（未設定）' },
+  { value: 'known', label: '認知済み' },
+  { value: 'unknown', label: '未認知' },
+  { value: 'suspected', label: '疑惑あり' },
+];

--- a/src/components/panel/pairSelectionHelpers.ts
+++ b/src/components/panel/pairSelectionHelpers.ts
@@ -29,10 +29,9 @@ export function getDirectionIndicator(type: RelationshipType, isReversed: boolea
  */
 export function getPlaceholder(type: RelationshipType, isReverse = false, hasItem = false): string {
   if (hasItem) {
-    if (type === 'one-way') return '例: 所有、使用';
-    if (type === 'bidirectional') return '例: 所有、使用';
+    // dual-directed のみ方向別に異なるプレースホルダーを返す
     if (type === 'dual-directed') return isReverse ? '例: 使用' : '例: 所有';
-    if (type === 'undirected') return '例: 所有、使用';
+    return '例: 所有、使用';
   }
   if (type === 'one-way') return '例: 片想い、憧れ';
   if (type === 'bidirectional') return '例: 友人、親子、同僚';

--- a/src/components/ui/NullableSlider.test.tsx
+++ b/src/components/ui/NullableSlider.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * NullableSlider コンポーネントのユニットテスト
+ * null 値を持てる数値スライダーの描画・インタラクションを検証する
+ *
+ * Phase 2 対応: onChange(value: number | null) 単一コールバック仕様
+ * - チェックボックスON（未設定）→ onChange(null) が呼ばれる
+ * - チェックボックスOFF（値あり）→ onChange(defaultValue) が呼ばれる
+ * - スライダー変更 → onChange(数値) が呼ばれる
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NullableSlider } from './NullableSlider';
+
+describe('NullableSlider', () => {
+  describe('描画', () => {
+    it('ラベルが表示される', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByText('親密度')).toBeInTheDocument();
+    });
+
+    it('スライダーが描画される', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('slider', { name: '親密度' })).toBeInTheDocument();
+    });
+
+    it('未設定チェックボックスが描画される', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('checkbox', { name: '親密度を未設定' })).toBeInTheDocument();
+    });
+
+    it('value が null でないとき、数値が表示される', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.75}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByText('0.75')).toBeInTheDocument();
+    });
+
+    it('value が null のとき、スライダーが disabled になる', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={null}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('slider', { name: '親密度' })).toBeDisabled();
+    });
+
+    it('value が null のとき、未設定チェックボックスがチェック済みになる', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={null}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('checkbox', { name: '親密度を未設定' })).toBeChecked();
+    });
+
+    it('value が null でないとき、スライダーが enabled になる', () => {
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('slider', { name: '親密度' })).not.toBeDisabled();
+    });
+  });
+
+  describe('インタラクション', () => {
+    it('値ありの状態でチェックボックスをクリックすると onChange(null) が呼ばれる', async () => {
+      const onChange = vi.fn();
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={onChange}
+        />
+      );
+      await userEvent.click(screen.getByRole('checkbox', { name: '親密度を未設定' }));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it('未設定状態のチェックボックスをクリックすると onChange(defaultValue) が呼ばれる', async () => {
+      const onChange = vi.fn();
+      render(
+        <NullableSlider
+          label="親密度"
+          value={null}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={onChange}
+        />
+      );
+      await userEvent.click(screen.getByRole('checkbox', { name: '親密度を未設定' }));
+      expect(onChange).toHaveBeenCalledWith(0.5);
+    });
+  });
+});

--- a/src/components/ui/NullableSlider.test.tsx
+++ b/src/components/ui/NullableSlider.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NullableSlider } from './NullableSlider';
 
@@ -118,6 +118,8 @@ describe('NullableSlider', () => {
         />
       );
       expect(screen.getByRole('slider', { name: '親密度' })).not.toBeDisabled();
+      // value が null でないとき、未設定チェックボックスが未チェックになる
+      expect(screen.getByRole('checkbox', { name: '親密度を未設定' })).not.toBeChecked();
     });
   });
 
@@ -154,7 +156,27 @@ describe('NullableSlider', () => {
         />
       );
       await userEvent.click(screen.getByRole('checkbox', { name: '親密度を未設定' }));
+      expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(0.5);
+    });
+
+    it('スライダーの値を変更すると onChange(数値) が呼ばれる', () => {
+      const onChange = vi.fn();
+      render(
+        <NullableSlider
+          label="親密度"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.05}
+          defaultValue={0.5}
+          onChange={onChange}
+        />
+      );
+      const slider = screen.getByRole('slider', { name: '親密度' });
+      fireEvent.change(slider, { target: { value: '0.8' } });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0.8);
     });
   });
 });

--- a/src/components/ui/NullableSlider.tsx
+++ b/src/components/ui/NullableSlider.tsx
@@ -1,0 +1,92 @@
+/**
+ * NullableSlider コンポーネント
+ * null 値を持てる数値スライダー
+ * 「未設定」チェックボックスで null ⇔ 数値を切り替える
+ */
+
+'use client';
+
+import { useId } from 'react';
+
+/**
+ * NullableSlider のプロパティ
+ */
+export type NullableSliderProps = {
+  /** スライダーのラベル（aria-label としても使用） */
+  label: string;
+  /** 現在の数値（未設定の場合は null） */
+  value: number | null;
+  /** スライダーの最小値 */
+  min: number;
+  /** スライダーの最大値 */
+  max: number;
+  /** スライダーのステップ */
+  step: number;
+  /** null のときのスライダーデフォルト値 */
+  defaultValue: number;
+  /**
+   * 値変更時に呼ばれる単一コールバック
+   * - スライダー操作時: 数値を渡す
+   * - 未設定チェックをONにしたとき: null を渡す
+   * - 未設定チェックをOFFにしたとき: defaultValue を渡す
+   */
+  onChange: (value: number | null) => void;
+};
+
+/**
+ * null 値を持てる数値スライダーコンポーネント
+ * 「未設定」チェックボックスで null ⇔ 数値を切り替える
+ */
+export function NullableSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  defaultValue,
+  onChange,
+}: NullableSliderProps) {
+  const isNull = value === null;
+  // useId() でインスタンス固有の ID を生成し、ラベル文字列による重複 ID を防ぐ
+  const baseId = useId();
+  const sliderId = `${baseId}-slider`;
+  const checkboxId = `${baseId}-nullable`;
+  // 未設定時にスライダーが表示する内部値（デフォルト値か現在値）
+  const displayValue = value ?? defaultValue;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs font-medium text-gray-700">
+        <label htmlFor={sliderId}>{label}</label>
+        <div className="flex items-center gap-1.5">
+          {!isNull && (
+            <span className="text-[10px] text-gray-500">{displayValue.toFixed(2)}</span>
+          )}
+          <label htmlFor={checkboxId} className="flex items-center gap-0.5 text-[10px] text-gray-500 cursor-pointer">
+            <input
+              id={checkboxId}
+              type="checkbox"
+              checked={isNull}
+              onChange={(e) => onChange(e.target.checked ? null : defaultValue)}
+              aria-label={`${label}を未設定`}
+              className="w-3 h-3"
+            />
+            未設定
+          </label>
+        </div>
+      </div>
+      <input
+        id={sliderId}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={displayValue}
+        disabled={isNull}
+        onChange={(e) => onChange(Number(e.target.value))}
+        aria-label={label}
+        className="w-full disabled:opacity-40"
+      />
+    </div>
+  );
+}

--- a/src/components/ui/NullableSlider.tsx
+++ b/src/components/ui/NullableSlider.tsx
@@ -84,7 +84,6 @@ export function NullableSlider({
         value={displayValue}
         disabled={isNull}
         onChange={(e) => onChange(Number(e.target.value))}
-        aria-label={label}
         className="w-full disabled:opacity-40"
       />
     </div>

--- a/src/components/ui/TagChipInput.test.tsx
+++ b/src/components/ui/TagChipInput.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * TagChipInput コンポーネントのユニットテスト
+ * タグのchip表示・追加・削除・IME対応を検証する
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TagChipInput } from './TagChipInput';
+
+const SUGGESTIONS = ['友人', '家族', '同僚', '恋人'] as const;
+
+describe('TagChipInput', () => {
+  describe('描画', () => {
+    it('既存タグがchipとして表示される', () => {
+      render(
+        <TagChipInput
+          value={['友人', '同僚']}
+          onChange={vi.fn()}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      expect(screen.getByText('友人')).toBeInTheDocument();
+      expect(screen.getByText('同僚')).toBeInTheDocument();
+    });
+
+    it('タグが空のときchipが表示されない', () => {
+      render(
+        <TagChipInput
+          value={[]}
+          onChange={vi.fn()}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      // chipエリア（flex-wrap）がレンダリングされないことを確認
+      expect(screen.queryByRole('button', { name: /を削除/ })).not.toBeInTheDocument();
+    });
+
+    it('各chipに削除ボタンが表示される', () => {
+      render(
+        <TagChipInput
+          value={['友人']}
+          onChange={vi.fn()}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      expect(screen.getByRole('button', { name: '友人を削除' })).toBeInTheDocument();
+    });
+
+    it('タグ入力フィールドが表示される', () => {
+      render(
+        <TagChipInput
+          value={[]}
+          onChange={vi.fn()}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      // list属性付き input は ARIA role が combobox になる
+      expect(screen.getByLabelText('タグを追加')).toBeInTheDocument();
+    });
+  });
+
+  describe('タグ追加', () => {
+    it('Enterキーでタグが追加される', async () => {
+      const onChange = vi.fn();
+      render(
+        <TagChipInput
+          value={[]}
+          onChange={onChange}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      const input = screen.getByLabelText('タグを追加');
+      await userEvent.type(input, '友人{Enter}');
+      expect(onChange).toHaveBeenCalledWith(['友人']);
+    });
+
+    it('前後のスペースはトリムされる', async () => {
+      const onChange = vi.fn();
+      render(
+        <TagChipInput
+          value={[]}
+          onChange={onChange}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      const input = screen.getByLabelText('タグを追加');
+      await userEvent.type(input, '  友人  {Enter}');
+      expect(onChange).toHaveBeenCalledWith(['友人']);
+    });
+
+    it('空白のみのタグは追加されない', async () => {
+      const onChange = vi.fn();
+      render(
+        <TagChipInput
+          value={[]}
+          onChange={onChange}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      const input = screen.getByLabelText('タグを追加');
+      await userEvent.type(input, '   {Enter}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('重複するタグは追加されない', async () => {
+      const onChange = vi.fn();
+      render(
+        <TagChipInput
+          value={['友人']}
+          onChange={onChange}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      const input = screen.getByLabelText('タグを追加');
+      await userEvent.type(input, '友人{Enter}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('タグ削除', () => {
+    it('削除ボタンをクリックするとタグが削除される', async () => {
+      const onChange = vi.fn();
+      render(
+        <TagChipInput
+          value={['友人', '同僚']}
+          onChange={onChange}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      await userEvent.click(screen.getByRole('button', { name: '友人を削除' }));
+      expect(onChange).toHaveBeenCalledWith(['同僚']);
+    });
+  });
+
+  describe('IME対応', () => {
+    it('IME変換中のEnterキーはタグ追加をしない', async () => {
+      const onChange = vi.fn();
+      render(
+        <TagChipInput
+          value={[]}
+          onChange={onChange}
+          suggestions={SUGGESTIONS}
+        />
+      );
+      const input = screen.getByLabelText('タグを追加');
+      // isComposing=true のキーダウンイベントをシミュレート
+      const keyDownEvent = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(keyDownEvent, 'isComposing', { value: true });
+      input.dispatchEvent(keyDownEvent);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/ui/TagChipInput.test.tsx
+++ b/src/components/ui/TagChipInput.test.tsx
@@ -134,7 +134,7 @@ describe('TagChipInput', () => {
   });
 
   describe('IME対応', () => {
-    it('IME変換中のEnterキーはタグ追加をしない', async () => {
+    it('IME変換中のEnterキーはタグ追加をしない', () => {
       const onChange = vi.fn();
       render(
         <TagChipInput
@@ -144,6 +144,8 @@ describe('TagChipInput', () => {
         />
       );
       const input = screen.getByLabelText('タグを追加');
+      // 入力中の文字をセット（IME変換中を想定）
+      Object.defineProperty(input, 'value', { value: 'ともだち', writable: true });
       // isComposing=true のキーダウンイベントをシミュレート
       const keyDownEvent = new KeyboardEvent('keydown', {
         key: 'Enter',
@@ -152,6 +154,7 @@ describe('TagChipInput', () => {
       });
       Object.defineProperty(keyDownEvent, 'isComposing', { value: true });
       input.dispatchEvent(keyDownEvent);
+      // IME変換中はタグが追加されない
       expect(onChange).not.toHaveBeenCalled();
     });
   });

--- a/src/components/ui/TagChipInput.test.tsx
+++ b/src/components/ui/TagChipInput.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TagChipInput } from './TagChipInput';
 
@@ -134,7 +134,7 @@ describe('TagChipInput', () => {
   });
 
   describe('IME対応', () => {
-    it('IME変換中のEnterキーはタグ追加をしない', () => {
+    it('IME変換中のEnterキーはタグ追加をしない', async () => {
       const onChange = vi.fn();
       render(
         <TagChipInput
@@ -144,16 +144,11 @@ describe('TagChipInput', () => {
         />
       );
       const input = screen.getByLabelText('タグを追加');
-      // 入力中の文字をセット（IME変換中を想定）
-      Object.defineProperty(input, 'value', { value: 'ともだち', writable: true });
-      // isComposing=true のキーダウンイベントをシミュレート
-      const keyDownEvent = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        bubbles: true,
-        cancelable: true,
-      });
-      Object.defineProperty(keyDownEvent, 'isComposing', { value: true });
-      input.dispatchEvent(keyDownEvent);
+      // userEvent.type で React の state（inputValue）を実際に更新する
+      await userEvent.type(input, 'ともだち');
+      // isComposing=true のEnterキーダウンイベントをシミュレート（IME変換確定前）
+      // fireEvent.keyDown の isComposing オプションが nativeEvent.isComposing に反映される
+      fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
       // IME変換中はタグが追加されない
       expect(onChange).not.toHaveBeenCalled();
     });

--- a/src/components/ui/TagChipInput.tsx
+++ b/src/components/ui/TagChipInput.tsx
@@ -1,0 +1,96 @@
+/**
+ * TagChipInput コンポーネント
+ * タグをchip形式で表示・追加・削除する入力コンポーネント
+ * SUGGESTED_TAGS 等を datalist として提供し、候補補完をサポートする
+ */
+
+'use client';
+
+import { useState, useId } from 'react';
+
+/**
+ * TagChipInput のプロパティ
+ */
+export type TagChipInputProps = {
+  /** 現在のタグ一覧 */
+  value: string[];
+  /** タグ変更時に呼ばれるコールバック */
+  onChange: (tags: string[]) => void;
+  /** datalist に表示する候補タグ */
+  suggestions: readonly string[];
+  /** datalist 要素の ID（省略時は useId() で生成） */
+  datalistId?: string;
+};
+
+/**
+ * タグ chip 入力コンポーネント
+ * suggestions を datalist として提供し、chip形式でタグを表示・削除する
+ */
+export function TagChipInput({ value, onChange, suggestions, datalistId: datalistIdProp }: TagChipInputProps) {
+  const [inputValue, setInputValue] = useState('');
+  // 呼び出し元から ID が渡されていれば使い、なければ useId() で一意な ID を生成する
+  const generatedId = useId();
+  const datalistId = datalistIdProp ?? `${generatedId}-tag-suggestions`;
+
+  const addTag = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag || value.includes(tag)) return;
+    onChange([...value, tag]);
+    setInputValue('');
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      // IME変換中のEnterは無視（日本語入力の変換確定時の誤動作を防ぐ）
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      addTag(inputValue);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* 既存タグのチップ表示 */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {value.map((tag) => (
+            <span
+              key={tag}
+              className="flex items-center gap-0.5 px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded-full"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                aria-label={`${tag}を削除`}
+                className="hover:text-blue-600 ml-0.5"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      {/* タグ入力フィールド */}
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        list={datalistId}
+        aria-label="タグを追加"
+        placeholder="タグを追加（Enter で確定）"
+        className="w-full px-3 py-1.5 text-xs border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+      />
+      <datalist id={datalistId}>
+        {suggestions.map((s) => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
+    </div>
+  );
+}

--- a/src/components/ui/TagChipInput.tsx
+++ b/src/components/ui/TagChipInput.tsx
@@ -34,7 +34,8 @@ export function TagChipInput({ value, onChange, suggestions, datalistId: datalis
 
   const addTag = (raw: string) => {
     const tag = raw.trim();
-    if (!tag || value.includes(tag)) return;
+    // 大文字・小文字を区別せず重複チェックし、元のケースを保持して追加する
+    if (!tag || value.some((t) => t.toLowerCase() === tag.toLowerCase())) return;
     onChange([...value, tag]);
     setInputValue('');
   };


### PR DESCRIPTION
## Summary

- `NullableSlider`、`TagChipInput`、`TurningPointsEditor`、`PersonMiniIcon` を別ファイルに抽出し、ユニットテストを追加
- ヘルパー関数・定数（`getDirectionIndicator`、`getPlaceholder`、`KINSHIP_OPTIONS`、`AWARENESS_OPTIONS`）を `pairSelectionHelpers.ts` に集約
- スライダー用の個別 `isNull` フラグ（6個）を廃止し `number | null` 単一 state に統合
- `NullableSlider` のコールバックを `onValueChange` + `onNullToggle` → `onChange: (number | null) => void` に一本化
- `PairSelectionPanel.tsx`: 1213行 → 890行（-323行）

## Test plan

- [x] `NullableSlider.test.tsx` — 10 tests（描画・インタラクション・スライダー変更）
- [x] `TagChipInput.test.tsx` — 10 tests（描画・追加・削除・IME対応）
- [x] `TurningPointsEditor.test.tsx` — 9 tests（描画・追加・削除・編集）
- [x] 既存 `PairSelectionPanel.test.tsx` — 63 tests、全てパス
- [x] 全テスト: 846 pass / 17 skipped
- [x] lint・type-check エラーなし

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)