### PR TITLE
feat: タイムラインスナップショット機能（Phase 1）

### DIFF
--- a/src/components/graph/RelationshipGraph.tsx
+++ b/src/components/graph/RelationshipGraph.tsx
@@ -11,6 +11,7 @@ import {
   Background,
   Controls,
   MiniMap,
+  Panel,
   useReactFlow,
   ConnectionMode,
   ConnectionLineType,
@@ -35,6 +36,8 @@ import { useContextMenu } from './useContextMenu';
 import { ContextMenu } from './ContextMenu';
 import { EdgeFilterPanel } from './EdgeFilterPanel';
 import { ChatInputBar } from './ChatInputBar';
+import { SnapshotCaptureButton } from './SnapshotCaptureButton';
+import { TimelineBar } from './TimelineBar';
 import { InterviewModal } from '@/components/interview/InterviewModal';
 import { useGraphStore } from '@/stores/useGraphStore';
 /** 固定 6 色の SVG マーカー定義（deriveEdgeVisual の markerKey と対応） */
@@ -238,6 +241,10 @@ export function RelationshipGraph() {
         <ShareButton />
         <SearchBar />
         <EdgeFilterPanel />
+        {/* スナップショット保存ボタン（右下のFAB） */}
+        <Panel position="bottom-right">
+          <SnapshotCaptureButton />
+        </Panel>
 
         {/* SVGマーカー定義（全エッジで共有）: 固定6色 + selected */}
         <svg>
@@ -306,6 +313,9 @@ export function RelationshipGraph() {
           </button>
         </div>
       )}
+
+      {/* タイムラインバー（タイムラインモード中に下部に表示） */}
+      <TimelineBar />
 
       {/* フローティングチャット入力バー */}
       <ChatInputBar />

--- a/src/components/graph/SnapshotCaptureButton.tsx
+++ b/src/components/graph/SnapshotCaptureButton.tsx
@@ -1,0 +1,57 @@
+/**
+ * スナップショット保存ボタンコンポーネント
+ *
+ * グラフキャンバス上に配置されるFABボタン（カメラアイコン）。
+ * クリック時にSnapshotCaptureDialogを表示し、ラベルを入力してスナップショットを保存する。
+ *
+ * タイムラインモード中はボタンを非表示にする。
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { Camera } from 'lucide-react';
+import { useGraphStore } from '@/stores/useGraphStore';
+import { SnapshotCaptureDialog } from '@/components/ui/SnapshotCaptureDialog';
+
+/**
+ * スナップショット保存ボタンコンポーネント
+ */
+export function SnapshotCaptureButton() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { captureSnapshot, timelineMode } = useGraphStore((state) => ({
+    captureSnapshot: state.captureSnapshot,
+    timelineMode: state.timelineMode,
+  }));
+
+  // タイムラインモード中はボタンを非表示
+  if (timelineMode) return null;
+
+  /**
+   * スナップショット保存ハンドラ
+   */
+  const handleCapture = (label: string, description?: string) => {
+    captureSnapshot(label, description);
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsDialogOpen(true)}
+        className="flex items-center gap-1.5 rounded-md bg-white px-3 py-2 text-sm font-medium shadow-md hover:bg-gray-50 border border-gray-200 transition-colors"
+        title="スナップショットを保存"
+        aria-label="スナップショットを保存"
+      >
+        <Camera size={16} />
+        <span>保存</span>
+      </button>
+
+      <SnapshotCaptureDialog
+        isOpen={isDialogOpen}
+        onCapture={handleCapture}
+        onCancel={() => setIsDialogOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/components/graph/TimelineBar.test.tsx
+++ b/src/components/graph/TimelineBar.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * TimelineBarコンポーネントのテスト
+ * タイムライン再生バーのUIを検証する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TimelineBar } from './TimelineBar';
+import { useGraphStore } from '@/stores/useGraphStore';
+import type { Snapshot } from '@/types/snapshot';
+
+// Zustandストアをモック
+vi.mock('@/stores/useGraphStore');
+const mockUseGraphStore = vi.mocked(useGraphStore);
+
+/** テスト用スナップショットを生成するヘルパー */
+function makeSnapshot(label: string, id: string = label): Snapshot {
+  return {
+    id,
+    label,
+    persons: [],
+    relationships: [],
+    createdAt: '2024-06-01T00:00:00.000Z',
+  };
+}
+
+/** ストアの基本モック値を生成するヘルパー */
+function makeStoreMock(overrides: Partial<{
+  snapshots: Snapshot[];
+  timelineMode: boolean;
+  activeSnapshotIndex: number | null;
+  setTimelineMode: ReturnType<typeof vi.fn>;
+  goToSnapshot: ReturnType<typeof vi.fn>;
+  goToLive: ReturnType<typeof vi.fn>;
+}> = {}) {
+  return {
+    snapshots: overrides.snapshots ?? [],
+    timelineMode: overrides.timelineMode ?? false,
+    activeSnapshotIndex: overrides.activeSnapshotIndex ?? null,
+    setTimelineMode: overrides.setTimelineMode ?? vi.fn(),
+    goToSnapshot: overrides.goToSnapshot ?? vi.fn(),
+    goToLive: overrides.goToLive ?? vi.fn(),
+  };
+}
+
+describe('TimelineBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイムラインモード=false のとき何も表示しない', () => {
+    mockUseGraphStore.mockReturnValue(makeStoreMock({ timelineMode: false }));
+
+    const { container } = render(<TimelineBar />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('タイムラインモード=true のときバーが表示される', () => {
+    const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0 })
+    );
+
+    render(<TimelineBar />);
+
+    // スライダーが表示されること
+    expect(screen.getByRole('slider')).toBeInTheDocument();
+    // 終了ボタンが表示されること
+    expect(screen.getByRole('button', { name: /終了/i })).toBeInTheDocument();
+  });
+
+  it('現在のスナップショットラベルが表示される', () => {
+    const snapshots = [makeSnapshot('序章'), makeSnapshot('第1話')];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0 })
+    );
+
+    render(<TimelineBar />);
+
+    expect(screen.getByText('序章')).toBeInTheDocument();
+  });
+
+  it('activeSnapshotIndex=null のとき現在ラベルが「ライブ」と表示される', () => {
+    const snapshots = [makeSnapshot('第1話')];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: null })
+    );
+
+    render(<TimelineBar />);
+
+    // 現在ラベルエリア（スライダーのaria-valuetextでも確認）
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuetext', 'ライブ');
+  });
+
+  it('スライダーを動かすと goToSnapshot が呼ばれる', () => {
+    const mockGoToSnapshot = vi.fn();
+    const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話'), makeSnapshot('第3話')];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({
+        snapshots,
+        timelineMode: true,
+        activeSnapshotIndex: 0,
+        goToSnapshot: mockGoToSnapshot,
+      })
+    );
+
+    render(<TimelineBar />);
+
+    const slider = screen.getByRole('slider');
+    // スライダーの値を変更（fireEventはonChangeを直接トリガー）
+    fireEvent.change(slider, { target: { value: '2' } });
+
+    // 値2はスナップショットインデックス1（2-1=1）
+    expect(mockGoToSnapshot).toHaveBeenCalledWith(1);
+  });
+
+  it('「終了」ボタンをクリックすると setTimelineMode(false) が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const mockSetTimelineMode = vi.fn();
+    const snapshots = [makeSnapshot('第1話')];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({
+        snapshots,
+        timelineMode: true,
+        activeSnapshotIndex: 0,
+        setTimelineMode: mockSetTimelineMode,
+      })
+    );
+
+    render(<TimelineBar />);
+
+    await user.click(screen.getByRole('button', { name: /終了/i }));
+
+    expect(mockSetTimelineMode).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/graph/TimelineBar.tsx
+++ b/src/components/graph/TimelineBar.tsx
@@ -1,0 +1,115 @@
+/**
+ * タイムラインバーコンポーネント
+ *
+ * タイムラインモード中にグラフキャンバス下部に表示されるコントロールバー。
+ * スライダーでスナップショット間を移動できる。
+ *
+ * 表示条件: timelineMode === true のとき（スナップショット0件でも表示）
+ *
+ * 機能:
+ * - スライダーによるスナップショット移動
+ * - 現在のスナップショットラベル表示（null = ライブ状態）
+ * - 終了ボタンでタイムラインモードを解除
+ */
+
+'use client';
+
+import { X } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { useGraphStore } from '@/stores/useGraphStore';
+
+/**
+ * タイムラインバーコンポーネント
+ */
+export function TimelineBar() {
+  const {
+    snapshots,
+    timelineMode,
+    activeSnapshotIndex,
+    setTimelineMode,
+    goToSnapshot,
+    goToLive,
+  } = useGraphStore(
+    useShallow((state) => ({
+      snapshots: state.snapshots,
+      timelineMode: state.timelineMode,
+      activeSnapshotIndex: state.activeSnapshotIndex,
+      setTimelineMode: state.setTimelineMode,
+      goToSnapshot: state.goToSnapshot,
+      goToLive: state.goToLive,
+    }))
+  );
+
+  // タイムラインモード以外は非表示
+  if (!timelineMode) return null;
+
+  /**
+   * スライダー値の変更ハンドラ
+   * 0はライブ状態、1〜n はスナップショットのインデックス（0始まり）を指す
+   */
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    if (value === 0) {
+      goToLive();
+    } else {
+      goToSnapshot(value - 1);
+    }
+  };
+
+  // スライダーの現在値（0=ライブ、1〜n=スナップショット）
+  const sliderValue = activeSnapshotIndex !== null ? activeSnapshotIndex + 1 : 0;
+  // スライダーの最大値（スナップショット数）
+  const sliderMax = snapshots.length;
+
+  // 現在表示中のラベル
+  const currentLabel =
+    activeSnapshotIndex !== null
+      ? (snapshots[activeSnapshotIndex]?.label ?? '不明')
+      : 'ライブ';
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 z-10 bg-white/95 backdrop-blur-sm border-t border-gray-200 px-4 py-3 flex items-center gap-4">
+      {/* 現在のラベル */}
+      <span className="text-sm font-medium text-gray-700 min-w-[6rem] truncate">
+        {currentLabel}
+      </span>
+
+      {/* スライダー */}
+      <div className="flex-1 flex items-center gap-2">
+        {/* ライブ */}
+        <span className="text-xs text-gray-400 whitespace-nowrap">ライブ</span>
+        <input
+          type="range"
+          min={0}
+          max={sliderMax}
+          value={sliderValue}
+          onChange={handleSliderChange}
+          disabled={snapshots.length === 0}
+          className="flex-1 h-2 accent-blue-600 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="タイムラインスライダー"
+          aria-valuemin={0}
+          aria-valuemax={sliderMax}
+          aria-valuenow={sliderValue}
+          aria-valuetext={currentLabel}
+        />
+        {/* 最終スナップショット */}
+        {snapshots.length > 0 && (
+          <span className="text-xs text-gray-400 whitespace-nowrap max-w-[6rem] truncate">
+            {snapshots[snapshots.length - 1]?.label}
+          </span>
+        )}
+      </div>
+
+      {/* 終了ボタン */}
+      <button
+        onClick={() => setTimelineMode(false)}
+        className="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-800 px-2 py-1 rounded hover:bg-gray-100 transition-colors"
+        aria-label="タイムラインモードを終了"
+        title="終了"
+      >
+        <X size={16} />
+        終了
+      </button>
+    </div>
+  );
+}

