### PR TITLE
feat: タイムラインスナップショット Phase 2 - アニメーション再生

### DIFF
--- a/src/components/graph/RelationshipGraph.tsx
+++ b/src/components/graph/RelationshipGraph.tsx
@@ -38,6 +38,8 @@ import { EdgeFilterPanel } from './EdgeFilterPanel';
 import { ChatInputBar } from './ChatInputBar';
 import { SnapshotCaptureButton } from './SnapshotCaptureButton';
 import { TimelineBar } from './TimelineBar';
+import { useSnapshotTransition } from './useSnapshotTransition';
+import { useTimelinePlayback } from './useTimelinePlayback';
 import { InterviewModal } from '@/components/interview/InterviewModal';
 import { useGraphStore } from '@/stores/useGraphStore';
 /** 固定 6 色の SVG マーカー定義（deriveEdgeVisual の markerKey と対応） */
@@ -149,6 +151,12 @@ export function RelationshipGraph() {
       forceParams,
     });
 
+
+  // タイムラインスナップショットのアニメーション遷移
+  const { transitionToSnapshot, isTransitioning } = useSnapshotTransition();
+
+  // タイムライン自動再生タイマー（isPlaying/playbackSpeed をストアから読む）
+  useTimelinePlayback(transitionToSnapshot, isTransitioning);
 
   // ノードドラッグ開始ハンドラ
   const onNodeDragStartHandler = useCallback(
@@ -315,7 +323,7 @@ export function RelationshipGraph() {
       )}
 
       {/* タイムラインバー（タイムラインモード中に下部に表示） */}
-      <TimelineBar />
+      <TimelineBar onTransition={transitionToSnapshot} isTransitioning={isTransitioning} />
 
       {/* フローティングチャット入力バー */}
       <ChatInputBar />

--- a/src/components/graph/SnapshotCaptureButton.tsx
+++ b/src/components/graph/SnapshotCaptureButton.tsx
@@ -11,6 +11,7 @@
 
 import { useState } from 'react';
 import { Camera } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { SnapshotCaptureDialog } from '@/components/ui/SnapshotCaptureDialog';
 
@@ -19,10 +20,12 @@ import { SnapshotCaptureDialog } from '@/components/ui/SnapshotCaptureDialog';
  */
 export function SnapshotCaptureButton() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const { captureSnapshot, timelineMode } = useGraphStore((state) => ({
-    captureSnapshot: state.captureSnapshot,
-    timelineMode: state.timelineMode,
-  }));
+  const { captureSnapshot, timelineMode } = useGraphStore(
+    useShallow((state) => ({
+      captureSnapshot: state.captureSnapshot,
+      timelineMode: state.timelineMode,
+    }))
+  );
 
   // タイムラインモード中はボタンを非表示
   if (timelineMode) return null;

