### PR TITLE
feat: スナップショット一覧のドラッグ並び替え機能を追加 (#94 Phase 3-1)

### DIFF
--- a/src/components/panel/SnapshotList.test.tsx
+++ b/src/components/panel/SnapshotList.test.tsx
@@ -35,6 +35,7 @@ function makeStoreMock(overrides: Partial<{
   goToSnapshot: ReturnType<typeof vi.fn>;
   goToLive: ReturnType<typeof vi.fn>;
   deleteSnapshot: ReturnType<typeof vi.fn>;
+  reorderSnapshots: ReturnType<typeof vi.fn>;
 }> = {}) {
   return {
     snapshots: overrides.snapshots ?? [],
@@ -44,6 +45,7 @@ function makeStoreMock(overrides: Partial<{
     goToSnapshot: overrides.goToSnapshot ?? vi.fn(),
     goToLive: overrides.goToLive ?? vi.fn(),
     deleteSnapshot: overrides.deleteSnapshot ?? vi.fn(),
+    reorderSnapshots: overrides.reorderSnapshots ?? vi.fn(),
   };
 }
 
@@ -121,5 +123,27 @@ describe('SnapshotList', () => {
     await user.click(screen.getByRole('button', { name: /第1話を削除/i }));
 
     expect(mockDeleteSnapshot).toHaveBeenCalledWith('snap-001');
+  });
+
+  it('タイムラインモード外でドラッグハンドルが表示される', () => {
+    const snapshots = [makeSnapshot({ id: 'snap-001', label: '第1話' })];
+    mockUseGraphStore.mockReturnValue(makeStoreMock({ snapshots, timelineMode: false }));
+
+    render(<SnapshotList />);
+
+    // ドラッグハンドルボタンが存在すること
+    expect(screen.getByRole('button', { name: '並び替え' })).toBeInTheDocument();
+  });
+
+  it('タイムラインモード中はドラッグハンドルが表示されない', () => {
+    const snapshots = [makeSnapshot({ id: 'snap-001', label: '第1話' })];
+    mockUseGraphStore.mockReturnValue(
+      makeStoreMock({ snapshots, timelineMode: true, activeSnapshotIndex: 0 })
+    );
+
+    render(<SnapshotList />);
+
+    // タイムラインモード中はドラッグハンドルが非表示であること
+    expect(screen.queryByRole('button', { name: '並び替え' })).not.toBeInTheDocument();
   });
 });

--- a/src/components/panel/SnapshotList.test.tsx
+++ b/src/components/panel/SnapshotList.test.tsx
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SnapshotList } from './SnapshotList';
+import { SnapshotList, computeReorderedSnapshotIds } from './SnapshotList';
 import { useGraphStore } from '@/stores/useGraphStore';
 import type { Snapshot } from '@/types/snapshot';
 
@@ -48,6 +48,50 @@ function makeStoreMock(overrides: Partial<{
     reorderSnapshots: overrides.reorderSnapshots ?? vi.fn(),
   };
 }