--- a/src/components/graph/useGraphInteractions.ts
+++ b/src/components/graph/useGraphInteractions.ts
@@ -61,6 +61,7 @@ export function useGraphInteractions({
   // Zustandストアから状態とアクションを取得
   const persons = useGraphStore((state) => state.persons);
   const relationships = useGraphStore((state) => state.relationships);
+  const timelineMode = useGraphStore((state) => state.timelineMode);
   const addPerson = useGraphStore((state) => state.addPerson);
   const addRelationship = useGraphStore((state) => state.addRelationship);
   const updateRelationship = useGraphStore((state) => state.updateRelationship);
@@ -69,6 +70,10 @@ export function useGraphInteractions({
   const setSelectedPersonIds = useGraphStore((state) => state.setSelectedPersonIds);
   const clearSelection = useGraphStore((state) => state.clearSelection);
   const selectPersonPairForEdit = useGraphStore((state) => state.selectPersonPairForEdit);
+
+  // タイムラインモードの状態をrefで保持（useEffect内で最新値を参照するため）
+  const timelineModeRef = useRef(timelineMode);
+  timelineModeRef.current = timelineMode;
 
   // ダイアログストアから確認ダイアログとアラートダイアログを取得
   const openConfirm = useDialogStore((state) => state.openConfirm);
@@ -94,6 +99,9 @@ export function useGraphInteractions({
   // 2つのノード間の接続を処理するヘルパー関数
   const tryStartConnection = useCallback(
     (sourceId: string, targetId: string) => {
+      // タイムラインモード中は関係の追加・編集を禁止
+      if (timelineMode) return;
+
       // 自己接続を防止
       if (sourceId === targetId) return;
 
@@ -116,13 +124,16 @@ export function useGraphInteractions({
         ...(existingRelationship ? { existingRelationshipId: existingRelationship.id } : {}),
       });
     },
-    [persons, relationships]
+    [persons, relationships, timelineMode]
   );
 
   // キャンバスへの画像ドロップハンドラ
   const handleDrop = useCallback(
     async (event: React.DragEvent<HTMLDivElement>) => {
       event.preventDefault();
+
+      // タイムラインモード中は編集操作を禁止
+      if (timelineMode) return;
 
       // ドロップされたファイルを取得
       const files = Array.from(event.dataTransfer.files);
@@ -152,7 +163,7 @@ export function useGraphInteractions({
         });
       }
     },
-    [screenToFlowPosition, openAlert]
+    [screenToFlowPosition, openAlert, timelineMode]
   );
 
   // ドラッグオーバーハンドラ（ドロップを許可するために必要）
@@ -163,6 +174,9 @@ export function useGraphInteractions({
   // クリップボードからのペーストハンドラ
   useEffect(() => {
     const handlePaste = async (event: ClipboardEvent) => {
+      // タイムラインモード中は編集操作を禁止
+      if (timelineModeRef.current) return;
+
       const items = event.clipboardData?.items;
       if (!items) return;
 
@@ -406,6 +420,9 @@ export function useGraphInteractions({
   // Delete/Backspaceキーでの削除前確認ハンドラ
   const handleBeforeDelete = useCallback(
     async ({ nodes: nodesToDelete, edges: edgesToDelete }: { nodes: Node[]; edges: Edge[] }) => {
+      // タイムラインモード中は削除操作を禁止
+      if (timelineMode) return false;
+
       // 削除対象がない場合は削除を拒否
       if (nodesToDelete.length === 0 && edgesToDelete.length === 0) {
         return false;
@@ -440,7 +457,7 @@ export function useGraphInteractions({
 
       return confirmed;
     },
-    [openConfirm]
+    [openConfirm, timelineMode]
   );
 
   // ノード削除ハンドラ（確認はonBeforeDeleteで実行済み）

--- a/src/components/panel/DefaultPanel.tsx
+++ b/src/components/panel/DefaultPanel.tsx
@@ -7,6 +7,7 @@
 
 import { PersonList } from './PersonList';
 import { ActiveChartHeader } from './ActiveChartHeader';
+import { SnapshotList } from './SnapshotList';
 
 /**
  * デフォルトパネルコンポーネント
@@ -17,6 +18,11 @@ export function DefaultPanel() {
       {/* チャート管理セクション */}
       <div>
         <ActiveChartHeader />
+      </div>
+
+      {/* タイムラインセクション */}
+      <div>
+        <SnapshotList />
       </div>
 
       {/* 人物管理セクション */}

--- a/src/components/panel/SnapshotList.test.tsx
+++ b/src/components/panel/SnapshotList.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * SnapshotListコンポーネントのテスト
+ * スナップショット一覧・削除・タイムラインモード開始のUIを検証する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SnapshotList } from './SnapshotList';
+import { useGraphStore } from '@/stores/useGraphStore';
+import type { Snapshot } from '@/types/snapshot';
+
+// Zustandストアをモック
+vi.mock('@/stores/useGraphStore');
+const mockUseGraphStore = vi.mocked(useGraphStore);
+
+/** テスト用スナップショットを生成するヘルパー */
+function makeSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    id: overrides.id ?? 'snap-001',
+    label: overrides.label ?? '第1話',
+    description: overrides.description,
+    persons: overrides.persons ?? [],
+    relationships: overrides.relationships ?? [],
+    createdAt: overrides.createdAt ?? '2024-06-01T00:00:00.000Z',
+  };
+}
+
+/** ストアの基本モック値を生成するヘルパー */
+function makeStoreMock(overrides: Partial<{
+  snapshots: Snapshot[];
+  timelineMode: boolean;
+  activeSnapshotIndex: number | null;
+  setTimelineMode: ReturnType<typeof vi.fn>;
+  goToSnapshot: ReturnType<typeof vi.fn>;
+  goToLive: ReturnType<typeof vi.fn>;
+  deleteSnapshot: ReturnType<typeof vi.fn>;
+}> = {}) {
+  return {
+    snapshots: overrides.snapshots ?? [],
+    timelineMode: overrides.timelineMode ?? false,
+    activeSnapshotIndex: overrides.activeSnapshotIndex ?? null,
+    setTimelineMode: overrides.setTimelineMode ?? vi.fn(),
+    goToSnapshot: overrides.goToSnapshot ?? vi.fn(),
+    goToLive: overrides.goToLive ?? vi.fn(),
+    deleteSnapshot: overrides.deleteSnapshot ?? vi.fn(),
+  };
+}
+
+describe('SnapshotList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('スナップショットが0件の場合は空状態のメッセージを表示する', () => {
+    mockUseGraphStore.mockReturnValue(makeStoreMock({ snapshots: [] }));
+
+    render(<SnapshotList />);
+
+    expect(screen.getByText(/スナップショットはまだありません/i)).toBeInTheDocument();
+  });
+
+  it('スナップショットが1件以上の場合はリストを表示する', () => {
+    const snapshots = [
+      makeSnapshot({ id: 'snap-001', label: '第1話' }),
+      makeSnapshot({ id: 'snap-002', label: '第2話' }),
+    ];
+    mockUseGraphStore.mockReturnValue(makeStoreMock({ snapshots }));
+
+    render(<SnapshotList />);
+
+    expect(screen.getByText('第1話')).toBeInTheDocument();
+    expect(screen.getByText('第2話')).toBeInTheDocument();
+  });
+
+  it('スナップショット件数が1件以上の場合は「再生を開始」ボタンが表示される', () => {
+    const snapshots = [makeSnapshot()];
+    mockUseGraphStore.mockReturnValue(makeStoreMock({ snapshots }));
+
+    render(<SnapshotList />);
+
+    expect(screen.getByRole('button', { name: /再生を開始/i })).toBeInTheDocument();
+  });
+
+  it('「再生を開始」ボタンをクリックすると setTimelineMode(true) が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const mockSetTimelineMode = vi.fn();
+    const snapshots = [makeSnapshot(), makeSnapshot({ id: 'snap-002', label: '第2話' })];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, setTimelineMode: mockSetTimelineMode })
+    );
+
+    render(<SnapshotList />);
+
+    await user.click(screen.getByRole('button', { name: /再生を開始/i }));
+
+    expect(mockSetTimelineMode).toHaveBeenCalledWith(true);
+  });
+
+  it('タイムラインモード中は「再生を終了」ボタンが表示される', () => {
+    const snapshots = [makeSnapshot()];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0 })
+    );
+
+    render(<SnapshotList />);
+
+    expect(screen.getByRole('button', { name: /再生を終了/i })).toBeInTheDocument();
+  });
+
+  it('スナップショット削除ボタンをクリックすると deleteSnapshot が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const mockDeleteSnapshot = vi.fn();
+    const snapshots = [makeSnapshot({ id: 'snap-001', label: '第1話' })];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, deleteSnapshot: mockDeleteSnapshot })
+    );
+
+    render(<SnapshotList />);
+
+    await user.click(screen.getByRole('button', { name: /第1話を削除/i }));
+
+    expect(mockDeleteSnapshot).toHaveBeenCalledWith('snap-001');
+  });
+});