--- a/src/components/graph/TimelineBar.test.tsx
+++ b/src/components/graph/TimelineBar.test.tsx
@@ -33,6 +33,10 @@ function makeStoreMock(overrides: Partial<{
   setTimelineMode: ReturnType<typeof vi.fn>;
   goToSnapshot: ReturnType<typeof vi.fn>;
   goToLive: ReturnType<typeof vi.fn>;
+  isPlaying: boolean;
+  playbackSpeed: number;
+  setPlaying: ReturnType<typeof vi.fn>;
+  setPlaybackSpeed: ReturnType<typeof vi.fn>;
 }> = {}) {
   return {
     snapshots: overrides.snapshots ?? [],
@@ -41,6 +45,10 @@ function makeStoreMock(overrides: Partial<{
     setTimelineMode: overrides.setTimelineMode ?? vi.fn(),
     goToSnapshot: overrides.goToSnapshot ?? vi.fn(),
     goToLive: overrides.goToLive ?? vi.fn(),
+    isPlaying: overrides.isPlaying ?? false,
+    playbackSpeed: overrides.playbackSpeed ?? 2000,
+    setPlaying: overrides.setPlaying ?? vi.fn(),
+    setPlaybackSpeed: overrides.setPlaybackSpeed ?? vi.fn(),
   };
 }
 
@@ -135,5 +143,174 @@ describe('TimelineBar', () => {
     await user.click(screen.getByRole('button', { name: /終了/i }));
 
     expect(mockSetTimelineMode).toHaveBeenCalledWith(false);
+  });
+
+  describe('再生コントロール', () => {
+    it('isPlaying=false のとき再生ボタン(▶)が表示される', () => {
+      // GIVEN: スナップショットあり、停止中
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0, isPlaying: false })
+      );
+
+      render(<TimelineBar />);
+
+      // THEN: 再生ボタンが存在する
+      expect(screen.getByRole('button', { name: /再生/i })).toBeInTheDocument();
+    });
+
+    it('再生ボタンをクリックすると setPlaying(true) が呼ばれる', async () => {
+      // GIVEN
+      const user = userEvent.setup();
+      const mockSetPlaying = vi.fn();
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0, isPlaying: false, setPlaying: mockSetPlaying })
+      );
+
+      render(<TimelineBar />);
+
+      // WHEN
+      await user.click(screen.getByRole('button', { name: /再生/i }));
+
+      // THEN
+      expect(mockSetPlaying).toHaveBeenCalledWith(true);
+    });
+
+    it('isPlaying=true のとき停止ボタン(⏸)が表示される', () => {
+      // GIVEN: 再生中
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0, isPlaying: true })
+      );
+
+      render(<TimelineBar />);
+
+      // THEN: 停止ボタンが存在する
+      expect(screen.getByRole('button', { name: /停止/i })).toBeInTheDocument();
+    });
+
+    it('停止ボタンをクリックすると setPlaying(false) が呼ばれる', async () => {
+      // GIVEN: 再生中
+      const user = userEvent.setup();
+      const mockSetPlaying = vi.fn();
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0, isPlaying: true, setPlaying: mockSetPlaying })
+      );
+
+      render(<TimelineBar />);
+
+      // WHEN
+      await user.click(screen.getByRole('button', { name: /停止/i }));
+
+      // THEN
+      expect(mockSetPlaying).toHaveBeenCalledWith(false);
+    });
+
+    it('スナップショット0件のとき再生ボタンがdisabledになる', () => {
+      // GIVEN: スナップショットなし
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots: [], timelineMode: true, isPlaying: false })
+      );
+
+      render(<TimelineBar />);
+
+      // THEN: 再生ボタンはdisabled
+      expect(screen.getByRole('button', { name: /再生/i })).toBeDisabled();
+    });
+
+    it('前へボタンをクリックすると onTransition が activeSnapshotIndex-1 で呼ばれる', async () => {
+      // GIVEN: 第2話（index=1）を表示中
+      const user = userEvent.setup();
+      const mockOnTransition = vi.fn();
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話'), makeSnapshot('第3話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 1 })
+      );
+
+      render(<TimelineBar onTransition={mockOnTransition} />);
+
+      // WHEN: 前へボタンをクリック
+      await user.click(screen.getByRole('button', { name: /前へ/i }));
+
+      // THEN: index=0 へ遷移
+      expect(mockOnTransition).toHaveBeenCalledWith(0);
+    });
+
+    it('次へボタンをクリックすると onTransition が activeSnapshotIndex+1 で呼ばれる', async () => {
+      // GIVEN: 第1話（index=0）を表示中
+      const user = userEvent.setup();
+      const mockOnTransition = vi.fn();
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0 })
+      );
+
+      render(<TimelineBar onTransition={mockOnTransition} />);
+
+      // WHEN: 次へボタンをクリック
+      await user.click(screen.getByRole('button', { name: /次へ/i }));
+
+      // THEN: index=1 へ遷移
+      expect(mockOnTransition).toHaveBeenCalledWith(1);
+    });
+
+    it('前へボタンはライブ状態（activeSnapshotIndex=null）のときdisabledになる', () => {
+      // GIVEN: ライブ状態
+      const snapshots = [makeSnapshot('第1話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: null })
+      );
+
+      render(<TimelineBar />);
+
+      // THEN: 前へボタンはdisabled
+      expect(screen.getByRole('button', { name: /前へ/i })).toBeDisabled();
+    });
+
+    it('次へボタンは最後のスナップショットのときdisabledになる', () => {
+      // GIVEN: 最後のスナップショット（index=1、全2件）
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 1 })
+      );
+
+      render(<TimelineBar />);
+
+      // THEN: 次へボタンはdisabled
+      expect(screen.getByRole('button', { name: /次へ/i })).toBeDisabled();
+    });
+
+    it('isTransitioning=true のときスライダーがdisabledになる', () => {
+      // GIVEN: アニメーション遷移中
+      const snapshots = [makeSnapshot('第1話'), makeSnapshot('第2話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0 })
+      );
+
+      render(<TimelineBar isTransitioning={true} />);
+
+      // THEN: スライダーがdisabled
+      expect(screen.getByRole('slider')).toBeDisabled();
+    });
+
+    it('速度ボタンをクリックすると setPlaybackSpeed が次の速度で呼ばれる', async () => {
+      // GIVEN: 現在の速度は 2000ms（1.5x）
+      const user = userEvent.setup();
+      const mockSetPlaybackSpeed = vi.fn();
+      const snapshots = [makeSnapshot('第1話')];
+      mockUseGraphStore.mockReturnValue(
+        makeStoreMock({ snapshots, timelineMode: true, playbackSpeed: 2000, setPlaybackSpeed: mockSetPlaybackSpeed })
+      );
+
+      render(<TimelineBar />);
+
+      // WHEN: 速度ボタンをクリック（2000ms → 1000ms へ循環）
+      await user.click(screen.getByRole('button', { name: /速度/i }));
+
+      // THEN: 次の速度に変更される
+      expect(mockSetPlaybackSpeed).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/graph/TimelineBar.tsx
+++ b/src/components/graph/TimelineBar.tsx
@@ -2,26 +2,51 @@
  * タイムラインバーコンポーネント
  *
  * タイムラインモード中にグラフキャンバス下部に表示されるコントロールバー。
- * スライダーでスナップショット間を移動できる。
+ * スライダーでスナップショット間を移動し、再生/停止/前後ボタンで操作できる。
  *
  * 表示条件: timelineMode === true のとき（スナップショット0件でも表示）
  *
  * 機能:
- * - スライダーによるスナップショット移動
- * - 現在のスナップショットラベル表示（null = ライブ状態）
- * - 終了ボタンでタイムラインモードを解除
+ * - 再生/停止ボタン: isPlaying を切り替える
+ * - 前へ/次へボタン: onTransition を呼んでスナップショットを移動
+ * - スライダー: スナップショット間を直接移動（isTransitioning 中はdisabled）
+ * - 速度ボタン: 再生速度を 1x / 1.5x / 2x でサイクル切り替え
+ * - 終了ボタン: タイムラインモードを解除
  */
 
 'use client';
 
-import { X } from 'lucide-react';
+import { Pause, Play, SkipBack, SkipForward, X } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
+
+/** 再生速度の設定（ミリ秒）。循環する順番で定義 */
+const PLAYBACK_SPEEDS = [3000, 2000, 1000] as const;
+
+/** 再生速度ラベルのマッピング */
+const SPEED_LABELS: Record<number, string> = {
+  3000: '1x',
+  2000: '1.5x',
+  1000: '2x',
+};
+
+/**
+ * TimelineBar コンポーネントのProps
+ */
+type TimelineBarProps = {
+  /**
+   * アニメーション付きスナップショット遷移関数
+   * 省略時は useGraphStore の goToSnapshot を直接呼ぶ
+   */
+  onTransition?: (index: number) => void;
+  /** アニメーション遷移中かどうか（true のときスライダーをdisabled化） */
+  isTransitioning?: boolean;
+};
 
 /**
  * タイムラインバーコンポーネント
  */
-export function TimelineBar() {
+export function TimelineBar({ onTransition, isTransitioning = false }: TimelineBarProps) {
   const {
     snapshots,
     timelineMode,
@@ -29,6 +54,10 @@ export function TimelineBar() {
     setTimelineMode,
     goToSnapshot,
     goToLive,
+    isPlaying,
+    playbackSpeed,
+    setPlaying,
+    setPlaybackSpeed,
   } = useGraphStore(
     useShallow((state) => ({
       snapshots: state.snapshots,
@@ -37,6 +66,10 @@ export function TimelineBar() {
       setTimelineMode: state.setTimelineMode,
       goToSnapshot: state.goToSnapshot,
       goToLive: state.goToLive,
+      isPlaying: state.isPlaying,
+      playbackSpeed: state.playbackSpeed,
+      setPlaying: state.setPlaying,
+      setPlaybackSpeed: state.setPlaybackSpeed,
     }))
   );
 
@@ -52,8 +85,45 @@ export function TimelineBar() {
     if (value === 0) {
       goToLive();
     } else {
-      goToSnapshot(value - 1);
+      const targetIndex = value - 1;
+      if (onTransition) {
+        onTransition(targetIndex);
+      } else {
+        goToSnapshot(targetIndex);
+      }
     }
+  };
+
+  /** 前へボタンのハンドラ */
+  const handlePrev = () => {
+    if (activeSnapshotIndex === null || activeSnapshotIndex === 0) return;
+    const targetIndex = activeSnapshotIndex - 1;
+    if (onTransition) {
+      onTransition(targetIndex);
+    } else {
+      goToSnapshot(targetIndex);
+    }
+  };
+
+  /** 次へボタンのハンドラ */
+  const handleNext = () => {
+    if (activeSnapshotIndex === snapshots.length - 1) return;
+    const targetIndex = activeSnapshotIndex === null ? 0 : activeSnapshotIndex + 1;
+    if (onTransition) {
+      onTransition(targetIndex);
+    } else {
+      goToSnapshot(targetIndex);
+    }
+  };
+
+  /**
+   * 速度ボタンのハンドラ
+   * 現在の速度から次の速度へ循環する: 3000ms → 2000ms → 1000ms → 3000ms
+   */
+  const handleSpeedCycle = () => {
+    const currentIndex = PLAYBACK_SPEEDS.indexOf(playbackSpeed as typeof PLAYBACK_SPEEDS[number]);
+    const nextIndex = (currentIndex + 1) % PLAYBACK_SPEEDS.length;
+    setPlaybackSpeed(PLAYBACK_SPEEDS[nextIndex]);
   };
 
   // スライダーの現在値（0=ライブ、1〜n=スナップショット）
@@ -67,10 +137,65 @@ export function TimelineBar() {
       ? (snapshots[activeSnapshotIndex]?.label ?? '不明')
       : 'ライブ';
 
+  // 前へボタンのdisabled条件
+  const isPrevDisabled = activeSnapshotIndex === null || activeSnapshotIndex === 0;
+  // 次へボタンのdisabled条件
+  const isNextDisabled = activeSnapshotIndex === snapshots.length - 1;
+  // 再生/停止ボタンのdisabled条件
+  const isPlayDisabled = snapshots.length === 0;
+
+  // 現在の速度ラベル
+  const currentSpeedLabel = SPEED_LABELS[playbackSpeed] ?? '1.5x';
+
   return (
-    <div className="absolute bottom-0 left-0 right-0 z-10 bg-white/95 backdrop-blur-sm border-t border-gray-200 px-4 py-3 flex items-center gap-4">
+    <div className="absolute bottom-0 left-0 right-0 z-10 bg-white/95 backdrop-blur-sm border-t border-gray-200 px-4 py-3 flex items-center gap-3">
+      {/* 前へボタン */}
+      <button
+        onClick={handlePrev}
+        disabled={isPrevDisabled || isTransitioning}
+        className="p-1.5 rounded hover:bg-gray-100 text-gray-600 hover:text-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        aria-label="前へ"
+        title="前のスナップショット"
+      >
+        <SkipBack size={16} />
+      </button>
+
+      {/* 再生/停止ボタン */}
+      {isPlaying ? (
+        <button
+          onClick={() => setPlaying(false)}
+          disabled={isPlayDisabled}
+          className="p-1.5 rounded hover:bg-gray-100 text-blue-600 hover:text-blue-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          aria-label="停止"
+          title="停止"
+        >
+          <Pause size={16} />
+        </button>
+      ) : (
+        <button
+          onClick={() => setPlaying(true)}
+          disabled={isPlayDisabled || isTransitioning}
+          className="p-1.5 rounded hover:bg-gray-100 text-gray-600 hover:text-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          aria-label="再生"
+          title="再生"
+        >
+          <Play size={16} />
+        </button>
+      )}
+
+      {/* 次へボタン */}
+      <button
+        onClick={handleNext}
+        disabled={isNextDisabled || isTransitioning}
+        className="p-1.5 rounded hover:bg-gray-100 text-gray-600 hover:text-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        aria-label="次へ"
+        title="次のスナップショット"
+      >
+        <SkipForward size={16} />
+      </button>
+
       {/* 現在のラベル */}
-      <span className="text-sm font-medium text-gray-700 min-w-[6rem] truncate">
+      <span className="text-sm font-medium text-gray-700 min-w-[5rem] truncate">
         {currentLabel}
       </span>
 
@@ -84,7 +209,7 @@ export function TimelineBar() {
           max={sliderMax}
           value={sliderValue}
           onChange={handleSliderChange}
-          disabled={snapshots.length === 0}
+          disabled={snapshots.length === 0 || isTransitioning}
           className="flex-1 h-2 accent-blue-600 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="タイムラインスライダー"
           aria-valuemin={0}
@@ -94,11 +219,21 @@ export function TimelineBar() {
         />
         {/* 最終スナップショット */}
         {snapshots.length > 0 && (
-          <span className="text-xs text-gray-400 whitespace-nowrap max-w-[6rem] truncate">
+          <span className="text-xs text-gray-400 whitespace-nowrap max-w-[5rem] truncate">
             {snapshots[snapshots.length - 1]?.label}
           </span>
         )}
       </div>
+
+      {/* 速度ボタン */}
+      <button
+        onClick={handleSpeedCycle}
+        className="text-xs font-medium text-gray-600 hover:text-gray-800 px-2 py-1 rounded hover:bg-gray-100 transition-colors min-w-[2.5rem] text-center"
+        aria-label="速度"
+        title={`再生速度: ${currentSpeedLabel}`}
+      >
+        {currentSpeedLabel}
+      </button>
 
       {/* 終了ボタン */}
       <button

--- a/src/components/graph/TimelineBar.tsx
+++ b/src/components/graph/TimelineBar.tsx
@@ -18,10 +18,8 @@
 
 import { Pause, Play, SkipBack, SkipForward, X } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
-import { useGraphStore } from '@/stores/useGraphStore';
-
-/** 再生速度の設定（ミリ秒）。循環する順番で定義 */
-const PLAYBACK_SPEEDS = [3000, 2000, 1000] as const;
+import { useGraphStore, PLAYBACK_SPEEDS } from '@/stores/useGraphStore';
+import type { PlaybackSpeed } from '@/stores/useGraphStore';
 
 /** 再生速度ラベルのマッピング */
 const SPEED_LABELS: Record<number, string> = {
@@ -121,7 +119,7 @@ export function TimelineBar({ onTransition, isTransitioning = false }: TimelineB
    * 現在の速度から次の速度へ循環する: 3000ms → 2000ms → 1000ms → 3000ms
    */
   const handleSpeedCycle = () => {
-    const currentIndex = PLAYBACK_SPEEDS.indexOf(playbackSpeed as typeof PLAYBACK_SPEEDS[number]);
+    const currentIndex = PLAYBACK_SPEEDS.indexOf(playbackSpeed as PlaybackSpeed);
     const nextIndex = (currentIndex + 1) % PLAYBACK_SPEEDS.length;
     setPlaybackSpeed(PLAYBACK_SPEEDS[nextIndex]);
   };
@@ -144,7 +142,8 @@ export function TimelineBar({ onTransition, isTransitioning = false }: TimelineB
   // スナップショットが0件の場合も明示的に disabled にする
   const isNextDisabled = snapshots.length === 0 || activeSnapshotIndex === snapshots.length - 1;
   // 再生/停止ボタンのdisabled条件
-  const isPlayDisabled = snapshots.length === 0;
+  // スナップショット0件、または最後のスナップショット表示中（進む先がない）
+  const isPlayDisabled = snapshots.length === 0 || activeSnapshotIndex === snapshots.length - 1;
 
   // 現在の速度ラベル
   const currentSpeedLabel = SPEED_LABELS[playbackSpeed] ?? '1.5x';

--- a/src/components/graph/TimelineBar.tsx
+++ b/src/components/graph/TimelineBar.tsx
@@ -140,7 +140,9 @@ export function TimelineBar({ onTransition, isTransitioning = false }: TimelineB
   // 前へボタンのdisabled条件
   const isPrevDisabled = activeSnapshotIndex === null || activeSnapshotIndex === 0;
   // 次へボタンのdisabled条件
-  const isNextDisabled = activeSnapshotIndex === snapshots.length - 1;
+  // snapshots.length === 0 のとき activeSnapshotIndex === snapshots.length - 1 は null === -1 で false になるため
+  // スナップショットが0件の場合も明示的に disabled にする
+  const isNextDisabled = snapshots.length === 0 || activeSnapshotIndex === snapshots.length - 1;
   // 再生/停止ボタンのdisabled条件
   const isPlayDisabled = snapshots.length === 0;
 

--- a/src/components/graph/useSnapshotTransition.test.ts
+++ b/src/components/graph/useSnapshotTransition.test.ts
@@ -1,0 +1,261 @@
+/**
+ * useSnapshotTransition フックのユニットテスト
+ *
+ * スナップショット間のアニメーション遷移の動作を検証する。
+ * - requestAnimationFrame をキャプチャして手動実行する方式でrAFアニメーションをテスト
+ * - fake timers で setTimeout を制御する
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSnapshotTransition } from './useSnapshotTransition';
+import { useGraphStore } from '@/stores/useGraphStore';
+import { useReactFlow } from '@xyflow/react';
+
+vi.mock('@/stores/useGraphStore');
+vi.mock('@xyflow/react');
+
+const mockUseGraphStore = vi.mocked(useGraphStore);
+const mockUseReactFlow = vi.mocked(useReactFlow);
+
+/**
+ * テスト用のデフォルトスナップショット
+ */
+const defaultSnapshot = {
+  id: 'snap-1',
+  label: '第1話',
+  persons: [
+    {
+      personId: 'person-織田',
+      name: '織田信長',
+      labels: ['武将'],
+      position: { x: 100, y: 200 },
+      properties: {},
+    },
+  ],
+  relationships: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+/**
+ * ストアモックを設定するヘルパー
+ */
+function setupStoreMock(overrides: {
+  snapshots?: typeof defaultSnapshot[];
+  activeSnapshotIndex?: number | null;
+  _livePersons?: { id: string; imageDataUrl?: string }[];
+  goToSnapshot?: ReturnType<typeof vi.fn>;
+}) {
+  const goToSnapshot = overrides.goToSnapshot ?? vi.fn();
+  mockUseGraphStore.mockReturnValue({
+    snapshots: overrides.snapshots ?? [defaultSnapshot],
+    activeSnapshotIndex: overrides.activeSnapshotIndex ?? null,
+    _livePersons: overrides._livePersons ?? [],
+    goToSnapshot,
+  } as ReturnType<typeof useGraphStore>);
+  return { goToSnapshot };
+}
+
+/**
+ * React Flow モックを設定するヘルパー
+ */
+function setupReactFlowMock(overrides: {
+  currentNodes?: { id: string; position: { x: number; y: number }; data: object }[];
+  setNodes?: ReturnType<typeof vi.fn>;
+  setEdges?: ReturnType<typeof vi.fn>;
+}) {
+  const setNodes = overrides.setNodes ?? vi.fn();
+  const setEdges = overrides.setEdges ?? vi.fn();
+  mockUseReactFlow.mockReturnValue({
+    getNodes: vi.fn().mockReturnValue(overrides.currentNodes ?? []),
+    setNodes,
+    getEdges: vi.fn().mockReturnValue([]),
+    setEdges,
+    // useReactFlowの他のメソッドはテスト対象外のため省略
+  } as unknown as ReturnType<typeof useReactFlow>);
+  return { setNodes, setEdges };
+}
+
+describe('useSnapshotTransition', () => {
+  // rAFのキャプチャ用
+  let capturedRafCallbacks: FrameRequestCallback[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    // requestAnimationFrame をキャプチャ（呼ばれたコールバックを手動実行できるようにする）
+    capturedRafCallbacks = [];
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      capturedRafCallbacks.push(cb);
+      return capturedRafCallbacks.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {
+      capturedRafCallbacks = [];
+    });
+
+    // performance.now をモック（アニメーション完了状態をシミュレートする）
+    vi.stubGlobal('performance', { now: vi.fn(() => 400) });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('初期状態では isTransitioning は false である', () => {
+    // GIVEN
+    setupStoreMock({});
+    setupReactFlowMock({});
+
+    // WHEN
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // THEN
+    expect(result.current.isTransitioning).toBe(false);
+  });
+
+  it('transitionToSnapshot を呼ぶと isTransitioning が true になる', () => {
+    // GIVEN
+    setupStoreMock({ snapshots: [defaultSnapshot] });
+    setupReactFlowMock({});
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // WHEN
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+
+    // THEN: アニメーション開始で isTransitioning=true
+    expect(result.current.isTransitioning).toBe(true);
+  });
+
+  it('transitionToSnapshot を呼ぶと requestAnimationFrame が起動される', () => {
+    // GIVEN
+    setupStoreMock({ snapshots: [defaultSnapshot] });
+    setupReactFlowMock({});
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // WHEN
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+
+    // THEN: rAFが少なくとも1回呼ばれている
+    expect(capturedRafCallbacks.length).toBeGreaterThan(0);
+  });
+
+  it('rAF コールバック実行後に setNodes が呼ばれる', () => {
+    // GIVEN: 現在ノードは空、対象スナップショットに人物が1人
+    setupStoreMock({ snapshots: [defaultSnapshot] });
+    const { setNodes } = setupReactFlowMock({ currentNodes: [] });
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // WHEN: アニメーション開始
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+
+    // rAF コールバックを手動実行（performance.now() = 400 > TRANSITION_DURATION_MS = 300）
+    act(() => {
+      const callbacks = [...capturedRafCallbacks];
+      capturedRafCallbacks = [];
+      callbacks.forEach((cb) => cb(400));
+    });
+
+    // THEN: setNodes が呼ばれてノードが設定された
+    expect(setNodes).toHaveBeenCalled();
+  });
+
+  it('TRANSITION_DURATION_MS 後に goToSnapshot が呼ばれる', () => {
+    // GIVEN
+    const { goToSnapshot } = setupStoreMock({ snapshots: [defaultSnapshot] });
+    setupReactFlowMock({});
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+
+    expect(goToSnapshot).not.toHaveBeenCalled();
+
+    // WHEN: TRANSITION_DURATION_MS (300ms) 経過
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // THEN: ストアのgoToSnapshotが正しいインデックスで呼ばれる
+    expect(goToSnapshot).toHaveBeenCalledWith(0);
+  });
+
+  it('TRANSITION_DURATION_MS 後に isTransitioning が false になる', () => {
+    // GIVEN
+    setupStoreMock({ snapshots: [defaultSnapshot] });
+    setupReactFlowMock({});
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+    expect(result.current.isTransitioning).toBe(true);
+
+    // WHEN: 300ms経過
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // THEN
+    expect(result.current.isTransitioning).toBe(false);
+  });
+
+  it('存在しないインデックスを指定しても何もしない', () => {
+    // GIVEN: スナップショット1件
+    const { goToSnapshot } = setupStoreMock({ snapshots: [defaultSnapshot] });
+    setupReactFlowMock({});
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // WHEN: 存在しないインデックス（index=5）
+    act(() => {
+      result.current.transitionToSnapshot(5);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // THEN: goToSnapshot は呼ばれない
+    expect(goToSnapshot).not.toHaveBeenCalled();
+    expect(result.current.isTransitioning).toBe(false);
+  });
+
+  it('遷移中に再度 transitionToSnapshot を呼ぶと前のアニメーションがキャンセルされる', () => {
+    // GIVEN: スナップショット2件
+    const snapshot2 = {
+      ...defaultSnapshot,
+      id: 'snap-2',
+      label: '第2話',
+    };
+    const { goToSnapshot } = setupStoreMock({ snapshots: [defaultSnapshot, snapshot2] });
+    setupReactFlowMock({});
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // WHEN: index=0 の遷移を開始
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+
+    // すぐに index=1 に遷移（前のアニメーションをキャンセル）
+    act(() => {
+      result.current.transitionToSnapshot(1);
+    });
+
+    // 300ms 後
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // THEN: 最後に呼ばれた index=1 のみ goToSnapshot が呼ばれる
+    expect(goToSnapshot).toHaveBeenCalledTimes(1);
+    expect(goToSnapshot).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/components/graph/useSnapshotTransition.test.ts
+++ b/src/components/graph/useSnapshotTransition.test.ts
@@ -18,6 +18,11 @@ vi.mock('@xyflow/react');
 const mockUseGraphStore = vi.mocked(useGraphStore);
 const mockUseReactFlow = vi.mocked(useReactFlow);
 
+/** テスト用のデフォルトRelationshipNarrative */
+const defaultNarrative = { summary: '', notes: '', turningPoints: [] };
+/** テスト用のデフォルトRelationshipProperties */
+const defaultProperties = { startDate: null, endDate: null, strength: null, customProperties: {} };
+
 /**
  * テスト用のデフォルトスナップショット
  */
@@ -38,10 +43,37 @@ const defaultSnapshot = {
 };
 
 /**
+ * エッジを含むスナップショット（エッジアニメーションテスト用）
+ */
+const snapshotWithEdge = {
+  id: 'snap-edge',
+  label: 'エッジあり',
+  persons: [
+    { personId: 'person-A', name: '人物A', labels: [], position: { x: 100, y: 100 }, properties: {} },
+    { personId: 'person-B', name: '人物B', labels: [], position: { x: 300, y: 100 }, properties: {} },
+  ],
+  relationships: [
+    {
+      relationshipId: 'rel-1',
+      type: '友人',
+      sourceId: 'person-A',
+      targetId: 'person-B',
+      label: null,
+      symmetric: false,
+      tags: [],
+      colorOverride: null,
+      properties: defaultProperties,
+      narrative: defaultNarrative,
+    },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+/**
  * ストアモックを設定するヘルパー
  */
 function setupStoreMock(overrides: {
-  snapshots?: typeof defaultSnapshot[];
+  snapshots?: unknown[];
   activeSnapshotIndex?: number | null;
   _livePersons?: { id: string; imageDataUrl?: string }[];
   goToSnapshot?: ReturnType<typeof vi.fn>;
@@ -226,6 +258,28 @@ describe('useSnapshotTransition', () => {
     // THEN: goToSnapshot は呼ばれない
     expect(goToSnapshot).not.toHaveBeenCalled();
     expect(result.current.isTransitioning).toBe(false);
+  });
+
+  it('rAF コールバック実行後に setEdges が呼ばれる（エッジアニメーション）', () => {
+    // GIVEN: エッジを含むスナップショットへ遷移
+    setupStoreMock({ snapshots: [snapshotWithEdge] });
+    const { setEdges } = setupReactFlowMock({ currentNodes: [] });
+    const { result } = renderHook(() => useSnapshotTransition());
+
+    // WHEN: アニメーション開始
+    act(() => {
+      result.current.transitionToSnapshot(0);
+    });
+
+    // rAF コールバックを手動実行
+    act(() => {
+      const callbacks = [...capturedRafCallbacks];
+      capturedRafCallbacks = [];
+      callbacks.forEach((cb) => cb(400));
+    });
+
+    // THEN: setEdges が呼ばれてエッジが設定された
+    expect(setEdges).toHaveBeenCalled();
   });
 
   it('遷移中に再度 transitionToSnapshot を呼ぶと前のアニメーションがキャンセルされる', () => {

--- a/src/components/graph/useSnapshotTransition.ts
+++ b/src/components/graph/useSnapshotTransition.ts
@@ -6,13 +6,15 @@
  * - ノード位置移動: rAF + easeOutCubic によるフレーム補間
  * - ノード出現（追加）: opacity 0→1 のフェードイン
  * - ノード消滅（削除）: opacity 1→0 のフェードアウト
+ * - エッジ出現（追加）: opacity 0→1 のフェードイン
+ * - エッジ消滅（削除）: opacity 1→0 のフェードアウト
  *
  * 設計方針:
  * - アニメーション中はストアの persons/relationships を変更しない
  *   → useGraphDataSync の useEffect が発火せず、アニメーションと競合しない
  * - TRANSITION_DURATION_MS 後に setTimeout でストアの goToSnapshot を呼んで状態を確定する
  * - 連続呼び出しには cancelAnimationFrame + clearTimeout で前のアニメーションをキャンセルする
- * - ノードの style.opacity を直接操作することでフェードイン/フェードアウトを実現する
+ * - ノード/エッジの style.opacity を直接操作することでフェードイン/フェードアウトを実現する
  */
 
 'use client';
@@ -21,7 +23,10 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
-import type { GraphNode } from '@/types/graph';
+import { deriveEdgeVisual } from '@/lib/relationship-visual';
+import type { GraphNode, RelationshipEdge } from '@/types/graph';
+import type { SnapshotRelationship } from '@/types/snapshot';
+import type { Relationship } from '@/types/relationship';
 
 /** アニメーション時間（ミリ秒） */
 const TRANSITION_DURATION_MS = 300;
@@ -49,12 +54,53 @@ function easeOutCubic(t: number): number {
 }
 
 /**
+ * SnapshotRelationship 配列を RelationshipEdge 配列に変換するヘルパー
+ * - 同一ペア間の並列エッジに対して edgeIndex / totalEdgesInPair を付与する
+ * - SnapshotRelationship は Relationship と共通フィールドを持つため deriveEdgeVisual に渡せる
+ *
+ * @param relationships - スナップショット時点の関係リスト
+ * @returns React Flow 用 RelationshipEdge 配列
+ */
+function snapshotRelationshipsToEdges(relationships: SnapshotRelationship[]): RelationshipEdge[] {
+  // 同一ペア内のエッジ数をカウント（並列エッジのオフセット計算用）
+  const pairCountMap = new Map<string, number>();
+  for (const r of relationships) {
+    const key = [r.sourceId, r.targetId].sort().join(':');
+    pairCountMap.set(key, (pairCountMap.get(key) ?? 0) + 1);
+  }
+  const pairIndexMap = new Map<string, number>();
+
+  return relationships.map((r) => {
+    const key = [r.sourceId, r.targetId].sort().join(':');
+    const edgeIndex = pairIndexMap.get(key) ?? 0;
+    pairIndexMap.set(key, edgeIndex + 1);
+    const totalEdgesInPair = pairCountMap.get(key) ?? 1;
+
+    return {
+      id: r.relationshipId,
+      source: r.sourceId,
+      target: r.targetId,
+      type: 'relationship' as const,
+      data: {
+        edgeType: r.type,
+        label: r.label,
+        symmetric: r.symmetric,
+        // SnapshotRelationship は Relationship と必要フィールドが一致するためキャストして渡す
+        visual: deriveEdgeVisual(r as unknown as Relationship),
+        edgeIndex,
+        totalEdgesInPair,
+      },
+    };
+  });
+}
+
+/**
  * スナップショット間アニメーション遷移フック
  *
  * @returns transitionToSnapshot 関数と isTransitioning フラグ
  */
 export function useSnapshotTransition(): UseSnapshotTransitionResult {
-  const { getNodes, setNodes } = useReactFlow();
+  const { getNodes, setNodes, getEdges, setEdges } = useReactFlow();
 
   const { snapshots, _livePersons, goToSnapshot } = useGraphStore(
     useShallow((state) => ({
@@ -115,6 +161,10 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
       const currentNodes = getNodes();
       const currentNodeMap = new Map(currentNodes.map((n) => [n.id, n]));
 
+      // 現在のエッジを取得（フェードアウト対象の特定用）
+      const currentEdges = getEdges();
+      const currentEdgeMap = new Map(currentEdges.map((e) => [e.id, e]));
+
       // 遷移先スナップショットからターゲットノードを構築する
       const targetNodes: GraphNode[] = targetSnapshot.persons.map((sp) => ({
         id: sp.personId,
@@ -128,6 +178,10 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
       }));
       const targetNodeMap = new Map(targetNodes.map((n) => [n.id, n]));
 
+      // 遷移先スナップショットからターゲットエッジを構築する
+      const targetEdges = snapshotRelationshipsToEdges(targetSnapshot.relationships);
+      const targetEdgeMap = new Map(targetEdges.map((e) => [e.id, e]));
+
       // アニメーション開始位置を記録（移動ノードの補間用）
       const startPositions = new Map(
         currentNodes.map((n) => [n.id, { x: n.position.x, y: n.position.y }])
@@ -140,6 +194,8 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
        * rAF アニメーションループ
        * - ターゲットノード: 出現（opacity 0→1）または位置補間（opacity 1）
        * - 削除ノード: 消滅（opacity 1→0）
+       * - ターゲットエッジ: 出現（opacity 0→1）または維持（opacity 1）
+       * - 削除エッジ: 消滅（opacity 1→0）
        */
       const animate = () => {
         const elapsed = performance.now() - startTime;
@@ -180,6 +236,35 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
 
         setNodes(animatedNodes);
 
+        // エッジアニメーション
+        const animatedEdges: RelationshipEdge[] = [];
+
+        // ターゲットエッジ（維持/追加）: フェードイン
+        for (const targetEdge of targetEdges) {
+          const isNewEdge = !currentEdgeMap.has(targetEdge.id);
+          animatedEdges.push({
+            ...targetEdge,
+            style: {
+              // 新規エッジはフェードイン、既存エッジは不透明のまま
+              opacity: isNewEdge ? easedProgress : 1,
+            },
+          });
+        }
+
+        // 削除エッジ: フェードアウト（ターゲットに存在しないもの）
+        for (const [id, currentEdge] of currentEdgeMap) {
+          if (!targetEdgeMap.has(id)) {
+            animatedEdges.push({
+              ...(currentEdge as RelationshipEdge),
+              style: {
+                opacity: 1 - easedProgress,
+              },
+            });
+          }
+        }
+
+        setEdges(animatedEdges);
+
         // アニメーション継続判定
         if (progress < 1) {
           animationFrameRef.current = requestAnimationFrame(animate);
@@ -203,7 +288,7 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
         timeoutRef.current = null;
       }, TRANSITION_DURATION_MS);
     },
-    [getNodes, setNodes]
+    [getNodes, setNodes, getEdges, setEdges]
   );
 
   return { transitionToSnapshot, isTransitioning };

--- a/src/components/graph/useSnapshotTransition.ts
+++ b/src/components/graph/useSnapshotTransition.ts
@@ -17,7 +17,7 @@
 
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
@@ -73,6 +73,21 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
   // useCallback の依存配列に入れられない値をrefで保持する
   const storeRef = useRef({ snapshots, _livePersons, goToSnapshot });
   storeRef.current = { snapshots, _livePersons, goToSnapshot };
+
+  // アンマウント時に rAF と setTimeout をクリーンアップする
+  // これにより unmount 後に setNodes / setIsTransitioning / goToSnapshot が呼ばれるリークを防ぐ
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
 
   const transitionToSnapshot = useCallback(
     (targetIndex: number) => {

--- a/src/components/graph/useSnapshotTransition.ts
+++ b/src/components/graph/useSnapshotTransition.ts
@@ -1,0 +1,195 @@
+/**
+ * useSnapshotTransition フック
+ *
+ * スナップショット間のアニメーション遷移を管理するフック。
+ * 以下のアニメーションを組み合わせて滑らかなスナップショット切り替えを実現する:
+ * - ノード位置移動: rAF + easeOutCubic によるフレーム補間
+ * - ノード出現（追加）: opacity 0→1 のフェードイン
+ * - ノード消滅（削除）: opacity 1→0 のフェードアウト
+ *
+ * 設計方針:
+ * - アニメーション中はストアの persons/relationships を変更しない
+ *   → useGraphDataSync の useEffect が発火せず、アニメーションと競合しない
+ * - TRANSITION_DURATION_MS 後に setTimeout でストアの goToSnapshot を呼んで状態を確定する
+ * - 連続呼び出しには cancelAnimationFrame + clearTimeout で前のアニメーションをキャンセルする
+ * - ノードの style.opacity を直接操作することでフェードイン/フェードアウトを実現する
+ */
+
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import { useReactFlow } from '@xyflow/react';
+import { useShallow } from 'zustand/react/shallow';
+import { useGraphStore } from '@/stores/useGraphStore';
+import type { GraphNode } from '@/types/graph';
+
+/** アニメーション時間（ミリ秒） */
+const TRANSITION_DURATION_MS = 300;
+
+/**
+ * useSnapshotTransition フックの戻り値型
+ */
+export type UseSnapshotTransitionResult = {
+  /**
+   * アニメーション付きで指定インデックスのスナップショットへ遷移する
+   * @param index - 遷移先スナップショットのインデックス
+   */
+  transitionToSnapshot: (index: number) => void;
+  /** アニメーション遷移中かどうか */
+  isTransitioning: boolean;
+};
+
+/**
+ * イージング関数: easeOutCubic
+ * @param t - 0〜1の値（0: 開始、1: 完了）
+ * @returns イージング後の値（0〜1）
+ */
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+/**
+ * スナップショット間アニメーション遷移フック
+ *
+ * @returns transitionToSnapshot 関数と isTransitioning フラグ
+ */
+export function useSnapshotTransition(): UseSnapshotTransitionResult {
+  const { getNodes, setNodes } = useReactFlow();
+
+  const { snapshots, _livePersons, goToSnapshot } = useGraphStore(
+    useShallow((state) => ({
+      snapshots: state.snapshots,
+      _livePersons: state._livePersons,
+      goToSnapshot: state.goToSnapshot,
+    }))
+  );
+
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  // 前回のアニメーションをキャンセルするためのref
+  const animationFrameRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // useCallback の依存配列に入れられない値をrefで保持する
+  const storeRef = useRef({ snapshots, _livePersons, goToSnapshot });
+  storeRef.current = { snapshots, _livePersons, goToSnapshot };
+
+  const transitionToSnapshot = useCallback(
+    (targetIndex: number) => {
+      const { snapshots: currentSnapshots, _livePersons: livePersons, goToSnapshot: storeGoToSnapshot } =
+        storeRef.current;
+
+      const targetSnapshot = currentSnapshots[targetIndex];
+      // 存在しないインデックスは何もしない（Fail-Fast）
+      if (!targetSnapshot) return;
+
+      // 前回のアニメーションをキャンセル
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      // ライブPersonsのMapを構築（imageDataUrl引き当て用）
+      const livePersonMap = new Map((livePersons ?? []).map((p) => [p.id, p]));
+
+      // 現在のReact Flowノードを取得（アニメーション開始位置）
+      const currentNodes = getNodes();
+      const currentNodeMap = new Map(currentNodes.map((n) => [n.id, n]));
+
+      // 遷移先スナップショットからターゲットノードを構築する
+      const targetNodes: GraphNode[] = targetSnapshot.persons.map((sp) => ({
+        id: sp.personId,
+        type: 'graph' as const,
+        data: {
+          name: sp.name,
+          imageDataUrl: livePersonMap.get(sp.personId)?.imageDataUrl,
+          labels: sp.labels,
+        },
+        position: sp.position ?? { x: 0, y: 0 },
+      }));
+      const targetNodeMap = new Map(targetNodes.map((n) => [n.id, n]));
+
+      // アニメーション開始位置を記録（移動ノードの補間用）
+      const startPositions = new Map(
+        currentNodes.map((n) => [n.id, { x: n.position.x, y: n.position.y }])
+      );
+      const startTime = performance.now();
+
+      setIsTransitioning(true);
+
+      /**
+       * rAF アニメーションループ
+       * - ターゲットノード: 出現（opacity 0→1）または位置補間（opacity 1）
+       * - 削除ノード: 消滅（opacity 1→0）
+       */
+      const animate = () => {
+        const elapsed = performance.now() - startTime;
+        const progress = Math.min(elapsed / TRANSITION_DURATION_MS, 1);
+        const easedProgress = easeOutCubic(progress);
+
+        const animatedNodes: GraphNode[] = [];
+
+        // ターゲットノード（維持/追加）: 位置補間 + フェードイン
+        for (const targetNode of targetNodes) {
+          const startPos = startPositions.get(targetNode.id) ?? targetNode.position;
+          const isNewNode = !currentNodeMap.has(targetNode.id);
+
+          animatedNodes.push({
+            ...targetNode,
+            position: {
+              x: startPos.x + (targetNode.position.x - startPos.x) * easedProgress,
+              y: startPos.y + (targetNode.position.y - startPos.y) * easedProgress,
+            },
+            style: {
+              // 新規ノードはフェードイン、既存ノードは不透明のまま
+              opacity: isNewNode ? easedProgress : 1,
+            },
+          });
+        }
+
+        // 削除ノード: フェードアウト（ターゲットに存在しないもの）
+        for (const [id, currentNode] of currentNodeMap) {
+          if (!targetNodeMap.has(id)) {
+            animatedNodes.push({
+              ...(currentNode as GraphNode),
+              style: {
+                opacity: 1 - easedProgress,
+              },
+            });
+          }
+        }
+
+        setNodes(animatedNodes);
+
+        // アニメーション継続判定
+        if (progress < 1) {
+          animationFrameRef.current = requestAnimationFrame(animate);
+        } else {
+          animationFrameRef.current = null;
+        }
+      };
+
+      animationFrameRef.current = requestAnimationFrame(animate);
+
+      // TRANSITION_DURATION_MS 後にストア状態を確定させる（authoritative trigger）
+      timeoutRef.current = setTimeout(() => {
+        // 万が一rAFが残っていればキャンセル
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current);
+          animationFrameRef.current = null;
+        }
+        // ストアのpersons/relationshipsを更新してuseGraphDataSyncに再同期させる
+        storeGoToSnapshot(targetIndex);
+        setIsTransitioning(false);
+        timeoutRef.current = null;
+      }, TRANSITION_DURATION_MS);
+    },
+    [getNodes, setNodes]
+  );
+
+  return { transitionToSnapshot, isTransitioning };
+}

--- a/src/components/graph/useTimelinePlayback.test.ts
+++ b/src/components/graph/useTimelinePlayback.test.ts
@@ -1,0 +1,182 @@
+/**
+ * useTimelinePlayback フックのユニットテスト
+ *
+ * 自動再生タイマーの動作を検証する。
+ * fake timers（vi.useFakeTimers）でsetIntervalを模擬する。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTimelinePlayback } from './useTimelinePlayback';
+import { useGraphStore } from '@/stores/useGraphStore';
+
+// useGraphStoreをモック化して制御しやすくする
+vi.mock('@/stores/useGraphStore');
+
+const mockUseGraphStore = vi.mocked(useGraphStore);
+
+/**
+ * デフォルトのストア状態を返すモックを設定するヘルパー
+ */
+function setupStoreMock(overrides: {
+  snapshots?: unknown[];
+  isPlaying?: boolean;
+  playbackSpeed?: number;
+  activeSnapshotIndex?: number | null;
+  setPlaying?: ReturnType<typeof vi.fn>;
+}) {
+  const setPlaying = overrides.setPlaying ?? vi.fn();
+  mockUseGraphStore.mockReturnValue({
+    snapshots: overrides.snapshots ?? [{ id: 'snap-1', label: '第1話' }, { id: 'snap-2', label: '第2話' }],
+    isPlaying: overrides.isPlaying ?? false,
+    playbackSpeed: overrides.playbackSpeed ?? 2000,
+    activeSnapshotIndex: overrides.activeSnapshotIndex ?? null,
+    setPlaying,
+  } as ReturnType<typeof useGraphStore>);
+  return { setPlaying };
+}
+
+describe('useTimelinePlayback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('isPlaying=false のときタイマーは動作しない', () => {
+    // GIVEN: 再生停止状態
+    const transitionToSnapshot = vi.fn();
+    setupStoreMock({ isPlaying: false });
+
+    // WHEN: フックをマウント
+    renderHook(() => useTimelinePlayback(transitionToSnapshot, false));
+
+    // THEN: インターバルが経過しても遷移は呼ばれない
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(transitionToSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('isPlaying=true でタイマー起動し playbackSpeed 間隔で transitionToSnapshot が呼ばれる', () => {
+    // GIVEN: ライブ状態（activeSnapshotIndex=null）から再生開始
+    const transitionToSnapshot = vi.fn();
+    setupStoreMock({
+      isPlaying: true,
+      playbackSpeed: 1000,
+      activeSnapshotIndex: null,
+      snapshots: [{ id: 'snap-1' }, { id: 'snap-2' }],
+    });
+
+    // WHEN
+    renderHook(() => useTimelinePlayback(transitionToSnapshot, false));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // THEN: ライブ状態からは最初のスナップショット(index=0)へ遷移
+    expect(transitionToSnapshot).toHaveBeenCalledTimes(1);
+    expect(transitionToSnapshot).toHaveBeenCalledWith(0);
+  });
+
+  it('activeSnapshotIndex=0 のとき次のスナップショット(index=1)へ遷移する', () => {
+    // GIVEN: 最初のスナップショットを表示中
+    const transitionToSnapshot = vi.fn();
+    setupStoreMock({
+      isPlaying: true,
+      playbackSpeed: 1000,
+      activeSnapshotIndex: 0,
+      snapshots: [{ id: 'snap-1' }, { id: 'snap-2' }, { id: 'snap-3' }],
+    });
+
+    // WHEN
+    renderHook(() => useTimelinePlayback(transitionToSnapshot, false));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // THEN
+    expect(transitionToSnapshot).toHaveBeenCalledWith(1);
+  });
+
+  it('最後のスナップショットのとき setPlaying(false) が呼ばれ自動停止する', () => {
+    // GIVEN: 最後のスナップショット（index=1、スナップショット数=2）を表示中
+    const transitionToSnapshot = vi.fn();
+    const { setPlaying } = setupStoreMock({
+      isPlaying: true,
+      playbackSpeed: 1000,
+      activeSnapshotIndex: 1,
+      snapshots: [{ id: 'snap-1' }, { id: 'snap-2' }],
+    });
+
+    // WHEN
+    renderHook(() => useTimelinePlayback(transitionToSnapshot, false));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // THEN: 遷移は呼ばれず、再生停止のみ
+    expect(transitionToSnapshot).not.toHaveBeenCalled();
+    expect(setPlaying).toHaveBeenCalledWith(false);
+  });
+
+  it('isTransitioning=true のときはticksをスキップする', () => {
+    // GIVEN: アニメーション遷移中
+    const transitionToSnapshot = vi.fn();
+    setupStoreMock({
+      isPlaying: true,
+      playbackSpeed: 1000,
+      activeSnapshotIndex: 0,
+      snapshots: [{ id: 'snap-1' }, { id: 'snap-2' }],
+    });
+
+    // WHEN
+    renderHook(() => useTimelinePlayback(transitionToSnapshot, true));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // THEN: スキップされるため遷移は呼ばれない
+    expect(transitionToSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('isPlaying が false になるとタイマーがクリアされる', () => {
+    // GIVEN: 再生中
+    const transitionToSnapshot = vi.fn();
+    setupStoreMock({
+      isPlaying: true,
+      playbackSpeed: 1000,
+      activeSnapshotIndex: null,
+      snapshots: [{ id: 'snap-1' }, { id: 'snap-2' }],
+    });
+
+    const { rerender } = renderHook(
+      ({ isTransitioning }: { isTransitioning: boolean }) =>
+        useTimelinePlayback(transitionToSnapshot, isTransitioning),
+      { initialProps: { isTransitioning: false } }
+    );
+
+    // WHEN: isPlaying を false に変更（ストアを更新）
+    setupStoreMock({
+      isPlaying: false,
+      playbackSpeed: 1000,
+      activeSnapshotIndex: null,
+      snapshots: [{ id: 'snap-1' }, { id: 'snap-2' }],
+    });
+    rerender({ isTransitioning: false });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    // THEN: タイマーが停止したため遷移は呼ばれない
+    expect(transitionToSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/graph/useTimelinePlayback.test.ts
+++ b/src/components/graph/useTimelinePlayback.test.ts
@@ -23,6 +23,7 @@ function setupStoreMock(overrides: {
   isPlaying?: boolean;
   playbackSpeed?: number;
   activeSnapshotIndex?: number | null;
+  timelineMode?: boolean;
   setPlaying?: ReturnType<typeof vi.fn>;
 }) {
   const setPlaying = overrides.setPlaying ?? vi.fn();
@@ -31,6 +32,8 @@ function setupStoreMock(overrides: {
     isPlaying: overrides.isPlaying ?? false,
     playbackSpeed: overrides.playbackSpeed ?? 2000,
     activeSnapshotIndex: overrides.activeSnapshotIndex ?? null,
+    // タイムラインモード外では再生タイマーが起動しないため、再生テストでは true にする
+    timelineMode: overrides.timelineMode ?? true,
     setPlaying,
   } as ReturnType<typeof useGraphStore>);
   return { setPlaying };

--- a/src/components/graph/useTimelinePlayback.ts
+++ b/src/components/graph/useTimelinePlayback.ts
@@ -27,15 +27,24 @@ export function useTimelinePlayback(
   transitionToSnapshot: (index: number) => void,
   isTransitioning: boolean
 ): void {
-  const { snapshots, isPlaying, playbackSpeed, activeSnapshotIndex, setPlaying } = useGraphStore(
+  const { snapshots, isPlaying, playbackSpeed, activeSnapshotIndex, timelineMode, setPlaying } = useGraphStore(
     useShallow((state) => ({
       snapshots: state.snapshots,
       isPlaying: state.isPlaying,
       playbackSpeed: state.playbackSpeed,
       activeSnapshotIndex: state.activeSnapshotIndex,
+      timelineMode: state.timelineMode,
       setPlaying: state.setPlaying,
     }))
   );
+
+  // タイムラインモード外で isPlaying が true になった場合は即座に停止する（防御的ガード）
+  // timelineMode=false のとき goToSnapshot が無効化されるため、再生を続けると UI とストアが不整合になる
+  useEffect(() => {
+    if (!timelineMode && isPlaying) {
+      setPlaying(false);
+    }
+  }, [timelineMode, isPlaying, setPlaying]);
 
   // 最新の値をrefで保持してsetInterval内でも参照できるようにする
   const isTransitioningRef = useRef(isTransitioning);
@@ -52,8 +61,8 @@ export function useTimelinePlayback(
   setPlayingRef.current = setPlaying;
 
   useEffect(() => {
-    // isPlaying=false のときはタイマーを起動しない
-    if (!isPlaying) return;
+    // isPlaying=false またはタイムラインモード外のときはタイマーを起動しない
+    if (!isPlaying || !timelineMode) return;
 
     const intervalId = setInterval(() => {
       // アニメーション遷移中はスキップ（前のアニメーションが完了するまで待機）
@@ -80,9 +89,9 @@ export function useTimelinePlayback(
       }
     }, playbackSpeed);
 
-    // クリーンアップ: isPlaying が false になったとき、または playbackSpeed が変わったときにタイマーを停止
+    // クリーンアップ: isPlaying/timelineMode が false になったとき、または playbackSpeed が変わったときにタイマーを停止
     return () => {
       clearInterval(intervalId);
     };
-  }, [isPlaying, playbackSpeed]);
+  }, [isPlaying, playbackSpeed, timelineMode]);
 }

--- a/src/components/graph/useTimelinePlayback.ts
+++ b/src/components/graph/useTimelinePlayback.ts
@@ -1,0 +1,88 @@
+/**
+ * useTimelinePlayback フック
+ *
+ * タイムラインの自動再生タイマーを管理するフック。
+ * setInterval でスナップショットを順次切り替え、最後のスナップショットで自動停止する。
+ *
+ * 設計方針:
+ * - isPlaying が true のときのみ setInterval を起動する
+ * - アニメーション遷移中（isTransitioning=true）のtickはスキップして前のアニメーションが
+ *   完了するまで待機する
+ * - クリーンアップで clearInterval を確実に呼ぶ
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useGraphStore } from '@/stores/useGraphStore';
+
+/**
+ * タイムライン自動再生タイマーを管理するフック
+ *
+ * @param transitionToSnapshot - アニメーション付きでスナップショットに遷移する関数
+ * @param isTransitioning - アニメーション遷移中かどうか
+ */
+export function useTimelinePlayback(
+  transitionToSnapshot: (index: number) => void,
+  isTransitioning: boolean
+): void {
+  const { snapshots, isPlaying, playbackSpeed, activeSnapshotIndex, setPlaying } = useGraphStore(
+    useShallow((state) => ({
+      snapshots: state.snapshots,
+      isPlaying: state.isPlaying,
+      playbackSpeed: state.playbackSpeed,
+      activeSnapshotIndex: state.activeSnapshotIndex,
+      setPlaying: state.setPlaying,
+    }))
+  );
+
+  // 最新の値をrefで保持してsetInterval内でも参照できるようにする
+  const isTransitioningRef = useRef(isTransitioning);
+  const activeSnapshotIndexRef = useRef(activeSnapshotIndex);
+  const snapshotsLengthRef = useRef(snapshots.length);
+  const transitionToSnapshotRef = useRef(transitionToSnapshot);
+  const setPlayingRef = useRef(setPlaying);
+
+  // refを最新値で更新する
+  isTransitioningRef.current = isTransitioning;
+  activeSnapshotIndexRef.current = activeSnapshotIndex;
+  snapshotsLengthRef.current = snapshots.length;
+  transitionToSnapshotRef.current = transitionToSnapshot;
+  setPlayingRef.current = setPlaying;
+
+  useEffect(() => {
+    // isPlaying=false のときはタイマーを起動しない
+    if (!isPlaying) return;
+
+    const intervalId = setInterval(() => {
+      // アニメーション遷移中はスキップ（前のアニメーションが完了するまで待機）
+      if (isTransitioningRef.current) return;
+
+      const currentIndex = activeSnapshotIndexRef.current;
+      const totalSnapshots = snapshotsLengthRef.current;
+
+      if (totalSnapshots === 0) {
+        // スナップショットがない場合は停止
+        setPlayingRef.current(false);
+        return;
+      }
+
+      if (currentIndex === null) {
+        // ライブ状態からは最初のスナップショットへ遷移
+        transitionToSnapshotRef.current(0);
+      } else if (currentIndex < totalSnapshots - 1) {
+        // 次のスナップショットへ遷移
+        transitionToSnapshotRef.current(currentIndex + 1);
+      } else {
+        // 最後のスナップショットに達したら自動停止
+        setPlayingRef.current(false);
+      }
+    }, playbackSpeed);
+
+    // クリーンアップ: isPlaying が false になったとき、または playbackSpeed が変わったときにタイマーを停止
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [isPlaying, playbackSpeed]);
+}

--- a/src/lib/snapshot-diff.test.ts
+++ b/src/lib/snapshot-diff.test.ts
@@ -1,0 +1,326 @@
+/**
+ * snapshot-diff.ts のユニットテスト
+ *
+ * スナップショット間のdiff計算ロジックを検証する。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeSnapshotDiff } from './snapshot-diff';
+import type { Snapshot, SnapshotPerson, SnapshotRelationship } from '@/types/snapshot';
+
+// テスト用のデフォルトRelationshipNarrative
+const defaultNarrative = {
+  summary: '',
+  notes: '',
+  turningPoints: [],
+};
+
+// テスト用のデフォルトRelationshipProperties
+const defaultProperties = {
+  startDate: null,
+  endDate: null,
+  strength: null,
+  customProperties: {},
+};
+
+/**
+ * テスト用スナップショット人物を生成するヘルパー
+ */
+function makePerson(
+  personId: string,
+  position?: { x: number; y: number }
+): SnapshotPerson {
+  return {
+    personId,
+    name: `人物${personId}`,
+    labels: [],
+    position,
+    properties: {},
+  };
+}
+
+/**
+ * テスト用スナップショット関係を生成するヘルパー
+ */
+function makeRelationship(
+  relationshipId: string,
+  sourceId: string,
+  targetId: string,
+  overrides?: Partial<SnapshotRelationship>
+): SnapshotRelationship {
+  return {
+    relationshipId,
+    type: '友人',
+    sourceId,
+    targetId,
+    label: null,
+    symmetric: false,
+    tags: [],
+    colorOverride: null,
+    properties: defaultProperties,
+    narrative: defaultNarrative,
+    ...overrides,
+  };
+}
+
+/**
+ * テスト用スナップショットを生成するヘルパー
+ */
+function makeSnapshot(
+  persons: SnapshotPerson[],
+  relationships: SnapshotRelationship[]
+): Snapshot {
+  return {
+    id: 'snap-test',
+    label: 'テスト',
+    persons,
+    relationships,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('computeSnapshotDiff', () => {
+  describe('人物のdiff計算', () => {
+    it('同一スナップショット間では全てunchangedになる', () => {
+      // GIVEN: 同一人物・同一位置のスナップショット
+      const personA = makePerson('person-1', { x: 100, y: 200 });
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personA], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.unchanged).toHaveLength(1);
+      expect(diff.persons.added).toHaveLength(0);
+      expect(diff.persons.removed).toHaveLength(0);
+      expect(diff.persons.moved).toHaveLength(0);
+    });
+
+    it('Bにのみ存在する人物はaddedに分類される', () => {
+      // GIVEN: AにはpersonAのみ、BにはpersonAとpersonBが存在
+      const personA = makePerson('person-1', { x: 100, y: 200 });
+      const personB = makePerson('person-2', { x: 300, y: 400 });
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personA, personB], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.added).toHaveLength(1);
+      expect(diff.persons.added[0].personId).toBe('person-2');
+      expect(diff.persons.unchanged).toHaveLength(1);
+    });
+
+    it('Aにのみ存在する人物はremovedに分類される', () => {
+      // GIVEN: AにはpersonAとpersonBが存在、BにはpersonAのみ
+      const personA = makePerson('person-1', { x: 100, y: 200 });
+      const personB = makePerson('person-2', { x: 300, y: 400 });
+      const snapshotA = makeSnapshot([personA, personB], []);
+      const snapshotB = makeSnapshot([personA], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.removed).toHaveLength(1);
+      expect(diff.persons.removed[0].personId).toBe('person-2');
+      expect(diff.persons.unchanged).toHaveLength(1);
+    });
+
+    it('位置が変化した人物はmovedに分類される', () => {
+      // GIVEN: 同一人物だが位置が異なるスナップショット
+      const personA = makePerson('person-1', { x: 100, y: 200 });
+      const personB = makePerson('person-1', { x: 500, y: 600 });
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personB], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.moved).toHaveLength(1);
+      expect(diff.persons.moved[0].personId).toBe('person-1');
+      expect(diff.persons.moved[0].from).toEqual({ x: 100, y: 200 });
+      expect(diff.persons.moved[0].to).toEqual({ x: 500, y: 600 });
+      expect(diff.persons.unchanged).toHaveLength(0);
+    });
+
+    it('positionがundefinedの人物はデフォルト位置(0,0)として扱われる', () => {
+      // GIVEN: positionなしの同一人物
+      const personNoPos = makePerson('person-1'); // positionなし
+      const snapshotA = makeSnapshot([personNoPos], []);
+      const snapshotB = makeSnapshot([personNoPos], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN: 両方undefined → 位置変化なし → unchanged
+      expect(diff.persons.unchanged).toHaveLength(1);
+      expect(diff.persons.moved).toHaveLength(0);
+    });
+
+    it('fromがundefined, toが(100,200)の場合はmovedに分類される', () => {
+      // GIVEN: Aはpositionなし、Bは位置あり
+      const personA = makePerson('person-1'); // positionなし → デフォルト(0,0)
+      const personB = makePerson('person-1', { x: 100, y: 200 });
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personB], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN: from=(0,0), to=(100,200) → moved
+      expect(diff.persons.moved).toHaveLength(1);
+      expect(diff.persons.moved[0].from).toEqual({ x: 0, y: 0 });
+      expect(diff.persons.moved[0].to).toEqual({ x: 100, y: 200 });
+    });
+
+    it('追加・削除・移動・変化なしが同時に発生する複合ケース', () => {
+      // GIVEN:
+      // - person-1: A/B両方で同じ位置 → unchanged
+      // - person-2: Aのみ存在 → removed
+      // - person-3: Bのみ存在 → added
+      // - person-4: A/B両方だが位置が違う → moved
+      const personA1 = makePerson('person-1', { x: 0, y: 0 });
+      const personA2 = makePerson('person-2', { x: 100, y: 0 });
+      const personA4 = makePerson('person-4', { x: 200, y: 0 });
+      const personB1 = makePerson('person-1', { x: 0, y: 0 });
+      const personB3 = makePerson('person-3', { x: 0, y: 100 });
+      const personB4 = makePerson('person-4', { x: 999, y: 999 });
+
+      const snapshotA = makeSnapshot([personA1, personA2, personA4], []);
+      const snapshotB = makeSnapshot([personB1, personB3, personB4], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.unchanged.map((p) => p.personId)).toEqual(['person-1']);
+      expect(diff.persons.removed.map((p) => p.personId)).toEqual(['person-2']);
+      expect(diff.persons.added.map((p) => p.personId)).toEqual(['person-3']);
+      expect(diff.persons.moved.map((p) => p.personId)).toEqual(['person-4']);
+    });
+
+    it('空スナップショット同士ではすべて空になる', () => {
+      // GIVEN
+      const snapshotA = makeSnapshot([], []);
+      const snapshotB = makeSnapshot([], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.added).toHaveLength(0);
+      expect(diff.persons.removed).toHaveLength(0);
+      expect(diff.persons.moved).toHaveLength(0);
+      expect(diff.persons.unchanged).toHaveLength(0);
+    });
+  });
+
+  describe('関係のdiff計算', () => {
+    it('同一スナップショット間では全てunchangedになる', () => {
+      // GIVEN
+      const relA = makeRelationship('rel-1', 'person-1', 'person-2');
+      const snapshotA = makeSnapshot([], [relA]);
+      const snapshotB = makeSnapshot([], [relA]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.relationships.unchanged).toHaveLength(1);
+      expect(diff.relationships.added).toHaveLength(0);
+      expect(diff.relationships.removed).toHaveLength(0);
+      expect(diff.relationships.changed).toHaveLength(0);
+    });
+
+    it('Bにのみ存在する関係はaddedに分類される', () => {
+      // GIVEN
+      const relA = makeRelationship('rel-1', 'person-1', 'person-2');
+      const relB = makeRelationship('rel-2', 'person-1', 'person-3');
+      const snapshotA = makeSnapshot([], [relA]);
+      const snapshotB = makeSnapshot([], [relA, relB]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.relationships.added).toHaveLength(1);
+      expect(diff.relationships.added[0].relationshipId).toBe('rel-2');
+    });
+
+    it('Aにのみ存在する関係はremovedに分類される', () => {
+      // GIVEN
+      const relA = makeRelationship('rel-1', 'person-1', 'person-2');
+      const relB = makeRelationship('rel-2', 'person-1', 'person-3');
+      const snapshotA = makeSnapshot([], [relA, relB]);
+      const snapshotB = makeSnapshot([], [relA]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.relationships.removed).toHaveLength(1);
+      expect(diff.relationships.removed[0].relationshipId).toBe('rel-2');
+    });
+
+    it('属性（label）が変化した関係はchangedに分類される', () => {
+      // GIVEN: 同一IDだがlabelが異なる
+      const relA = makeRelationship('rel-1', 'person-1', 'person-2', { label: '旧ラベル' });
+      const relB = makeRelationship('rel-1', 'person-1', 'person-2', { label: '新ラベル' });
+      const snapshotA = makeSnapshot([], [relA]);
+      const snapshotB = makeSnapshot([], [relB]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.relationships.changed).toHaveLength(1);
+      expect(diff.relationships.changed[0].relationshipId).toBe('rel-1');
+      expect(diff.relationships.changed[0].from.label).toBe('旧ラベル');
+      expect(diff.relationships.changed[0].to.label).toBe('新ラベル');
+    });
+
+    it('属性（colorOverride）が変化した関係はchangedに分類される', () => {
+      // GIVEN
+      const relA = makeRelationship('rel-1', 'person-1', 'person-2', { colorOverride: null });
+      const relB = makeRelationship('rel-1', 'person-1', 'person-2', { colorOverride: '#ff0000' });
+      const snapshotA = makeSnapshot([], [relA]);
+      const snapshotB = makeSnapshot([], [relB]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.relationships.changed).toHaveLength(1);
+    });
+
+    it('関係の追加・削除・変化・変化なしが同時に発生する複合ケース', () => {
+      // GIVEN:
+      // - rel-1: A/B両方で同じ属性 → unchanged
+      // - rel-2: Aのみ → removed
+      // - rel-3: Bのみ → added
+      // - rel-4: A/B両方だがlabelが違う → changed
+      const rel1A = makeRelationship('rel-1', 'p1', 'p2');
+      const rel2A = makeRelationship('rel-2', 'p1', 'p3');
+      const rel4A = makeRelationship('rel-4', 'p1', 'p4', { label: '旧' });
+      const rel1B = makeRelationship('rel-1', 'p1', 'p2');
+      const rel3B = makeRelationship('rel-3', 'p2', 'p3');
+      const rel4B = makeRelationship('rel-4', 'p1', 'p4', { label: '新' });
+
+      const snapshotA = makeSnapshot([], [rel1A, rel2A, rel4A]);
+      const snapshotB = makeSnapshot([], [rel1B, rel3B, rel4B]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.relationships.unchanged.map((r) => r.relationshipId)).toEqual(['rel-1']);
+      expect(diff.relationships.removed.map((r) => r.relationshipId)).toEqual(['rel-2']);
+      expect(diff.relationships.added.map((r) => r.relationshipId)).toEqual(['rel-3']);
+      expect(diff.relationships.changed.map((r) => r.relationshipId)).toEqual(['rel-4']);
+    });
+  });
+});

--- a/src/lib/snapshot-diff.test.ts
+++ b/src/lib/snapshot-diff.test.ts
@@ -217,6 +217,91 @@ describe('computeSnapshotDiff', () => {
       expect(diff.persons.moved).toHaveLength(0);
       expect(diff.persons.unchanged).toHaveLength(0);
     });
+
+    it('同じ位置でも名前が変化した人物はchangedに分類される', () => {
+      // GIVEN: personIdと位置は同じだが名前が異なる
+      const personA: SnapshotPerson = {
+        personId: 'person-1',
+        name: '旧名前',
+        labels: [],
+        position: { x: 100, y: 200 },
+        properties: {},
+      };
+      const personB: SnapshotPerson = {
+        personId: 'person-1',
+        name: '新名前',
+        labels: [],
+        position: { x: 100, y: 200 },
+        properties: {},
+      };
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personB], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN: 位置は同じだが名前が変化 → changed に分類
+      expect(diff.persons.changed).toHaveLength(1);
+      expect(diff.persons.changed[0].personId).toBe('person-1');
+      expect(diff.persons.changed[0].name).toBe('新名前');
+      expect(diff.persons.unchanged).toHaveLength(0);
+      expect(diff.persons.moved).toHaveLength(0);
+    });
+
+    it('同じ位置でもラベルが変化した人物はchangedに分類される', () => {
+      // GIVEN
+      const personA: SnapshotPerson = {
+        personId: 'person-1',
+        name: '織田信長',
+        labels: ['武将'],
+        position: { x: 100, y: 200 },
+        properties: {},
+      };
+      const personB: SnapshotPerson = {
+        personId: 'person-1',
+        name: '織田信長',
+        labels: ['武将', '天下人'],
+        position: { x: 100, y: 200 },
+        properties: {},
+      };
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personB], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN
+      expect(diff.persons.changed).toHaveLength(1);
+      expect(diff.persons.unchanged).toHaveLength(0);
+    });
+
+    it('位置と属性の両方が変化した人物はmovedに分類される（位置変化を優先）', () => {
+      // GIVEN: 位置も名前も変化
+      const personA: SnapshotPerson = {
+        personId: 'person-1',
+        name: '旧名前',
+        labels: [],
+        position: { x: 100, y: 200 },
+        properties: {},
+      };
+      const personB: SnapshotPerson = {
+        personId: 'person-1',
+        name: '新名前',
+        labels: [],
+        position: { x: 500, y: 600 },
+        properties: {},
+      };
+      const snapshotA = makeSnapshot([personA], []);
+      const snapshotB = makeSnapshot([personB], []);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN: 位置変化を優先してmovedに分類
+      expect(diff.persons.moved).toHaveLength(1);
+      expect(diff.persons.changed).toHaveLength(0);
+      expect(diff.persons.unchanged).toHaveLength(0);
+    });
   });
 
   describe('関係のdiff計算', () => {
@@ -264,6 +349,23 @@ describe('computeSnapshotDiff', () => {
       // THEN
       expect(diff.relationships.removed).toHaveLength(1);
       expect(diff.relationships.removed[0].relationshipId).toBe('rel-2');
+    });
+
+    it('接続先（sourceId/targetId）が変化した関係はchangedに分類される', () => {
+      // GIVEN: 同一IDだがtargetIdが異なる（エッジの張り替え）
+      const relA = makeRelationship('rel-1', 'person-1', 'person-2');
+      const relB = makeRelationship('rel-1', 'person-1', 'person-3');
+      const snapshotA = makeSnapshot([], [relA]);
+      const snapshotB = makeSnapshot([], [relB]);
+
+      // WHEN
+      const diff = computeSnapshotDiff(snapshotA, snapshotB);
+
+      // THEN: 接続先が変化したのでchangedに分類
+      expect(diff.relationships.changed).toHaveLength(1);
+      expect(diff.relationships.changed[0].relationshipId).toBe('rel-1');
+      expect(diff.relationships.changed[0].from.targetId).toBe('person-2');
+      expect(diff.relationships.changed[0].to.targetId).toBe('person-3');
     });
 
     it('属性（label）が変化した関係はchangedに分類される', () => {

--- a/src/lib/snapshot-diff.ts
+++ b/src/lib/snapshot-diff.ts
@@ -46,8 +46,10 @@ export type SnapshotDiff = {
     added: SnapshotPerson[];
     /** Aにのみ存在する人物（消滅） */
     removed: SnapshotPerson[];
-    /** A/B両方に存在し位置が変化した人物 */
+    /** A/B両方に存在し位置が変化した人物（属性変化も同時に起きている場合を含む） */
     moved: MovedPerson[];
+    /** A/B両方に存在し位置は同じだが属性（name/labels/properties）が変化した人物 */
+    changed: SnapshotPerson[];
     /** A/B両方に存在し変化がない人物 */
     unchanged: SnapshotPerson[];
   };
@@ -84,12 +86,28 @@ function isSamePosition(
 }
 
 /**
+ * 人物の属性（name/labels/properties）が変化しているかどうかをJSON文字列比較で判定する
+ * - position は別途 isSamePosition で比較するため、ここでは比較しない
+ */
+function isPersonAttributeChanged(a: SnapshotPerson, b: SnapshotPerson): boolean {
+  const pickComparableFields = (p: SnapshotPerson) => ({
+    name: p.name,
+    labels: p.labels,
+    properties: p.properties,
+  });
+  return JSON.stringify(pickComparableFields(a)) !== JSON.stringify(pickComparableFields(b));
+}
+
+/**
  * 関係の属性が変化しているかどうかをJSON文字列比較で判定する
+ * - sourceId/targetId の接続先変更も変化として検出する
  * - label, symmetric, colorOverride, tags, type, properties を対象とする
  * - narrative は変化検出対象に含めない（narrative変化はアニメーション対象外）
  */
 function isRelationshipChanged(a: SnapshotRelationship, b: SnapshotRelationship): boolean {
   const pickComparableFields = (r: SnapshotRelationship) => ({
+    sourceId: r.sourceId,
+    targetId: r.targetId,
     type: r.type,
     label: r.label,
     symmetric: r.symmetric,
@@ -119,21 +137,25 @@ export function computeSnapshotDiff(from: Snapshot, to: Snapshot): SnapshotDiff 
   const addedPersons: SnapshotPerson[] = [];
   const removedPersons: SnapshotPerson[] = [];
   const movedPersons: MovedPerson[] = [];
+  const changedPersons: SnapshotPerson[] = [];
   const unchangedPersons: SnapshotPerson[] = [];
 
-  // toを走査: added or moved or unchanged
+  // toを走査: added or moved or changed or unchanged
   for (const [personId, toPerson] of toPersonMap) {
     const fromPerson = fromPersonMap.get(personId);
     if (fromPerson === undefined) {
       // Bにのみ存在 → added
       addedPersons.push(toPerson);
     } else if (!isSamePosition(fromPerson.position, toPerson.position)) {
-      // 位置が変化 → moved
+      // 位置が変化 → moved（属性変化も同時に起きていても位置変化を優先）
       movedPersons.push({
         personId,
         from: resolvePosition(fromPerson.position),
         to: resolvePosition(toPerson.position),
       });
+    } else if (isPersonAttributeChanged(fromPerson, toPerson)) {
+      // 位置は同じだが属性が変化 → changed
+      changedPersons.push(toPerson);
     } else {
       // 変化なし → unchanged
       unchangedPersons.push(toPerson);
@@ -187,6 +209,7 @@ export function computeSnapshotDiff(from: Snapshot, to: Snapshot): SnapshotDiff 
       added: addedPersons,
       removed: removedPersons,
       moved: movedPersons,
+      changed: changedPersons,
       unchanged: unchangedPersons,
     },
     relationships: {

--- a/src/lib/snapshot-diff.ts
+++ b/src/lib/snapshot-diff.ts
@@ -1,0 +1,199 @@
+/**
+ * スナップショット間のdiff計算モジュール
+ *
+ * スナップショットAからBへの遷移で発生する変化を計算する純粋関数を提供する。
+ * アニメーション遷移の制御（出現・消滅・移動）に使用する。
+ *
+ * 設計方針:
+ * - personId / relationshipId ベースでA/Bを照合する
+ * - positionがundefinedの場合はデフォルト位置(0,0)として扱う
+ * - 関係の属性変化はJSON文字列比較で検出する（シンプルさ優先）
+ */
+
+import type { Snapshot, SnapshotPerson, SnapshotRelationship } from '@/types/snapshot';
+
+/**
+ * 人物の移動情報
+ */
+type MovedPerson = {
+  /** 対象人物のID */
+  personId: string;
+  /** 移動前の位置 */
+  from: { x: number; y: number };
+  /** 移動後の位置 */
+  to: { x: number; y: number };
+};
+
+/**
+ * 関係の属性変化情報
+ */
+type ChangedRelationship = {
+  /** 対象関係のID */
+  relationshipId: string;
+  /** 変化前の状態 */
+  from: SnapshotRelationship;
+  /** 変化後の状態 */
+  to: SnapshotRelationship;
+};
+
+/**
+ * スナップショット間のdiff結果
+ */
+export type SnapshotDiff = {
+  /** 人物のdiff */
+  persons: {
+    /** Bにのみ存在する人物（出現） */
+    added: SnapshotPerson[];
+    /** Aにのみ存在する人物（消滅） */
+    removed: SnapshotPerson[];
+    /** A/B両方に存在し位置が変化した人物 */
+    moved: MovedPerson[];
+    /** A/B両方に存在し変化がない人物 */
+    unchanged: SnapshotPerson[];
+  };
+  /** 関係のdiff */
+  relationships: {
+    /** Bにのみ存在する関係（出現） */
+    added: SnapshotRelationship[];
+    /** Aにのみ存在する関係（消滅） */
+    removed: SnapshotRelationship[];
+    /** 同一IDで属性が変化した関係 */
+    changed: ChangedRelationship[];
+    /** A/B両方に存在し変化がない関係 */
+    unchanged: SnapshotRelationship[];
+  };
+};
+
+/**
+ * positionがundefinedの場合にデフォルト位置を返す
+ */
+function resolvePosition(position?: { x: number; y: number }): { x: number; y: number } {
+  return position ?? { x: 0, y: 0 };
+}
+
+/**
+ * 2つの位置が同一かどうかを判定する
+ */
+function isSamePosition(
+  a: { x: number; y: number } | undefined,
+  b: { x: number; y: number } | undefined
+): boolean {
+  const posA = resolvePosition(a);
+  const posB = resolvePosition(b);
+  return posA.x === posB.x && posA.y === posB.y;
+}
+
+/**
+ * 関係の属性が変化しているかどうかをJSON文字列比較で判定する
+ * - label, symmetric, colorOverride, tags, type, properties を対象とする
+ * - narrative は変化検出対象に含めない（narrative変化はアニメーション対象外）
+ */
+function isRelationshipChanged(a: SnapshotRelationship, b: SnapshotRelationship): boolean {
+  const pickComparableFields = (r: SnapshotRelationship) => ({
+    type: r.type,
+    label: r.label,
+    symmetric: r.symmetric,
+    tags: r.tags,
+    colorOverride: r.colorOverride,
+    properties: r.properties,
+  });
+  return JSON.stringify(pickComparableFields(a)) !== JSON.stringify(pickComparableFields(b));
+}
+
+/**
+ * スナップショットAからBへのdiffを計算する
+ *
+ * @param from - 遷移元のスナップショット
+ * @param to - 遷移先のスナップショット
+ * @returns diff結果（追加・削除・移動・変化なし）
+ */
+export function computeSnapshotDiff(from: Snapshot, to: Snapshot): SnapshotDiff {
+  // === 人物のdiff計算 ===
+  const fromPersonMap = new Map<string, SnapshotPerson>(
+    from.persons.map((p) => [p.personId, p])
+  );
+  const toPersonMap = new Map<string, SnapshotPerson>(
+    to.persons.map((p) => [p.personId, p])
+  );
+
+  const addedPersons: SnapshotPerson[] = [];
+  const removedPersons: SnapshotPerson[] = [];
+  const movedPersons: MovedPerson[] = [];
+  const unchangedPersons: SnapshotPerson[] = [];
+
+  // toを走査: added or moved or unchanged
+  for (const [personId, toPerson] of toPersonMap) {
+    const fromPerson = fromPersonMap.get(personId);
+    if (fromPerson === undefined) {
+      // Bにのみ存在 → added
+      addedPersons.push(toPerson);
+    } else if (!isSamePosition(fromPerson.position, toPerson.position)) {
+      // 位置が変化 → moved
+      movedPersons.push({
+        personId,
+        from: resolvePosition(fromPerson.position),
+        to: resolvePosition(toPerson.position),
+      });
+    } else {
+      // 変化なし → unchanged
+      unchangedPersons.push(toPerson);
+    }
+  }
+
+  // fromを走査: removed（toに存在しないもの）
+  for (const [personId, fromPerson] of fromPersonMap) {
+    if (!toPersonMap.has(personId)) {
+      removedPersons.push(fromPerson);
+    }
+  }
+
+  // === 関係のdiff計算 ===
+  const fromRelMap = new Map<string, SnapshotRelationship>(
+    from.relationships.map((r) => [r.relationshipId, r])
+  );
+  const toRelMap = new Map<string, SnapshotRelationship>(
+    to.relationships.map((r) => [r.relationshipId, r])
+  );
+
+  const addedRels: SnapshotRelationship[] = [];
+  const removedRels: SnapshotRelationship[] = [];
+  const changedRels: ChangedRelationship[] = [];
+  const unchangedRels: SnapshotRelationship[] = [];
+
+  // toを走査: added or changed or unchanged
+  for (const [relationshipId, toRel] of toRelMap) {
+    const fromRel = fromRelMap.get(relationshipId);
+    if (fromRel === undefined) {
+      // Bにのみ存在 → added
+      addedRels.push(toRel);
+    } else if (isRelationshipChanged(fromRel, toRel)) {
+      // 属性が変化 → changed
+      changedRels.push({ relationshipId, from: fromRel, to: toRel });
+    } else {
+      // 変化なし → unchanged
+      unchangedRels.push(toRel);
+    }
+  }
+
+  // fromを走査: removed（toに存在しないもの）
+  for (const [relationshipId, fromRel] of fromRelMap) {
+    if (!toRelMap.has(relationshipId)) {
+      removedRels.push(fromRel);
+    }
+  }
+
+  return {
+    persons: {
+      added: addedPersons,
+      removed: removedPersons,
+      moved: movedPersons,
+      unchanged: unchangedPersons,
+    },
+    relationships: {
+      added: addedRels,
+      removed: removedRels,
+      changed: changedRels,
+      unchanged: unchangedRels,
+    },
+  };
+}

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3289,6 +3289,8 @@ describe('useGraphStore', () => {
         activeSnapshotIndex: null,
         _livePersons: null,
         _liveRelationships: null,
+        isPlaying: false,
+        playbackSpeed: 2000,
       });
       store.persons.forEach((p) => store.removePerson(p.id));
       store.relationships.forEach((r) => store.removeRelationship(r.id));

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3552,5 +3552,76 @@ describe('useGraphStore', () => {
         expect(result.current.persons[0].name).toBe('細川藤孝');
       });
     });
+
+    describe('isPlaying / playbackSpeed', () => {
+      it('setPlaying(true) で isPlaying が true になる', () => {
+        // GIVEN: 初期状態（isPlaying=false）
+        const { result } = renderHook(() => useGraphStore());
+        expect(result.current.isPlaying).toBe(false);
+
+        // WHEN
+        act(() => {
+          result.current.setPlaying(true);
+        });
+
+        // THEN
+        expect(result.current.isPlaying).toBe(true);
+      });
+
+      it('setPlaying(false) で isPlaying が false になる', () => {
+        // GIVEN: isPlaying=true の状態
+        const { result } = renderHook(() => useGraphStore());
+        act(() => {
+          result.current.setPlaying(true);
+        });
+
+        // WHEN
+        act(() => {
+          result.current.setPlaying(false);
+        });
+
+        // THEN
+        expect(result.current.isPlaying).toBe(false);
+      });
+
+      it('setPlaybackSpeed でplaybackSpeedが変わる', () => {
+        // GIVEN: 初期状態（playbackSpeed=2000）
+        const { result } = renderHook(() => useGraphStore());
+        expect(result.current.playbackSpeed).toBe(2000);
+
+        // WHEN: 高速に変更
+        act(() => {
+          result.current.setPlaybackSpeed(1000);
+        });
+
+        // THEN
+        expect(result.current.playbackSpeed).toBe(1000);
+      });
+
+      it('setTimelineMode(false) で isPlaying が false にリセットされる', () => {
+        // GIVEN: タイムラインモード + 再生中の状態
+        const { result } = renderHook(() => useGraphStore());
+        act(() => {
+          result.current.addPerson({ name: '織田信長', labels: [], properties: {} });
+        });
+        act(() => {
+          result.current.captureSnapshot('第1話');
+        });
+        act(() => {
+          result.current.setTimelineMode(true);
+          result.current.setPlaying(true);
+        });
+        expect(result.current.isPlaying).toBe(true);
+
+        // WHEN: タイムラインモードを終了
+        act(() => {
+          result.current.setTimelineMode(false);
+        });
+
+        // THEN: 再生も停止される
+        expect(result.current.isPlaying).toBe(false);
+        expect(result.current.timelineMode).toBe(false);
+      });
+    });
   });
 });

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -823,6 +823,8 @@ export const useGraphStore = create<GraphStore>()(
             activeSnapshotIndex: null,
             _livePersons: null,
             _liveRelationships: null,
+            // 再生状態もリセット（別チャートの再生状態が残らないように）
+            isPlaying: false,
           }));
 
           // 9. lastActiveChartIdを更新
@@ -863,6 +865,8 @@ export const useGraphStore = create<GraphStore>()(
             _livePersons: null,
             _liveRelationships: null,
             pauseAutoSave: false,
+            // 再生状態もリセット（前チャートの再生状態が残らないように）
+            isPlaying: false,
           }));
 
           // 4. lastActiveChartIdを更新

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -4,6 +4,15 @@
  */
 
 import { create } from 'zustand';
+
+/**
+ * 自動再生の再生速度（ミリ秒）の許可値
+ * UIの3段階（1x/1.5x/2x）に対応する。TimelineBar.tsx も参照する。
+ */
+export const PLAYBACK_SPEEDS = [3000, 2000, 1000] as const;
+
+/** 自動再生の再生速度型（許可された3値のみ） */
+export type PlaybackSpeed = (typeof PLAYBACK_SPEEDS)[number];
 import { temporal } from 'zundo';
 import { nanoid } from 'nanoid';
 import type { Person } from '@/types/person';
@@ -92,8 +101,8 @@ type GraphState = {
   _liveRelationships: Relationship[] | null;
   /** アニメーション自動再生中かどうか */
   isPlaying: boolean;
-  /** 自動再生の再生間隔（ミリ秒）。デフォルト: 2000ms */
-  playbackSpeed: number;
+  /** 自動再生の再生間隔（ミリ秒）。PLAYBACK_SPEEDS で定義された3段階のみ有効 */
+  playbackSpeed: PlaybackSpeed;
 };
 
 /**
@@ -409,9 +418,9 @@ type GraphActions = {
 
   /**
    * 自動再生の再生速度を設定する
-   * @param ms - 再生間隔（ミリ秒）。1000 / 2000 / 3000 の3段階を推奨
+   * @param ms - 再生間隔（ミリ秒）。PLAYBACK_SPEEDS で定義された値のみ有効
    */
-  setPlaybackSpeed: (ms: number) => void;
+  setPlaybackSpeed: (ms: PlaybackSpeed) => void;
 
   /**
    * 指定インデックスのスナップショット状態をグラフに反映する
@@ -1173,6 +1182,8 @@ export const useGraphStore = create<GraphStore>()(
         },
 
         setPlaybackSpeed: (ms) => {
+          // PLAYBACK_SPEEDS 以外の値は無視する（防御的ガード）
+          if (!(PLAYBACK_SPEEDS as readonly number[]).includes(ms)) return;
           set(() => ({ playbackSpeed: ms }));
         },
 

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -90,6 +90,10 @@ type GraphState = {
   _livePersons: Person[] | null;
   /** タイムラインモード中のライブRelationshipsデータ退避（モード終了時に復元する） */
   _liveRelationships: Relationship[] | null;
+  /** アニメーション自動再生中かどうか */
+  isPlaying: boolean;
+  /** 自動再生の再生間隔（ミリ秒）。デフォルト: 2000ms */
+  playbackSpeed: number;
 };
 
 /**
@@ -115,6 +119,8 @@ const INITIAL_STATE: GraphState = {
   activeSnapshotIndex: null,
   _livePersons: null,
   _liveRelationships: null,
+  isPlaying: false,
+  playbackSpeed: 2000,
 };
 
 
@@ -390,10 +396,22 @@ type GraphActions = {
   /**
    * タイムライン再生モードの有効/無効を切り替える
    * - true: ライブデータを退避し、pauseAutoSave=true で編集操作を無効化
-   * - false: ライブデータを復元し、pauseAutoSave=false で通常モードに戻る
+   * - false: ライブデータを復元し、pauseAutoSave=false で通常モードに戻る（isPlayingもリセット）
    * @param enabled - true でタイムラインモードに入る
    */
   setTimelineMode: (enabled: boolean) => void;
+
+  /**
+   * アニメーション自動再生状態を設定する
+   * @param playing - true で再生開始、false で停止
+   */
+  setPlaying: (playing: boolean) => void;
+
+  /**
+   * 自動再生の再生速度を設定する
+   * @param ms - 再生間隔（ミリ秒）。1000 / 2000 / 3000 の3段階を推奨
+   */
+  setPlaybackSpeed: (ms: number) => void;
 
   /**
    * 指定インデックスのスナップショット状態をグラフに反映する
@@ -1132,16 +1150,26 @@ export const useGraphStore = create<GraphStore>()(
             }));
           } else {
             // タイムラインモードを終了: ライブデータを復元してpauseAutoSave=false
+            // isPlayingもリセットして再生を確実に停止する
             set((s) => ({
               timelineMode: false,
               pauseAutoSave: false,
               activeSnapshotIndex: null,
+              isPlaying: false,
               persons: s._livePersons ?? s.persons,
               relationships: s._liveRelationships ?? s.relationships,
               _livePersons: null,
               _liveRelationships: null,
             }));
           }
+        },
+
+        setPlaying: (playing) => {
+          set(() => ({ isPlaying: playing }));
+        },
+
+        setPlaybackSpeed: (ms) => {
+          set(() => ({ playbackSpeed: ms }));
         },
 
         goToSnapshot: (index) => {


### PR DESCRIPTION
## Summary

- `useSnapshotTransition`: rAF + easeOutCubicによるノード位置補間とopacityアニメーション（出現/消滅）でスナップショット間を滑らかに遷移するフック
- `useTimelinePlayback`: setIntervalでスナップショットを順次切り替え、最後のスナップショットで自動停止するフック
- `snapshot-diff`: スナップショット間のdiff計算（added/removed/moved/unchanged）を行う純粋関数
- `useGraphStore`: `isPlaying`/`playbackSpeed` stateと`setPlaying`/`setPlaybackSpeed` actionを追加
- `TimelineBar`: 再生/停止・前へ/次へ・速度切替（1x/1.5x/2x）のコントロールUIを追加

## 設計のポイント

- **アニメーション方式**: rAF + easeOutCubicで位置補間（`useEgoLayout.ts`パターン踏襲）、opacity変化でフェードイン/アウト
- **useGraphDataSyncとの競合回避**: アニメーション中はストアの`persons`/`relationships`を変更しないため競合しない。300ms後のsetTimeoutで`goToSnapshot`を呼んで状態を確定する
- **連続遷移**: `cancelAnimationFrame` + `clearTimeout`で前のアニメーションをキャンセル
- **再生速度**: 3000ms(1x) / 2000ms(1.5x) / 1000ms(2x)の3段階でサイクル切り替え

## Test plan

- [ ] `npm run lint && npm run type-check && npm test` が全て通過することを確認
- [ ] スナップショット2件以上作成 → タイムラインモードに入る → 前後ボタンでノード移動/出現/消滅アニメーションを確認
- [ ] 再生ボタン → 自動再生 → 最後のスナップショットで自動停止を確認
- [ ] 速度ボタンで1x/1.5x/2xを切り替え → 再生間隔が変化することを確認
- [ ] 再生中にスライダーを操作 → アニメーション中断・新遷移開始を確認

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * グラフのスナップショット間を自動的に遷移するタイムライン再生機能を追加しました。
  * 再生/一時停止ボタンでタイムラインの再生を制御できるようになりました。
  * 再生速度を調整可能にしました。
  * 前後のスナップショットへ移動するナビゲーションボタンを追加しました。
  * スナップショット遷移にスムーズなアニメーション効果を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->