+
+describe('computeReorderedSnapshotIds', () => {
+  const makeSnapshotForUtil = (id: string): Snapshot => ({
+    id,
+    label: id,
+    persons: [],
+    relationships: [],
+    createdAt: new Date().toISOString(),
+  });
+
+  it('先頭要素を末尾に移動する', () => {
+    const snapshots = ['a', 'b', 'c'].map(makeSnapshotForUtil);
+
+    // 'a'を'c'の位置に移動 → ['b', 'c', 'a']
+    const result = computeReorderedSnapshotIds(snapshots, 'a', 'c');
+
+    expect(result).toEqual(['b', 'c', 'a']);
+  });
+
+  it('末尾要素を先頭に移動する', () => {
+    const snapshots = ['a', 'b', 'c'].map(makeSnapshotForUtil);
+
+    // 'c'を'a'の位置に移動 → ['c', 'a', 'b']
+    const result = computeReorderedSnapshotIds(snapshots, 'c', 'a');
+
+    expect(result).toEqual(['c', 'a', 'b']);
+  });
+
+  it('activeIdが存在しない場合はnullを返す', () => {
+    const snapshots = ['a', 'b'].map(makeSnapshotForUtil);
+
+    const result = computeReorderedSnapshotIds(snapshots, '存在しないID', 'b');
+
+    expect(result).toBeNull();
+  });
+
+  it('overIdが存在しない場合はnullを返す', () => {
+    const snapshots = ['a', 'b'].map(makeSnapshotForUtil);
+
+    const result = computeReorderedSnapshotIds(snapshots, 'a', '存在しないID');
+
+    expect(result).toBeNull();
+  });
+});
 
 describe('SnapshotList', () => {
   beforeEach(() => {

--- a/src/components/panel/SnapshotList.tsx
+++ b/src/components/panel/SnapshotList.tsx
@@ -9,6 +9,8 @@
  * - ドラッグ&ドロップによるスナップショットの並び替え（タイムラインモード外のみ）
  *
  * スナップショットが0件の場合は空状態メッセージを表示する。
+ *
+ * @module SnapshotList
  */
 
 'use client';
@@ -30,7 +32,32 @@ import {
 } from '@dnd-kit/sortable';
 import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
+import type { Snapshot } from '@/types/snapshot';
 import { SortableSnapshotItem } from './SortableSnapshotItem';
+
+/**
+ * ドラッグ終了イベントからスナップショットの新しいID順序を計算する純粋関数。
+ * テスト可能なロジックをコンポーネント外に切り出している。
+ *
+ * @param snapshots - 現在のスナップショット配列
+ * @param activeId - ドラッグ中のスナップショットID
+ * @param overId - ドロップ先のスナップショットID
+ * @returns 並び替え後のスナップショットIDの配列。activeIdまたはoverIdが見つからない場合はnull
+ */
+export function computeReorderedSnapshotIds(
+  snapshots: Snapshot[],
+  activeId: string,
+  overId: string
+): string[] | null {
+  const oldIndex = snapshots.findIndex((s) => s.id === activeId);
+  const newIndex = snapshots.findIndex((s) => s.id === overId);
+  if (oldIndex === -1 || newIndex === -1) return null;
+
+  const newOrder = [...snapshots];
+  const [removed] = newOrder.splice(oldIndex, 1);
+  newOrder.splice(newIndex, 0, removed);
+  return newOrder.map((s) => s.id);
+}
 
 /**
  * スナップショット一覧コンポーネント
@@ -67,20 +94,18 @@ export function SnapshotList() {
 
   /**
    * ドラッグ終了時に並び替えを適用する。
-   * タイムラインモード中は早期returnして操作を無視する。
+   * タイムラインモード中は早期returnして操作を無視する（UIのハンドル非表示との二重防御）。
    */
   const handleDragEnd = (event: DragEndEvent) => {
+    if (timelineMode) return;
+
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
-    const oldIndex = snapshots.findIndex((s) => s.id === active.id);
-    const newIndex = snapshots.findIndex((s) => s.id === over.id);
-    if (oldIndex === -1 || newIndex === -1) return;
-
-    const newOrder = [...snapshots];
-    const [removed] = newOrder.splice(oldIndex, 1);
-    newOrder.splice(newIndex, 0, removed);
-    reorderSnapshots(newOrder.map((s) => s.id));
+    const newIds = computeReorderedSnapshotIds(snapshots, String(active.id), String(over.id));
+    if (newIds !== null) {
+      reorderSnapshots(newIds);
+    }
   };
 
   return (

--- a/src/components/panel/SnapshotList.tsx
+++ b/src/components/panel/SnapshotList.tsx
@@ -6,15 +6,31 @@
  * - タイムライン再生モードの開始/終了
  * - 各スナップショットへのジャンプ
  * - スナップショットの削除
+ * - ドラッグ&ドロップによるスナップショットの並び替え（タイムラインモード外のみ）
  *
  * スナップショットが0件の場合は空状態メッセージを表示する。
  */
 
 'use client';
 
-import { Trash2, Play, StopCircle } from 'lucide-react';
+import { Play, StopCircle } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
 import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
+import { SortableSnapshotItem } from './SortableSnapshotItem';
 
 /**
  * スナップショット一覧コンポーネント
@@ -28,6 +44,7 @@ export function SnapshotList() {
     goToSnapshot,
     goToLive,
     deleteSnapshot,
+    reorderSnapshots,
   } = useGraphStore(
     useShallow((state) => ({
       snapshots: state.snapshots,
@@ -37,8 +54,34 @@ export function SnapshotList() {
       goToSnapshot: state.goToSnapshot,
       goToLive: state.goToLive,
       deleteSnapshot: state.deleteSnapshot,
+      reorderSnapshots: state.reorderSnapshots,
     }))
   );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  /**
+   * ドラッグ終了時に並び替えを適用する。
+   * タイムラインモード中は早期returnして操作を無視する。
+   */
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = snapshots.findIndex((s) => s.id === active.id);
+    const newIndex = snapshots.findIndex((s) => s.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newOrder = [...snapshots];
+    const [removed] = newOrder.splice(oldIndex, 1);
+    newOrder.splice(newIndex, 0, removed);
+    reorderSnapshots(newOrder.map((s) => s.id));
+  };
 
   return (
     <div>
@@ -86,64 +129,35 @@ export function SnapshotList() {
 
       {/* スナップショット一覧 */}
       {snapshots.length > 0 && (
-        <ul className="space-y-1">
-          {snapshots.map((snapshot, index) => {
-            const isActive = timelineMode && activeSnapshotIndex === index;
-            return (
-              <li
-                key={snapshot.id}
-                className={`flex items-center gap-2 rounded-md px-2 py-1.5 group ${
-                  isActive
-                    ? 'bg-blue-50 border border-blue-200'
-                    : 'hover:bg-gray-50'
-                }`}
-              >
-                {/* スナップショット番号 */}
-                <span className="text-xs text-gray-400 min-w-[1.5rem] text-right">
-                  {index + 1}.
-                </span>
-
-                {/* ラベル（クリックでジャンプ） */}
-                <button
-                  onClick={() => {
-                    if (!timelineMode) {
-                      setTimelineMode(true);
-                    }
-                    goToSnapshot(index);
-                  }}
-                  className={`flex-1 text-left text-sm truncate ${
-                    isActive ? 'text-blue-700 font-medium' : 'text-gray-700 hover:text-gray-900'
-                  }`}
-                  title={snapshot.description ?? snapshot.label}
-                >
-                  {snapshot.label}
-                </button>
-
-                {/* ライブに戻るボタン（タイムラインモード中のアクティブ項目） */}
-                {isActive && (
-                  <button
-                    onClick={goToLive}
-                    className="text-xs text-blue-500 hover:text-blue-700 whitespace-nowrap transition-colors"
-                  >
-                    ライブへ
-                  </button>
-                )}
-
-                {/* 削除ボタン（タイムラインモード外のみ表示） */}
-                {!timelineMode && (
-                  <button
-                    onClick={() => deleteSnapshot(snapshot.id)}
-                    className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 rounded"
-                    aria-label={`${snapshot.label}を削除`}
-                    title={`${snapshot.label}を削除`}
-                  >
-                    <Trash2 size={14} />
-                  </button>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={snapshots.map((s) => s.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="space-y-1">
+              {snapshots.map((snapshot, index) => {
+                const isActive = timelineMode && activeSnapshotIndex === index;
+                return (
+                  <SortableSnapshotItem
+                    key={snapshot.id}
+                    snapshot={snapshot}
+                    index={index}
+                    isActive={isActive}
+                    timelineMode={timelineMode}
+                    onGoToSnapshot={goToSnapshot}
+                    onSetTimelineMode={setTimelineMode}
+                    onGoToLive={goToLive}
+                    onDelete={deleteSnapshot}
+                  />
+                );
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
       )}
     </div>
   );

--- a/src/components/panel/SortableSnapshotItem.test.tsx
+++ b/src/components/panel/SortableSnapshotItem.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * SortableSnapshotItemコンポーネントのテスト
+ *
+ * ドラッグ可能なスナップショット項目の表示・操作を検証する。
+ * DndContextでラップしてuseSortableフックを動作させる。
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { DndContext } from '@dnd-kit/core';
+import { SortableSnapshotItem } from './SortableSnapshotItem';
+import type { Snapshot } from '@/types/snapshot';
+
+/** テスト用スナップショットを生成する */
+const createMockSnapshot = (overrides: Partial<Snapshot> = {}): Snapshot => ({
+  id: 'snapshot-id-1',
+  label: '第1話',
+  persons: [],
+  relationships: [],
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('SortableSnapshotItem', () => {
+  const mockOnGoToSnapshot = vi.fn();
+  const mockOnSetTimelineMode = vi.fn();
+  const mockOnGoToLive = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  beforeEach(() => {
+    mockOnGoToSnapshot.mockClear();
+    mockOnSetTimelineMode.mockClear();
+    mockOnGoToLive.mockClear();
+    mockOnDelete.mockClear();
+  });
+
+  /** デフォルトのpropsでコンポーネントを描画するヘルパー */
+  const renderComponent = (overrides: {
+    snapshot?: Partial<Snapshot>;
+    index?: number;
+    isActive?: boolean;
+    timelineMode?: boolean;
+  } = {}) => {
+    const snapshot = createMockSnapshot(overrides.snapshot);
+    return render(
+      <DndContext>
+        <SortableSnapshotItem
+          snapshot={snapshot}
+          index={overrides.index ?? 0}
+          isActive={overrides.isActive ?? false}
+          timelineMode={overrides.timelineMode ?? false}
+          onGoToSnapshot={mockOnGoToSnapshot}
+          onSetTimelineMode={mockOnSetTimelineMode}
+          onGoToLive={mockOnGoToLive}
+          onDelete={mockOnDelete}
+        />
+      </DndContext>
+    );
+  };
+
+  it('スナップショットのラベルが表示される', () => {
+    renderComponent({ snapshot: { label: '第1話' } });
+
+    expect(screen.getByText('第1話')).toBeInTheDocument();
+  });
+
+  it('スナップショット番号が表示される', () => {
+    // index=2（3番目）の場合は「3.」と表示される
+    renderComponent({ index: 2 });
+
+    expect(screen.getByText('3.')).toBeInTheDocument();
+  });
+
+  it('タイムラインモード外でドラッグハンドルが表示される', () => {
+    renderComponent({ timelineMode: false });
+
+    expect(screen.getByRole('button', { name: '並び替え' })).toBeInTheDocument();
+  });
+
+  it('タイムラインモード中はドラッグハンドルが非表示になる', () => {
+    renderComponent({ timelineMode: true });
+
+    expect(screen.queryByRole('button', { name: '並び替え' })).not.toBeInTheDocument();
+  });
+
+  it('タイムラインモード外で削除ボタンが表示される', () => {
+    renderComponent({ snapshot: { label: '第1話' }, timelineMode: false });
+
+    expect(screen.getByRole('button', { name: '第1話を削除' })).toBeInTheDocument();
+  });
+
+  it('タイムラインモード中は削除ボタンが非表示になる', () => {
+    renderComponent({ snapshot: { label: '第1話' }, timelineMode: true });
+
+    expect(screen.queryByRole('button', { name: '第1話を削除' })).not.toBeInTheDocument();
+  });
+
+  it('ラベルをクリックするとタイムラインモードが開始されてスナップショットにジャンプする', async () => {
+    const user = userEvent.setup();
+    renderComponent({ index: 1, timelineMode: false });
+
+    await user.click(screen.getByText('第1話'));
+
+    // タイムラインモードを開始してからスナップショットにジャンプすること
+    expect(mockOnSetTimelineMode).toHaveBeenCalledWith(true);
+    expect(mockOnGoToSnapshot).toHaveBeenCalledWith(1);
+  });
+
+  it('タイムラインモード中にラベルをクリックするとスナップショットにジャンプする（モード変更なし）', async () => {
+    const user = userEvent.setup();
+    renderComponent({ index: 0, timelineMode: true });
+
+    await user.click(screen.getByText('第1話'));
+
+    // 既にタイムラインモード中なのでsetTimelineModeは呼ばれない
+    expect(mockOnSetTimelineMode).not.toHaveBeenCalled();
+    expect(mockOnGoToSnapshot).toHaveBeenCalledWith(0);
+  });
+
+  it('アクティブなスナップショットに「ライブへ」ボタンが表示される', () => {
+    renderComponent({ isActive: true, timelineMode: true });
+
+    expect(screen.getByText('ライブへ')).toBeInTheDocument();
+  });
+
+  it('「ライブへ」ボタンをクリックするとgoToLiveが呼ばれる', async () => {
+    const user = userEvent.setup();
+    renderComponent({ isActive: true, timelineMode: true });
+
+    await user.click(screen.getByText('ライブへ'));
+
+    expect(mockOnGoToLive).toHaveBeenCalledOnce();
+  });
+
+  it('削除ボタンをクリックするとonDeleteがスナップショットIDで呼ばれる', async () => {
+    const user = userEvent.setup();
+    renderComponent({
+      snapshot: { id: 'test-snapshot-id', label: '第1話' },
+      timelineMode: false,
+    });
+
+    await user.click(screen.getByRole('button', { name: '第1話を削除' }));
+
+    expect(mockOnDelete).toHaveBeenCalledWith('test-snapshot-id');
+  });
+});

--- a/src/components/panel/SortableSnapshotItem.tsx
+++ b/src/components/panel/SortableSnapshotItem.tsx
@@ -1,0 +1,134 @@
+/**
+ * SortableSnapshotItemコンポーネント
+ *
+ * @dnd-kit/sortableを使用してドラッグ&ドロップで並び替え可能なスナップショット項目。
+ * SnapshotList内で使用され、GripVerticalアイコンのドラッグハンドルで並び替えを行う。
+ *
+ * 注意: タイムラインモード中はドラッグハンドルを非表示にする。
+ * activeSnapshotIndexがインデックスベースのため、再生中の並び替えは禁止。
+ */
+
+'use client';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Trash2, GripVertical } from 'lucide-react';
+import type { Snapshot } from '@/types/snapshot';
+
+/**
+ * SortableSnapshotItemのプロップス
+ */
+export type SortableSnapshotItemProps = {
+  /** 表示するスナップショット */
+  snapshot: Snapshot;
+  /** スナップショット番号（0始まりのインデックス） */
+  index: number;
+  /** タイムラインモード中かつこの項目がアクティブかどうか */
+  isActive: boolean;
+  /** タイムラインモード中かどうか */
+  timelineMode: boolean;
+  /** スナップショットへジャンプするハンドラー */
+  onGoToSnapshot: (index: number) => void;
+  /** タイムラインモードを切り替えるハンドラー */
+  onSetTimelineMode: (enabled: boolean) => void;
+  /** ライブ状態に戻るハンドラー */
+  onGoToLive: () => void;
+  /** スナップショットを削除するハンドラー */
+  onDelete: (snapshotId: string) => void;
+};
+
+/**
+ * ドラッグ&ドロップで並び替え可能なスナップショット項目コンポーネント
+ */
+export function SortableSnapshotItem({
+  snapshot,
+  index,
+  isActive,
+  timelineMode,
+  onGoToSnapshot,
+  onSetTimelineMode,
+  onGoToLive,
+  onDelete,
+}: SortableSnapshotItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: snapshot.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 rounded-md px-2 py-1.5 group ${
+        isActive
+          ? 'bg-blue-50 border border-blue-200'
+          : 'hover:bg-gray-50'
+      }`}
+    >
+      {/* ドラッグハンドル（タイムラインモード中は非表示） */}
+      {!timelineMode && (
+        <button
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing text-gray-300 hover:text-gray-500 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none flex-shrink-0"
+          aria-label="並び替え"
+        >
+          <GripVertical size={14} />
+        </button>
+      )}
+
+      {/* スナップショット番号 */}
+      <span className="text-xs text-gray-400 min-w-[1.5rem] text-right flex-shrink-0">
+        {index + 1}.
+      </span>
+
+      {/* ラベル（クリックでジャンプ） */}
+      <button
+        onClick={() => {
+          if (!timelineMode) {
+            onSetTimelineMode(true);
+          }
+          onGoToSnapshot(index);
+        }}
+        className={`flex-1 text-left text-sm truncate ${
+          isActive ? 'text-blue-700 font-medium' : 'text-gray-700 hover:text-gray-900'
+        }`}
+        title={snapshot.description ?? snapshot.label}
+      >
+        {snapshot.label}
+      </button>
+
+      {/* ライブに戻るボタン（タイムラインモード中のアクティブ項目） */}
+      {isActive && (
+        <button
+          onClick={onGoToLive}
+          className="text-xs text-blue-500 hover:text-blue-700 whitespace-nowrap transition-colors"
+        >
+          ライブへ
+        </button>
+      )}
+
+      {/* 削除ボタン（タイムラインモード外のみ表示） */}
+      {!timelineMode && (
+        <button
+          onClick={() => onDelete(snapshot.id)}
+          className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 rounded"
+          aria-label={`${snapshot.label}を削除`}
+          title={`${snapshot.label}を削除`}
+        >
+          <Trash2 size={14} />
+        </button>
+      )}
+    </li>
+  );
+}

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3425,6 +3425,82 @@ describe('useGraphStore', () => {
       });
     });
 
+    describe('reorderSnapshots', () => {
+      it('スナップショットの順序を並び替える', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        // 3件のスナップショットを作成する
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+          result.current.captureSnapshot('第3話');
+        });
+
+        const [id1, id2, id3] = result.current.snapshots.map((s) => s.id);
+
+        // 順序を逆にする
+        act(() => {
+          result.current.reorderSnapshots([id3, id2, id1]);
+        });
+
+        expect(result.current.snapshots[0].label).toBe('第3話');
+        expect(result.current.snapshots[1].label).toBe('第2話');
+        expect(result.current.snapshots[2].label).toBe('第1話');
+      });
+
+      it('タイムラインモード中は並び替えを無視する', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        const [id1, id2] = result.current.snapshots.map((s) => s.id);
+
+        // タイムラインモードに入る
+        act(() => {
+          result.current.setTimelineMode(true);
+        });
+
+        // タイムラインモード中に並び替えを試みる（無視される）
+        act(() => {
+          result.current.reorderSnapshots([id2, id1]);
+        });
+
+        // 順序は変わらないこと
+        expect(result.current.snapshots[0].label).toBe('第1話');
+        expect(result.current.snapshots[1].label).toBe('第2話');
+      });
+
+      it('存在しないIDが含まれる場合はエラーをスローする', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+        });
+
+        expect(() => {
+          result.current.reorderSnapshots(['存在しないID']);
+        }).toThrow('並び順に存在しないスナップショットIDが含まれています');
+      });
+
+      it('スナップショット数と異なる長さの配列はエラーをスローする', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        const [id1] = result.current.snapshots.map((s) => s.id);
+
+        expect(() => {
+          result.current.reorderSnapshots([id1]);
+        }).toThrow('並び順のスナップショット数が一致しません');
+      });
+    });
+
     describe('setTimelineMode / goToSnapshot / goToLive', () => {
       it('タイムラインモードに入るとpauseAutoSaveがtrueになる', () => {
         const { result } = renderHook(() => useGraphStore());

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3499,6 +3499,23 @@ describe('useGraphStore', () => {
           result.current.reorderSnapshots([id1]);
         }).toThrow('並び順のスナップショット数が一致しません');
       });
+
+      it('重複したIDが含まれる場合はエラーをスローする', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+          result.current.captureSnapshot('第3話');
+        });
+
+        const [id1, _id2] = result.current.snapshots.map((s) => s.id);
+
+        // snapshotIds=[id1,id1,id1]は長さ一致・IDも存在するが重複しており実質1件分欠落する
+        expect(() => {
+          result.current.reorderSnapshots([id1, id1, id1]);
+        }).toThrow('並び順に重複したスナップショットIDが含まれています');
+      });
     });
 
     describe('setTimelineMode / goToSnapshot / goToLive', () => {

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -403,6 +403,14 @@ type GraphActions = {
   updateSnapshot: (snapshotId: string, updates: { label?: string; description?: string }) => void;
 
   /**
+   * スナップショットの並び順を変更する
+   * - タイムラインモード中は無操作（activeSnapshotIndexがインデックスベースのため）
+   * @param snapshotIds - 並び替え後のスナップショットIDの配列
+   * @throws スナップショット数が一致しない場合、または存在しないIDが含まれる場合
+   */
+  reorderSnapshots: (snapshotIds: string[]) => void;
+
+  /**
    * タイムライン再生モードの有効/無効を切り替える
    * - true: ライブデータを退避し、pauseAutoSave=true で編集操作を無効化
    * - false: ライブデータを復元し、pauseAutoSave=false で通常モードに戻る（isPlayingもリセット）
@@ -1142,6 +1150,35 @@ export const useGraphStore = create<GraphStore>()(
               s.id === snapshotId ? { ...s, ...updates } : s
             ),
           }));
+        },
+
+        reorderSnapshots: (snapshotIds) => {
+          const { snapshots, timelineMode } = get();
+
+          // タイムラインモード中は並び替え禁止（activeSnapshotIndexがインデックスベースのため表示がズレる）
+          if (timelineMode) {
+            return;
+          }
+
+          if (snapshotIds.length !== snapshots.length) {
+            throw new Error('並び順のスナップショット数が一致しません');
+          }
+
+          const currentIds = new Set(snapshots.map((s) => s.id));
+          const hasInvalidId = snapshotIds.some((id) => !currentIds.has(id));
+          if (hasInvalidId) {
+            throw new Error('並び順に存在しないスナップショットIDが含まれています');
+          }
+
+          // snapshotIdsの順序に従ってsnapshots配列を並び替える
+          const orderMap = new Map(snapshotIds.map((id, index) => [id, index]));
+          const sortedSnapshots = [...snapshots].sort((a, b) => {
+            const indexA = orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+            const indexB = orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+            return indexA - indexB;
+          });
+
+          set(() => ({ snapshots: sortedSnapshots }));
         },
 
         setTimelineMode: (enabled) => {

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -1164,6 +1164,11 @@ export const useGraphStore = create<GraphStore>()(
             throw new Error('並び順のスナップショット数が一致しません');
           }
 
+          // 重複チェック: 重複があると一部IDが欠落した並び順になるためエラーとする
+          if (new Set(snapshotIds).size !== snapshotIds.length) {
+            throw new Error('並び順に重複したスナップショットIDが含まれています');
+          }
+
           const currentIds = new Set(snapshots.map((s) => s.id));
           const hasInvalidId = snapshotIds.some((id) => !currentIds.has(id));
           if (hasInvalidId) {


### PR DESCRIPTION
## Summary

- `@dnd-kit/sortable`を使用して`SnapshotList`のアイテムをドラッグ&ドロップで並び替え可能にした
- `reorderSnapshots`アクションをZustandストアに追加（同期関数、auto-saveで永続化）
- `SortableSnapshotItem`コンポーネントを新規作成（`SortableChartCard`と同パターン）
- タイムラインモード中は`activeSnapshotIndex`がインデックスベースのため並び替えを禁止（ストア側早期return + UIのハンドル非表示の二重防御）

## Test plan

- [x] `reorderSnapshots`の単体テスト（正常並び替え、タイムラインモード禁止、不正IDエラー、数不一致エラー）
- [x] `SortableSnapshotItem`のUIテスト（ラベル表示、ドラッグハンドル表示/非表示、削除ボタン、クリック動作）
- [x] `SnapshotList`のテスト（ドラッグハンドルの表示/非表示）
- [x] 全76テストファイル・1048テストケース通過
- [x] lint/type-check エラーゼロ

Related to #94 (Phase 3-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)