--- a/src/components/panel/SnapshotList.tsx
+++ b/src/components/panel/SnapshotList.tsx
@@ -1,0 +1,150 @@
+/**
+ * スナップショット一覧コンポーネント
+ *
+ * サイドパネル（DefaultPanel）内に配置され、以下の機能を提供する:
+ * - スナップショット一覧の表示（ラベル・作成日時）
+ * - タイムライン再生モードの開始/終了
+ * - 各スナップショットへのジャンプ
+ * - スナップショットの削除
+ *
+ * スナップショットが0件の場合は空状態メッセージを表示する。
+ */
+
+'use client';
+
+import { Trash2, Play, StopCircle } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { useGraphStore } from '@/stores/useGraphStore';
+
+/**
+ * スナップショット一覧コンポーネント
+ */
+export function SnapshotList() {
+  const {
+    snapshots,
+    timelineMode,
+    activeSnapshotIndex,
+    setTimelineMode,
+    goToSnapshot,
+    goToLive,
+    deleteSnapshot,
+  } = useGraphStore(
+    useShallow((state) => ({
+      snapshots: state.snapshots,
+      timelineMode: state.timelineMode,
+      activeSnapshotIndex: state.activeSnapshotIndex,
+      setTimelineMode: state.setTimelineMode,
+      goToSnapshot: state.goToSnapshot,
+      goToLive: state.goToLive,
+      deleteSnapshot: state.deleteSnapshot,
+    }))
+  );
+
+  return (
+    <div>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-gray-700">
+          タイムライン
+          {snapshots.length > 0 && (
+            <span className="ml-1.5 text-xs font-normal text-gray-400">
+              ({snapshots.length}件)
+            </span>
+          )}
+        </h2>
+
+        {/* 再生開始/終了ボタン（スナップショットが1件以上の場合） */}
+        {snapshots.length > 0 && (
+          timelineMode ? (
+            <button
+              onClick={() => setTimelineMode(false)}
+              className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-800 transition-colors"
+              aria-label="再生を終了"
+            >
+              <StopCircle size={14} />
+              再生を終了
+            </button>
+          ) : (
+            <button
+              onClick={() => setTimelineMode(true)}
+              className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 transition-colors"
+              aria-label="再生を開始"
+            >
+              <Play size={14} />
+              再生を開始
+            </button>
+          )
+        )}
+      </div>
+
+      {/* スナップショットが0件の場合 */}
+      {snapshots.length === 0 && (
+        <p className="text-xs text-gray-400 text-center py-4">
+          スナップショットはまだありません
+        </p>
+      )}
+
+      {/* スナップショット一覧 */}
+      {snapshots.length > 0 && (
+        <ul className="space-y-1">
+          {snapshots.map((snapshot, index) => {
+            const isActive = timelineMode && activeSnapshotIndex === index;
+            return (
+              <li
+                key={snapshot.id}
+                className={`flex items-center gap-2 rounded-md px-2 py-1.5 group ${
+                  isActive
+                    ? 'bg-blue-50 border border-blue-200'
+                    : 'hover:bg-gray-50'
+                }`}
+              >
+                {/* スナップショット番号 */}
+                <span className="text-xs text-gray-400 min-w-[1.5rem] text-right">
+                  {index + 1}.
+                </span>
+
+                {/* ラベル（クリックでジャンプ） */}
+                <button
+                  onClick={() => {
+                    if (!timelineMode) {
+                      setTimelineMode(true);
+                    }
+                    goToSnapshot(index);
+                  }}
+                  className={`flex-1 text-left text-sm truncate ${
+                    isActive ? 'text-blue-700 font-medium' : 'text-gray-700 hover:text-gray-900'
+                  }`}
+                  title={snapshot.description ?? snapshot.label}
+                >
+                  {snapshot.label}
+                </button>
+
+                {/* ライブに戻るボタン（タイムラインモード中のアクティブ項目） */}
+                {isActive && (
+                  <button
+                    onClick={goToLive}
+                    className="text-xs text-blue-500 hover:text-blue-700 whitespace-nowrap transition-colors"
+                  >
+                    ライブへ
+                  </button>
+                )}
+
+                {/* 削除ボタン（タイムラインモード外のみ表示） */}
+                {!timelineMode && (
+                  <button
+                    onClick={() => deleteSnapshot(snapshot.id)}
+                    className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all"
+                    aria-label={`${snapshot.label}を削除`}
+                    title={`${snapshot.label}を削除`}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/panel/SnapshotList.tsx
+++ b/src/components/panel/SnapshotList.tsx
@@ -133,7 +133,7 @@ export function SnapshotList() {
                 {!timelineMode && (
                   <button
                     onClick={() => deleteSnapshot(snapshot.id)}
-                    className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all"
+                    className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 rounded"
                     aria-label={`${snapshot.label}を削除`}
                     title={`${snapshot.label}を削除`}
                   >

--- a/src/components/ui/SnapshotCaptureDialog.test.tsx
+++ b/src/components/ui/SnapshotCaptureDialog.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * SnapshotCaptureDialogコンポーネントのテスト
+ * スナップショット保存のラベル・説明入力ダイアログのUIを検証する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SnapshotCaptureDialog } from './SnapshotCaptureDialog';
+
+describe('SnapshotCaptureDialog', () => {
+  const mockOnCapture = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('isOpen=false のとき何も表示しない', () => {
+    const { container } = render(
+      <SnapshotCaptureDialog
+        isOpen={false}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('isOpen=true のときダイアログが表示される', () => {
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    // ラベル入力フィールドが表示されること
+    expect(screen.getByRole('textbox', { name: /ラベル/i })).toBeInTheDocument();
+    // 保存ボタンが表示されること
+    expect(screen.getByRole('button', { name: /保存/i })).toBeInTheDocument();
+    // キャンセルボタンが表示されること
+    expect(screen.getByRole('button', { name: /キャンセル/i })).toBeInTheDocument();
+  });
+
+  it('ラベルを入力して保存ボタンを押すと onCapture が呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    // ラベルを入力
+    const labelInput = screen.getByRole('textbox', { name: /ラベル/i });
+    await user.type(labelInput, '第1話');
+
+    // 保存ボタンをクリック
+    await user.click(screen.getByRole('button', { name: /保存/i }));
+
+    expect(mockOnCapture).toHaveBeenCalledWith('第1話', undefined);
+  });
+
+  it('ラベルと説明を入力して保存すると両方が渡される', async () => {
+    const user = userEvent.setup();
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    await user.type(screen.getByRole('textbox', { name: /ラベル/i }), '第2話');
+    await user.type(screen.getByRole('textbox', { name: /説明/i }), '明智光秀が登場する回');
+
+    await user.click(screen.getByRole('button', { name: /保存/i }));
+
+    expect(mockOnCapture).toHaveBeenCalledWith('第2話', '明智光秀が登場する回');
+  });
+
+  it('ラベルが空のとき保存ボタンが無効になる', () => {
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /保存/i })).toBeDisabled();
+  });
+
+  it('キャンセルボタンを押すと onCancel が呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /キャンセル/i }));
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escapeキーで onCancel が呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    await user.keyboard('{Escape}');
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('ラベル入力中にEnterキーを押すと保存される（IMEなし）', async () => {
+    const user = userEvent.setup();
+    render(
+      <SnapshotCaptureDialog
+        isOpen={true}
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const labelInput = screen.getByRole('textbox', { name: /ラベル/i });
+    await user.type(labelInput, '第3話');
+    await user.keyboard('{Enter}');
+
+    expect(mockOnCapture).toHaveBeenCalledWith('第3話', undefined);
+  });
+});

--- a/src/components/ui/SnapshotCaptureDialog.tsx
+++ b/src/components/ui/SnapshotCaptureDialog.tsx
@@ -1,0 +1,179 @@
+/**
+ * スナップショット保存ダイアログコンポーネント
+ *
+ * ユーザーが「スナップショットを保存」ボタンを押したときに表示されるダイアログ。
+ * ラベル（必須）と説明（任意）を入力して、スナップショットとして保存できる。
+ *
+ * 特徴:
+ * - ラベルが空の場合は保存ボタンを無効化
+ * - Enterキーで保存（IME変換中は無視）
+ * - Escapeキーでキャンセル
+ * - 背景クリックでキャンセル
+ */
+
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+/**
+ * SnapshotCaptureDialogのプロパティ
+ * @property isOpen - ダイアログを表示するかどうか
+ * @property onCapture - 保存ボタン押下時のコールバック（label, description を受け取る）
+ * @property onCancel - キャンセル時のコールバック
+ */
+type SnapshotCaptureDialogProps = {
+  isOpen: boolean;
+  onCapture: (label: string, description?: string) => void;
+  onCancel: () => void;
+};
+
+/**
+ * スナップショット保存ダイアログ
+ */
+export function SnapshotCaptureDialog({ isOpen, onCapture, onCancel }: SnapshotCaptureDialogProps) {
+  const [label, setLabel] = useState('');
+  const [description, setDescription] = useState('');
+  const labelInputRef = useRef<HTMLInputElement>(null);
+
+  // ダイアログが開くたびに入力値をリセットしてフォーカス
+  useEffect(() => {
+    if (isOpen) {
+      setLabel('');
+      setDescription('');
+      // 次フレームでフォーカス（DOM更新後）
+      const timer = setTimeout(() => {
+        labelInputRef.current?.focus();
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  // Escapeキーでキャンセル
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onCancel();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  const isValid = label.trim().length > 0;
+
+  /**
+   * 保存処理
+   */
+  const handleCapture = () => {
+    if (!isValid) return;
+    onCapture(label.trim(), description.trim() || undefined);
+  };
+
+  /**
+   * ラベル入力のEnterキー処理（IME変換中は無視）
+   */
+  const handleLabelKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      // IME変換中のEnterは無視（日本語入力の変換確定時の誤動作を防ぐ）
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      handleCapture();
+    }
+  };
+
+  /**
+   * 背景クリックでキャンセル
+   */
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleOverlayClick}
+      role="presentation"
+    >
+      <div
+        className="bg-white rounded-lg shadow-lg p-6 max-w-sm w-full mx-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="snapshot-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <h2 id="snapshot-dialog-title" className="text-lg font-bold mb-4">
+          スナップショットを保存
+        </h2>
+
+        {/* ラベル入力（必須） */}
+        <div className="mb-4">
+          <label
+            htmlFor="snapshot-label"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            ラベル
+            <span className="text-red-500 ml-1" aria-hidden="true">*</span>
+          </label>
+          <input
+            ref={labelInputRef}
+            id="snapshot-label"
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={handleLabelKeyDown}
+            placeholder="例: 第1話、2024年春"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+            aria-required="true"
+          />
+        </div>
+
+        {/* 説明入力（任意） */}
+        <div className="mb-6">
+          <label
+            htmlFor="snapshot-description"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            説明
+            <span className="text-gray-400 ml-1 text-xs font-normal">（任意）</span>
+          </label>
+          <input
+            id="snapshot-description"
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="このシーンの説明を入力"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+          />
+        </div>
+
+        {/* ボタン */}
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-800 font-medium transition-colors text-sm"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleCapture}
+            disabled={!isValid}
+            className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed text-white font-medium transition-colors text-sm"
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auto-save.ts
+++ b/src/lib/auto-save.ts
@@ -64,6 +64,8 @@ function buildChartFromState(): Chart | null {
     forceEnabled: state.forceEnabled,
     forceParams: state.forceParams,
     egoLayoutParams: state.egoLayoutParams,
+    snapshots: state.snapshots,
+    schemaVersion: 12,
     createdAt: meta.createdAt,
     updatedAt: new Date().toISOString(),
   };
@@ -124,6 +126,7 @@ export function startAutoSave(): void {
     forceEnabled: initialState.forceEnabled,
     forceParams: initialState.forceParams,
     egoLayoutParams: initialState.egoLayoutParams,
+    snapshots: initialState.snapshots,
   });
 
   // ストアの変更を監視
@@ -135,6 +138,7 @@ export function startAutoSave(): void {
       forceEnabled: state.forceEnabled,
       forceParams: state.forceParams,
       egoLayoutParams: state.egoLayoutParams,
+      snapshots: state.snapshots,
     });
 
     // 変更がない場合はスキップ

--- a/src/lib/auto-save.ts
+++ b/src/lib/auto-save.ts
@@ -42,6 +42,10 @@ let currentSavePromise: Promise<void> | null = null;
 
 /**
  * 現在のストア状態からChartオブジェクトを構築する
+ *
+ * タイムラインモード中は退避済みのライブデータ（_livePersons/_liveRelationships）を使用する。
+ * これによりスナップショット状態がIndexedDBに永続化されることを防ぐ。
+ *
  * @returns Chartオブジェクト（activeChartIdがnullの場合はnull）
  */
 function buildChartFromState(): Chart | null {
@@ -56,11 +60,15 @@ function buildChartFromState(): Chart | null {
     return null;
   }
 
+  // タイムラインモード中は退避済みのライブデータを使用（スナップショット状態を永続化しない）
+  const persons = state.timelineMode ? (state._livePersons ?? state.persons) : state.persons;
+  const relationships = state.timelineMode ? (state._liveRelationships ?? state.relationships) : state.relationships;
+
   return {
     id: state.activeChartId,
     name: meta.name,
-    persons: state.persons,
-    relationships: state.relationships,
+    persons,
+    relationships,
     forceEnabled: state.forceEnabled,
     forceParams: state.forceParams,
     egoLayoutParams: state.egoLayoutParams,
@@ -119,6 +127,7 @@ export function startAutoSave(): void {
   }
 
   // 前回の状態を保持（変更検出用）
+  // snapshotsは大きくなり得るためJSON.stringify外で参照比較する
   const initialState = useGraphStore.getState();
   let previousState = JSON.stringify({
     persons: initialState.persons,
@@ -126,27 +135,47 @@ export function startAutoSave(): void {
     forceEnabled: initialState.forceEnabled,
     forceParams: initialState.forceParams,
     egoLayoutParams: initialState.egoLayoutParams,
-    snapshots: initialState.snapshots,
   });
+  let previousSnapshots = initialState.snapshots;
 
   // ストアの変更を監視
   unsubscribe = useGraphStore.subscribe((state) => {
-    // 監視対象フィールドの現在の状態
+    // タイムラインモード中は変更検出・保存キューイングをスキップして基準状態だけ同期する
+    // これによりgoToSnapshot/goToLiveによるpersons/relationships切り替えが保存されることを防ぐ
+    if (state.pauseAutoSave) {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      hasPendingSave = false;
+      previousState = JSON.stringify({
+        persons: state.persons,
+        relationships: state.relationships,
+        forceEnabled: state.forceEnabled,
+        forceParams: state.forceParams,
+        egoLayoutParams: state.egoLayoutParams,
+      });
+      previousSnapshots = state.snapshots;
+      return;
+    }
+
+    // 監視対象フィールドの現在の状態（snapshotsは参照比較で効率化）
     const currentState = JSON.stringify({
       persons: state.persons,
       relationships: state.relationships,
       forceEnabled: state.forceEnabled,
       forceParams: state.forceParams,
       egoLayoutParams: state.egoLayoutParams,
-      snapshots: state.snapshots,
     });
+    const snapshotsChanged = state.snapshots !== previousSnapshots;
 
     // 変更がない場合はスキップ
-    if (currentState === previousState) {
+    if (currentState === previousState && !snapshotsChanged) {
       return;
     }
 
     previousState = currentState;
+    previousSnapshots = state.snapshots;
 
     // debounceタイマーをクリア
     if (debounceTimer) {

--- a/src/lib/migration.test.ts
+++ b/src/lib/migration.test.ts
@@ -10,6 +10,7 @@ import {
   migrateV9ToV10,
   migrateV10ToV11,
   migratePersonsV10ToV11,
+  normalizeChart,
 } from './migration';
 import type { Person } from '@/types/person';
 import type { LegacyRelationshipV8, LegacyRelationshipV9, LegacyPersonV10 } from './migration';
@@ -1529,5 +1530,76 @@ describe('migrateV9ToV10', () => {
     expect(result[1].labels).toEqual(['物']);
     expect(result[2].labels).toEqual(['人物']);
     result.forEach((p) => expect(p).not.toHaveProperty('kind'));
+  });
+});
+
+describe('normalizeChart', () => {
+  // v12マイグレーションのテスト
+
+  // v11チャートのベースデータ（スナップショットなし）
+  const baseV11Chart = {
+    id: 'chart-001',
+    name: '戦国時代の相関図',
+    persons: [
+      {
+        id: 'p1',
+        labels: ['人物'],
+        name: '織田信長',
+        properties: {},
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ],
+    relationships: [],
+    forceEnabled: false,
+    forceParams: DEFAULT_FORCE_PARAMS,
+    egoLayoutParams: DEFAULT_EGO_LAYOUT_PARAMS,
+    schemaVersion: 11,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  describe('v11チャートのv12への正規化', () => {
+    it('schemaVersion: 11 のチャートに snapshots: [] を補完する', () => {
+      const result = normalizeChart({ ...baseV11Chart });
+
+      expect(result.schemaVersion).toBe(12);
+      expect(result.snapshots).toEqual([]);
+    });
+
+    it('既に snapshots が設定されている場合はそのまま保持する', () => {
+      const existingSnapshot = {
+        id: 'snap-001',
+        label: '第1話',
+        persons: [],
+        relationships: [],
+        createdAt: '2024-06-01T00:00:00.000Z',
+      };
+      const chartWithSnapshots = {
+        ...baseV11Chart,
+        snapshots: [existingSnapshot],
+        schemaVersion: 11,
+      };
+
+      const result = normalizeChart(chartWithSnapshots);
+
+      expect(result.schemaVersion).toBe(12);
+      expect(result.snapshots).toHaveLength(1);
+      expect(result.snapshots?.[0].label).toBe('第1話');
+    });
+  });
+
+  describe('v12チャートはそのまま返す', () => {
+    it('schemaVersion: 12 のチャートはデータ変更なしで返す', () => {
+      const v12Chart = {
+        ...baseV11Chart,
+        snapshots: [],
+        schemaVersion: 12,
+      };
+
+      const result = normalizeChart(v12Chart);
+
+      // 同一オブジェクトが返ること（変換処理なし）
+      expect(result).toBe(v12Chart);
+    });
   });
 });

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -711,7 +711,7 @@ export function migrateGraphState(persistedState: unknown, version: number): unk
   return state;
 }
 
-// ─── IndexedDB Chart の正規化（v11 へのインプレース変換） ─────────────────────
+// ─── IndexedDB Chart の正規化（v12 形式への変換） ──────────────────────────────
 
 /**
  * IndexedDB からロードした Chart を v12 形式に正規化する

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -714,16 +714,21 @@ export function migrateGraphState(persistedState: unknown, version: number): unk
 // ─── IndexedDB Chart の正規化（v11 へのインプレース変換） ─────────────────────
 
 /**
- * IndexedDB からロードした Chart を v11 形式に正規化する
+ * IndexedDB からロードした Chart を v12 形式に正規化する
+ *
+ * スキーマ変換の段階:
+ *   v8以前  → v9: レイヤーベース → プロパティグラフ（forward/reverse構造）
+ *   v9/v10  → v11: Person.kind → labels、RelationshipV9 → Relationship
+ *   v11     → v12: snapshots フィールドの追加（タイムライン機能対応）
  *
  * @param chart - ロードした Chart オブジェクト（古い schemaVersion の可能性あり）
- * @returns v11 形式に正規化された Chart
+ * @returns v12 形式に正規化された Chart
  */
 export function normalizeChart(chart: Chart): Chart {
   const schemaVersion = chart.schemaVersion ?? 0;
 
-  // v11以降はすでに最新形式
-  if (schemaVersion >= 11) return chart;
+  // v12以降はすでに最新形式
+  if (schemaVersion >= 12) return chart;
 
   let persons = chart.persons as unknown as LegacyPersonV10[];
   let relationships = chart.relationships as unknown[];
@@ -756,10 +761,12 @@ export function normalizeChart(chart: Chart): Chart {
   // persons に properties フィールドを追加
   const normalizedPersons = migratePersonsV10ToV11(persons);
 
+  // v11形式に正規化したチャートをv12に変換（snapshotsフィールドを補完）
   return {
     ...chart,
     persons: normalizedPersons,
     relationships: normalizedRelationships,
-    schemaVersion: 11,
+    snapshots: chart.snapshots ?? [],
+    schemaVersion: 12,
   };
 }

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3276,4 +3276,281 @@ describe('useGraphStore', () => {
       });
     });
   });
+
+  // ─── タイムラインスナップショット機能 ──────────────────────────────────────────
+
+  describe('スナップショット機能', () => {
+    beforeEach(async () => {
+      const store = useGraphStore.getState();
+      // snapshotsの初期化（タイムライン状態もリセット）
+      useGraphStore.setState({
+        snapshots: [],
+        timelineMode: false,
+        activeSnapshotIndex: null,
+        _livePersons: null,
+        _liveRelationships: null,
+      });
+      store.persons.forEach((p) => store.removePerson(p.id));
+      store.relationships.forEach((r) => store.removeRelationship(r.id));
+    });
+
+    describe('captureSnapshot', () => {
+      it('現在の状態をスナップショットとして保存する', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        // 人物を追加した状態でスナップショットを保存
+        act(() => {
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '織田信長',
+            properties: {},
+          });
+        });
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+        });
+
+        expect(result.current.snapshots).toHaveLength(1);
+        expect(result.current.snapshots[0].label).toBe('第1話');
+        expect(result.current.snapshots[0].persons).toHaveLength(1);
+        expect(result.current.snapshots[0].persons[0].name).toBe('織田信長');
+        expect(result.current.snapshots[0].id).toBeTruthy();
+        expect(result.current.snapshots[0].createdAt).toBeTruthy();
+      });
+
+      it('descriptionを指定してスナップショットを保存できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第2話', '明智光秀が登場する回');
+        });
+
+        expect(result.current.snapshots[0].description).toBe('明智光秀が登場する回');
+      });
+
+      it('スナップショットのpersonsはimageDataUrlを含まない', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '豊臣秀吉',
+            imageDataUrl: 'data:image/webp;base64,AAAA',
+            properties: {},
+          });
+        });
+
+        act(() => {
+          result.current.captureSnapshot('第3話');
+        });
+
+        // SnapshotPersonはimageDataUrlを持たないこと
+        const snapshotPerson = result.current.snapshots[0].persons[0];
+        expect(snapshotPerson).not.toHaveProperty('imageDataUrl');
+        expect(snapshotPerson.personId).toBeTruthy();
+        expect(snapshotPerson.name).toBe('豊臣秀吉');
+      });
+
+      it('複数のスナップショットを追加できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+        });
+
+        act(() => {
+          result.current.captureSnapshot('第2話');
+        });
+
+        expect(result.current.snapshots).toHaveLength(2);
+        expect(result.current.snapshots[0].label).toBe('第1話');
+        expect(result.current.snapshots[1].label).toBe('第2話');
+      });
+    });
+
+    describe('deleteSnapshot', () => {
+      it('指定したIDのスナップショットを削除する', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        const snapshotId = result.current.snapshots[0].id;
+
+        act(() => {
+          result.current.deleteSnapshot(snapshotId);
+        });
+
+        expect(result.current.snapshots).toHaveLength(1);
+        expect(result.current.snapshots[0].label).toBe('第2話');
+      });
+    });
+
+    describe('updateSnapshot', () => {
+      it('スナップショットのラベルを更新する', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+        });
+
+        const snapshotId = result.current.snapshots[0].id;
+
+        act(() => {
+          result.current.updateSnapshot(snapshotId, { label: '序章' });
+        });
+
+        expect(result.current.snapshots[0].label).toBe('序章');
+      });
+
+      it('スナップショットの説明を更新する', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+        });
+
+        const snapshotId = result.current.snapshots[0].id;
+
+        act(() => {
+          result.current.updateSnapshot(snapshotId, { description: '物語の始まり' });
+        });
+
+        expect(result.current.snapshots[0].description).toBe('物語の始まり');
+      });
+    });
+
+    describe('setTimelineMode / goToSnapshot / goToLive', () => {
+      it('タイムラインモードに入るとpauseAutoSaveがtrueになる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+        });
+
+        expect(result.current.timelineMode).toBe(true);
+        expect(result.current.pauseAutoSave).toBe(true);
+      });
+
+      it('タイムラインモードを終了するとpauseAutoSaveがfalseになり、ライブ状態が復元される', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '徳川家康',
+            properties: {},
+          });
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+        });
+
+        act(() => {
+          result.current.goToSnapshot(0);
+        });
+
+        // タイムラインモード終了
+        act(() => {
+          result.current.setTimelineMode(false);
+        });
+
+        expect(result.current.timelineMode).toBe(false);
+        expect(result.current.pauseAutoSave).toBe(false);
+        // ライブ状態の人物が復元されていること
+        expect(result.current.persons[0].name).toBe('徳川家康');
+      });
+
+      it('goToSnapshotで指定インデックスのスナップショット状態が反映される', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        // 第1話: 人物1人
+        act(() => {
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '上杉謙信',
+            properties: {},
+          });
+          result.current.captureSnapshot('第1話');
+        });
+
+        // 第2話: 人物2人
+        act(() => {
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '武田信玄',
+            properties: {},
+          });
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+        });
+
+        // 第1話スナップショットに移動
+        act(() => {
+          result.current.goToSnapshot(0);
+        });
+
+        expect(result.current.activeSnapshotIndex).toBe(0);
+        // 第1話時点では人物1人
+        expect(result.current.persons).toHaveLength(1);
+        expect(result.current.persons[0].name).toBe('上杉謙信');
+      });
+
+      it('goToLiveでライブ状態に戻る', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '明智光秀',
+            properties: {},
+          });
+          result.current.addPerson({
+            labels: ['人物'],
+            name: '細川藤孝',
+            properties: {},
+          });
+          result.current.captureSnapshot('第1話');
+        });
+
+        // 第1話から人物を削除してライブ状態へ
+        act(() => {
+          const mitsuhideId = result.current.persons.find(
+            (p) => p.name === '明智光秀'
+          )!.id;
+          result.current.removePerson(mitsuhideId);
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+          result.current.goToSnapshot(0);
+        });
+
+        // ライブ状態に戻る（明智光秀が削除された最終状態）
+        act(() => {
+          result.current.goToLive();
+        });
+
+        expect(result.current.activeSnapshotIndex).toBeNull();
+        // ライブ状態は人物1人（明智光秀を削除済み）
+        expect(result.current.persons).toHaveLength(1);
+        expect(result.current.persons[0].name).toBe('細川藤孝');
+      });
+    });
+  });
 });

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -12,6 +12,7 @@ import { INITIAL_EDGE_FILTER } from '@/types/relationship';
 import type { EgoLayoutParams } from '@/lib/ego-layout';
 import { DEFAULT_EGO_LAYOUT_PARAMS } from '@/lib/ego-layout';
 import type { ChartMeta, Chart } from '@/types/chart';
+import type { Snapshot, SnapshotPerson, SnapshotRelationship } from '@/types/snapshot';
 import {
   initDB,
   saveChart,
@@ -79,6 +80,16 @@ type GraphState = {
   editingRelationshipId: string | null;
   /** エッジフィルタ（タグ・述語による絞り込み、セッション内のみ保持） */
   edgeFilter: EdgeFilter;
+  /** タイムラインスナップショット一覧（チャートに永続化される） */
+  snapshots: Snapshot[];
+  /** タイムライン再生モード（true のとき編集操作を無効化、pauseAutoSave=true） */
+  timelineMode: boolean;
+  /** 再生中のスナップショットインデックス（null = ライブ状態） */
+  activeSnapshotIndex: number | null;
+  /** タイムラインモード中のライブPersonsデータ退避（モード終了時に復元する） */
+  _livePersons: Person[] | null;
+  /** タイムラインモード中のライブRelationshipsデータ退避（モード終了時に復元する） */
+  _liveRelationships: Relationship[] | null;
 };
 
 /**
@@ -99,6 +110,11 @@ const INITIAL_STATE: GraphState = {
   pauseAutoSave: false,
   editingRelationshipId: null,
   edgeFilter: INITIAL_EDGE_FILTER,
+  snapshots: [],
+  timelineMode: false,
+  activeSnapshotIndex: null,
+  _livePersons: null,
+  _liveRelationships: null,
 };
 
 
@@ -125,13 +141,15 @@ function buildChartFromState(state: GraphState): Chart | null {
   return {
     id: state.activeChartId,
     name: meta.name,
-    persons: state.persons,
-    relationships: state.relationships,
+    // タイムラインモード中は退避したライブデータを保存（スナップショット表示状態を上書きしない）
+    persons: state._livePersons ?? state.persons,
+    relationships: state._liveRelationships ?? state.relationships,
     forceEnabled: state.forceEnabled,
     forceParams: state.forceParams,
     egoLayoutParams: state.egoLayoutParams,
-    // v11 形式であることを明示する（ロード時の再マイグレーションを防ぐ）
-    schemaVersion: 11,
+    snapshots: state.snapshots,
+    // v12 形式であることを明示する（ロード時の再マイグレーションを防ぐ）
+    schemaVersion: 12,
     createdAt: meta.createdAt,
     updatedAt: new Date().toISOString(),
   };
@@ -348,6 +366,47 @@ type GraphActions = {
    * すべてのデータをリセットする（全チャート削除 + デフォルトチャート作成）
    */
   resetAllData: () => Promise<void>;
+
+  /**
+   * 現在のグラフ状態をスナップショットとして保存する
+   * @param label - スナップショットの名前（例: "第1話", "2024年春"）
+   * @param description - 任意の説明文
+   */
+  captureSnapshot: (label: string, description?: string) => void;
+
+  /**
+   * 指定したIDのスナップショットを削除する
+   * @param snapshotId - 削除するスナップショットのID
+   */
+  deleteSnapshot: (snapshotId: string) => void;
+
+  /**
+   * スナップショットのラベルまたは説明を更新する
+   * @param snapshotId - 更新するスナップショットのID
+   * @param updates - 更新する内容（label または description）
+   */
+  updateSnapshot: (snapshotId: string, updates: { label?: string; description?: string }) => void;
+
+  /**
+   * タイムライン再生モードの有効/無効を切り替える
+   * - true: ライブデータを退避し、pauseAutoSave=true で編集操作を無効化
+   * - false: ライブデータを復元し、pauseAutoSave=false で通常モードに戻る
+   * @param enabled - true でタイムラインモードに入る
+   */
+  setTimelineMode: (enabled: boolean) => void;
+
+  /**
+   * 指定インデックスのスナップショット状態をグラフに反映する
+   * タイムラインモード中のみ有効（タイムラインモード外では何もしない）
+   * @param index - スナップショットのインデックス
+   */
+  goToSnapshot: (index: number) => void;
+
+  /**
+   * ライブ状態（最新の編集状態）に戻る
+   * 退避していたライブデータを復元する
+   */
+  goToLive: () => void;
 };
 
 /**
@@ -661,6 +720,7 @@ export const useGraphStore = create<GraphStore>()(
             forceEnabled: chart.forceEnabled,
             forceParams: chart.forceParams,
             egoLayoutParams: chart.egoLayoutParams,
+            snapshots: chart.snapshots ?? [],
             isInitialized: true,
           }));
 
@@ -737,8 +797,14 @@ export const useGraphStore = create<GraphStore>()(
             forceEnabled: false,
             forceParams: DEFAULT_FORCE_PARAMS,
             egoLayoutParams: DEFAULT_EGO_LAYOUT_PARAMS,
+            snapshots: [],
             selectedPersonIds: [],
             chartMetas: updatedMetas,
+            // タイムラインモードも解除（新チャート作成時はライブ状態で開始）
+            timelineMode: false,
+            activeSnapshotIndex: null,
+            _livePersons: null,
+            _liveRelationships: null,
           }));
 
           // 9. lastActiveChartIdを更新
@@ -771,7 +837,14 @@ export const useGraphStore = create<GraphStore>()(
             forceEnabled: chart.forceEnabled,
             forceParams: chart.forceParams,
             egoLayoutParams: chart.egoLayoutParams,
+            snapshots: chart.snapshots ?? [],
             selectedPersonIds: [], // 選択状態をクリア
+            // タイムラインモードも解除（チャート切り替え時はライブ状態に戻す）
+            timelineMode: false,
+            activeSnapshotIndex: null,
+            _livePersons: null,
+            _liveRelationships: null,
+            pauseAutoSave: false,
           }));
 
           // 4. lastActiveChartIdを更新
@@ -949,6 +1022,165 @@ export const useGraphStore = create<GraphStore>()(
           // 5. ストアを更新
           set(() => ({
             chartMetas: sortedMetas,
+          }));
+        },
+
+        captureSnapshot: (label, description) => {
+          const state = get();
+          // タイムラインモード中はスナップショット保存を禁止
+          if (state.timelineMode) return;
+
+          // SnapshotPerson: imageDataUrlを除いた軽量表現（personIdで画像を参照）
+          const snapshotPersons: SnapshotPerson[] = state.persons.map((p) => ({
+            personId: p.id,
+            name: p.name,
+            labels: p.labels,
+            position: p.position,
+            properties: p.properties,
+          }));
+
+          // SnapshotRelationship: 全フィールドをコピー（数値変化のアニメーション追跡用）
+          const snapshotRelationships: SnapshotRelationship[] = state.relationships.map((r) => ({
+            relationshipId: r.id,
+            type: r.type,
+            sourceId: r.sourceId,
+            targetId: r.targetId,
+            label: r.label,
+            symmetric: r.symmetric,
+            tags: r.tags,
+            colorOverride: r.colorOverride,
+            properties: r.properties,
+          }));
+
+          const snapshot: Snapshot = {
+            id: nanoid(),
+            label,
+            ...(description !== undefined ? { description } : {}),
+            persons: snapshotPersons,
+            relationships: snapshotRelationships,
+            createdAt: new Date().toISOString(),
+          };
+
+          set((s) => ({ snapshots: [...s.snapshots, snapshot] }));
+        },
+
+        deleteSnapshot: (snapshotId) => {
+          set((s) => {
+            const deletedIndex = s.snapshots.findIndex((snap) => snap.id === snapshotId);
+            const newSnapshots = s.snapshots.filter((snap) => snap.id !== snapshotId);
+
+            // activeSnapshotIndex を削除後の配列に合わせて調整
+            let newActiveSnapshotIndex = s.activeSnapshotIndex;
+            if (s.activeSnapshotIndex !== null && deletedIndex !== -1) {
+              if (deletedIndex < s.activeSnapshotIndex) {
+                // 削除されたスナップショットが現在地より前ならインデックスを1つ前にずらす
+                newActiveSnapshotIndex = s.activeSnapshotIndex - 1;
+              } else if (deletedIndex === s.activeSnapshotIndex) {
+                // 削除されたスナップショットが現在地ならライブに戻す
+                newActiveSnapshotIndex = null;
+              }
+            }
+
+            return {
+              snapshots: newSnapshots,
+              activeSnapshotIndex: newActiveSnapshotIndex,
+            };
+          });
+        },
+
+        updateSnapshot: (snapshotId, updates) => {
+          set((state) => ({
+            snapshots: state.snapshots.map((s) =>
+              s.id === snapshotId ? { ...s, ...updates } : s
+            ),
+          }));
+        },
+
+        setTimelineMode: (enabled) => {
+          const state = get();
+
+          if (enabled) {
+            // タイムラインモードに入る: ライブデータを退避してpauseAutoSave=true
+            set(() => ({
+              timelineMode: true,
+              pauseAutoSave: true,
+              activeSnapshotIndex: null,
+              _livePersons: state.persons,
+              _liveRelationships: state.relationships,
+            }));
+          } else {
+            // タイムラインモードを終了: ライブデータを復元してpauseAutoSave=false
+            set((s) => ({
+              timelineMode: false,
+              pauseAutoSave: false,
+              activeSnapshotIndex: null,
+              persons: s._livePersons ?? s.persons,
+              relationships: s._liveRelationships ?? s.relationships,
+              _livePersons: null,
+              _liveRelationships: null,
+            }));
+          }
+        },
+
+        goToSnapshot: (index) => {
+          const state = get();
+          // タイムラインモード外では何もしない
+          if (!state.timelineMode) return;
+
+          const snapshot = state.snapshots[index];
+          if (!snapshot) return;
+
+          // スナップショット時点のPersonを復元する
+          // imageDataUrlは現在のlivePersonsから personId で引く（削除済みはプレースホルダー表示）
+          const livePersonMap = new Map(
+            (state._livePersons ?? []).map((p) => [p.id, p])
+          );
+          const restoredPersons: Person[] = snapshot.persons.map((sp) => {
+            const livePerson = livePersonMap.get(sp.personId);
+            return {
+              id: sp.personId,
+              name: sp.name,
+              labels: sp.labels,
+              position: sp.position,
+              properties: sp.properties,
+              imageDataUrl: livePerson?.imageDataUrl,
+              createdAt: livePerson?.createdAt ?? snapshot.createdAt,
+            };
+          });
+
+          // スナップショット時点のRelationshipを復元する
+          const restoredRelationships: Relationship[] = snapshot.relationships.map((sr) => ({
+            id: sr.relationshipId,
+            type: sr.type,
+            sourceId: sr.sourceId,
+            targetId: sr.targetId,
+            label: sr.label,
+            symmetric: sr.symmetric,
+            tags: sr.tags,
+            colorOverride: sr.colorOverride,
+            properties: sr.properties,
+            // narrativeはスナップショットに含まないのでデフォルト値
+            narrative: { summary: null, notes: null, turningPoints: [] },
+            createdAt: snapshot.createdAt,
+            updatedAt: snapshot.createdAt,
+          }));
+
+          set(() => ({
+            activeSnapshotIndex: index,
+            persons: restoredPersons,
+            relationships: restoredRelationships,
+          }));
+        },
+
+        goToLive: () => {
+          const state = get();
+          // タイムラインモード外では何もしない
+          if (!state.timelineMode) return;
+
+          set((s) => ({
+            activeSnapshotIndex: null,
+            persons: s._livePersons ?? s.persons,
+            relationships: s._liveRelationships ?? s.relationships,
           }));
         },
 

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -1031,15 +1031,17 @@ export const useGraphStore = create<GraphStore>()(
           if (state.timelineMode) return;
 
           // SnapshotPerson: imageDataUrlを除いた軽量表現（personIdで画像を参照）
+          // 配列・オブジェクトは後続の編集で過去スナップショットが変化しないようディープクローンする
           const snapshotPersons: SnapshotPerson[] = state.persons.map((p) => ({
             personId: p.id,
             name: p.name,
-            labels: p.labels,
-            position: p.position,
-            properties: p.properties,
+            labels: [...p.labels],
+            position: p.position ? { ...p.position } : undefined,
+            properties: { ...p.properties },
           }));
 
           // SnapshotRelationship: 全フィールドをコピー（数値変化のアニメーション追跡用）
+          // 配列・オブジェクト・narrativeもディープクローンして不変性を保証
           const snapshotRelationships: SnapshotRelationship[] = state.relationships.map((r) => ({
             relationshipId: r.id,
             type: r.type,
@@ -1047,9 +1049,14 @@ export const useGraphStore = create<GraphStore>()(
             targetId: r.targetId,
             label: r.label,
             symmetric: r.symmetric,
-            tags: r.tags,
+            tags: [...r.tags],
             colorOverride: r.colorOverride,
-            properties: r.properties,
+            properties: { ...r.properties },
+            narrative: {
+              summary: r.narrative.summary,
+              notes: r.narrative.notes,
+              turningPoints: r.narrative.turningPoints.map((tp) => ({ ...tp })),
+            },
           }));
 
           const snapshot: Snapshot = {
@@ -1081,9 +1088,19 @@ export const useGraphStore = create<GraphStore>()(
               }
             }
 
+            // アクティブスナップショットを削除した場合はライブデータへ復元する
+            const deletingActiveSnapshot =
+              s.activeSnapshotIndex !== null && deletedIndex === s.activeSnapshotIndex;
+
             return {
               snapshots: newSnapshots,
               activeSnapshotIndex: newActiveSnapshotIndex,
+              ...(deletingActiveSnapshot && s.timelineMode
+                ? {
+                    persons: s._livePersons ?? s.persons,
+                    relationships: s._liveRelationships ?? s.relationships,
+                  }
+                : {}),
             };
           });
         },
@@ -1098,6 +1115,11 @@ export const useGraphStore = create<GraphStore>()(
 
         setTimelineMode: (enabled) => {
           const state = get();
+
+          // 既に同じモードなら何もしない（再入時にliveデータを上書きしないため）
+          if (enabled === state.timelineMode) {
+            return;
+          }
 
           if (enabled) {
             // タイムラインモードに入る: ライブデータを退避してpauseAutoSave=true
@@ -1140,9 +1162,9 @@ export const useGraphStore = create<GraphStore>()(
             return {
               id: sp.personId,
               name: sp.name,
-              labels: sp.labels,
-              position: sp.position,
-              properties: sp.properties,
+              labels: [...sp.labels],
+              position: sp.position ? { ...sp.position } : undefined,
+              properties: { ...sp.properties },
               imageDataUrl: livePerson?.imageDataUrl,
               createdAt: livePerson?.createdAt ?? snapshot.createdAt,
             };
@@ -1156,11 +1178,17 @@ export const useGraphStore = create<GraphStore>()(
             targetId: sr.targetId,
             label: sr.label,
             symmetric: sr.symmetric,
-            tags: sr.tags,
+            tags: [...sr.tags],
             colorOverride: sr.colorOverride,
-            properties: sr.properties,
-            // narrativeはスナップショットに含まないのでデフォルト値
-            narrative: { summary: null, notes: null, turningPoints: [] },
+            properties: { ...sr.properties },
+            // narrativeを復元する（古いスナップショットにnarrativeがない場合はデフォルト値）
+            narrative: sr.narrative
+              ? {
+                  summary: sr.narrative.summary,
+                  notes: sr.narrative.notes,
+                  turningPoints: sr.narrative.turningPoints.map((tp) => ({ ...tp })),
+                }
+              : { summary: null, notes: null, turningPoints: [] },
             createdAt: snapshot.createdAt,
             updatedAt: snapshot.createdAt,
           }));
@@ -1230,9 +1258,12 @@ export const useGraphStore = create<GraphStore>()(
       {
         // UI状態（selectedPersonIds, forceEnabled, egoLayoutParams, sidePanelOpen, activeChartId, chartMetas, isInitialized, isLoading）はundo対象外
         // データ状態（persons, relationships）のみをundo履歴に保存
+        // タイムラインモード中はgoToSnapshotによる一時的な切り替えをUndo履歴に記録しない
         partialize: (state) => ({
-          persons: state.persons,
-          relationships: state.relationships,
+          persons: state.timelineMode ? (state._livePersons ?? state.persons) : state.persons,
+          relationships: state.timelineMode
+            ? (state._liveRelationships ?? state.relationships)
+            : state.relationships,
         }),
       }
     )

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -1,10 +1,11 @@
 /**
  * 相関図（Chart）の型定義
- * 複数の相関図を管理するためのデータモデル（v11 プロパティグラフ方式）
+ * 複数の相関図を管理するためのデータモデル（v12 タイムラインスナップショット対応）
  */
 
 import type { Person } from './person';
 import type { Relationship } from './relationship';
+import type { Snapshot } from './snapshot';
 import type { ForceParams } from '@/stores/useGraphStore';
 import type { EgoLayoutParams } from '@/lib/ego-layout';
 
@@ -17,6 +18,7 @@ import type { EgoLayoutParams } from '@/lib/ego-layout';
  * @property forceEnabled - force-directedレイアウトが有効かどうか
  * @property forceParams - force-directedレイアウトのパラメータ
  * @property egoLayoutParams - EGO Layoutのパラメータ
+ * @property snapshots - タイムラインスナップショット一覧（v12以降、省略時は空配列として扱う）
  * @property schemaVersion - 関係スキーマのバージョン（undefined は v8 以前）
  * @property createdAt - 作成日時（ISO 8601形式の文字列）
  * @property updatedAt - 最終更新日時（ISO 8601形式の文字列）
@@ -29,6 +31,8 @@ export type Chart = {
   forceEnabled: boolean;
   forceParams: ForceParams;
   egoLayoutParams: EgoLayoutParams;
+  /** タイムラインスナップショット一覧（v12以降、省略時は空配列として扱う） */
+  snapshots?: Snapshot[];
   /** 関係スキーマのバージョン（undefined は v8 以前として扱う） */
   schemaVersion?: number;
   createdAt: string;

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -1,0 +1,77 @@
+/**
+ * タイムラインスナップショットの型定義
+ *
+ * ユーザーが任意のタイミングで保存したグラフ全体の状態（スナップショット）を表す。
+ * スライダー再生機能で過去の状態を閲覧・アニメーション再生するために使用する。
+ *
+ * 設計方針:
+ * - 完全スナップショット方式（差分ではなく各時点の全状態を保存）
+ * - imageDataUrl を保持せず personId で参照することで画像重複を回避
+ * - Chart.persons[] が参照元。削除済み Person はプレースホルダー表示する
+ */
+
+import type { RelationshipProperties } from './relationship';
+
+/**
+ * スナップショット時点の人物の軽量表現
+ *
+ * @property personId - Person.id への参照（画像取得時に使用）
+ * @property name - スナップショット時点の名前（名前変更の変遷を追跡可能）
+ * @property labels - スナップショット時点のラベル配列
+ * @property position - スナップショット時点のキャンバス座標
+ * @property properties - スナップショット時点のカスタムプロパティ
+ */
+export type SnapshotPerson = {
+  personId: string;
+  name: string;
+  labels: string[];
+  position?: { x: number; y: number };
+  properties: Record<string, unknown>;
+};
+
+/**
+ * スナップショット時点の関係の表現
+ *
+ * @property relationshipId - Relationship.id への参照
+ * @property type - エッジ型ラベル
+ * @property sourceId - 起点ノードID
+ * @property targetId - 終点ノードID
+ * @property label - 表示ラベル（null の場合は type を使用）
+ * @property symmetric - true=無向表示、false=有向
+ * @property tags - 分類タグ配列
+ * @property colorOverride - エッジ色の手動上書き
+ * @property properties - ドメイン属性 + カスタムプロパティ（数値変化のアニメーション追跡用）
+ */
+export type SnapshotRelationship = {
+  relationshipId: string;
+  type: string;
+  sourceId: string;
+  targetId: string;
+  label: string | null;
+  symmetric: boolean;
+  tags: string[];
+  colorOverride: string | null;
+  properties: RelationshipProperties;
+};
+
+/**
+ * タイムラインスナップショット
+ *
+ * ユーザーが保存したある時点のグラフ全体の状態を表す。
+ * Chart.snapshots[] として保存される。
+ *
+ * @property id - 一意な識別子（nanoidで生成）
+ * @property label - ユーザーが付ける名前（例: "第1話", "2024年春"）
+ * @property description - 任意の説明文
+ * @property persons - スナップショット時点の人物リスト（imageDataUrl を除く軽量表現）
+ * @property relationships - スナップショット時点の関係リスト
+ * @property createdAt - 保存日時（ISO 8601形式）
+ */
+export type Snapshot = {
+  id: string;
+  label: string;
+  description?: string;
+  persons: SnapshotPerson[];
+  relationships: SnapshotRelationship[];
+  createdAt: string;
+};

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -10,7 +10,7 @@
  * - Chart.persons[] が参照元。削除済み Person はプレースホルダー表示する
  */
 
-import type { RelationshipProperties } from './relationship';
+import type { RelationshipNarrative, RelationshipProperties } from './relationship';
 
 /**
  * スナップショット時点の人物の軽量表現
@@ -41,6 +41,7 @@ export type SnapshotPerson = {
  * @property tags - 分類タグ配列
  * @property colorOverride - エッジ色の手動上書き
  * @property properties - ドメイン属性 + カスタムプロパティ（数値変化のアニメーション追跡用）
+ * @property narrative - 自由記述（タイムライン表示での欠落を防ぐため保存）
  */
 export type SnapshotRelationship = {
   relationshipId: string;
@@ -52,6 +53,7 @@ export type SnapshotRelationship = {
   tags: string[];
   colorOverride: string | null;
   properties: RelationshipProperties;
+  narrative: RelationshipNarrative;
 };
 
 /**


### PR DESCRIPTION
## Summary

- スナップショット方式でグラフ全体の状態を任意のタイミングで保存する機能を追加
- タイムラインバー（スライダー）でスナップショット間を移動して過去の状態を閲覧可能
- スキーマをv11→v12に更新し、`snapshots`フィールドを追加（既存データは自動マイグレーション）

## 追加コンポーネント

| コンポーネント | 役割 |
|---|---|
| `SnapshotCaptureButton` | グラフ右下のFAB（カメラアイコン）→ ダイアログを開く |
| `SnapshotCaptureDialog` | ラベル・説明入力モーダル（IME対応済み） |
| `SnapshotList` | サイドパネルのスナップショット一覧・削除・再生開始 |
| `TimelineBar` | グラフ下部のスライダー＋終了ボタン |

## 設計上のポイント

- **完全スナップショット方式**: 差分ではなくフルコピーを保存し、スライダーのランダムアクセスをO(1)で実現
- **画像データの重複回避**: `imageDataUrl`はスナップショットに含めず、`personId`で参照（各スナップショット数KB程度）
- **タイムラインモード**: `pauseAutoSave=true`で編集を無効化し、`_livePersons`/`_liveRelationships`でライブデータを退避
- **Shallow比較**: `useShallow`を使用してストアセレクターの不要な再レンダリングを防止

## 関連Issue

- Phase 2（アニメーション再生）: #93
- Phase 3（応用機能）: #94

## Test plan

- [x] Lint / 型チェック / テスト（983件）がすべてパス
- [x] スナップショット保存ダイアログのIME対応（`isComposing`チェック）
- [x] `deleteSnapshot`がアクティブインデックスを正しく調整すること
- [x] `auto-save.ts`の`buildChartFromState`に`snapshots`を含めること
- [ ] 手動テスト: 人物・関係を追加→保存→変更→再度保存→スライダーで確認
- [ ] タイムラインモード中は編集操作が無効であることの確認
- [ ] ブラウザリロード後もスナップショットが保持されることの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * グラフの状態をスナップショットとして保存・復元できる機能を実装
  * タイムラインUI経由でスナップショットの表示・削除・編集が可能に
  * タイムラインモード中の編集操作を制限

* **テスト**
  * スナップショット機能関連の包括的なテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->