### PR TITLE
feat: スナップショット間のdiffハイライト機能を追加 (#94 Phase 3-2)

### DIFF
--- a/src/components/graph/RelationshipEdge.tsx
+++ b/src/components/graph/RelationshipEdge.tsx
@@ -25,6 +25,7 @@ import { useGraphStore } from '@/stores/useGraphStore';
 import { getEdgeIntersectionPoints } from '@/lib/node-intersection';
 import type { RelationshipEdgeData } from '@/types/graph';
 import { calculateParallelEdgeOffset } from '@/lib/graph-utils';
+import { getDiffEdgeStyle, getDiffMarkerKey } from '@/lib/diff-highlight';
 
 /**
  * 関係エッジコンポーネント
@@ -147,21 +148,24 @@ export const RelationshipEdge = memo((props: EdgeProps) => {
   // deriveEdgeVisual で導出された視覚属性を使用する
   const { color, strokeWidth: baseStrokeWidth, dashed, markerKey } = edgeData.visual;
 
-  // マーカーの設定（選択状態のときは blue マーカーを使用。非選択時は視覚属性のキーを使用）
-  const markerSuffix = selected ? 'blue' : markerKey;
+  // diffハイライトスタイルを取得（タイムラインモードのスナップショット切り替え時に適用）
+  const diffStyle = getDiffEdgeStyle(edgeData.diffStatus);
+  const diffMarkerKey = getDiffMarkerKey(edgeData.diffStatus);
+
+  // マーカーの設定（優先順位: selected > diffStatus > visual）
+  const markerSuffix = selected ? 'blue' : (diffMarkerKey ?? markerKey);
 
   // v11: symmetric=true → 矢印なし（無向）、symmetric=false → targetに矢印（有向）
   const markerEnd = edgeData.symmetric ? undefined : `url(#arrow-${markerSuffix})`;
 
-  // エッジのスタイル（選択状態・visual から色と太さを適用）
-  const strokeColor = selected ? '#3b82f6' : color;
+  // エッジのスタイル（優先順位: selected > diffStatus > visual）
   // 破線スタイル（secrecy >= 0.5 のとき破線）
   const strokeDasharray = dashed ? '8 4' : undefined;
-  const edgeStyle = {
-    stroke: strokeColor,
-    strokeWidth: selected ? 3.5 : baseStrokeWidth,
-    strokeDasharray,
-  };
+  const edgeStyle = selected
+    ? { stroke: '#3b82f6', strokeWidth: 3.5, strokeDasharray }
+    : diffStyle
+      ? { stroke: diffStyle.stroke, strokeWidth: diffStyle.strokeWidth, strokeDasharray }
+      : { stroke: color, strokeWidth: baseStrokeWidth, strokeDasharray };
 
   // 表示ラベル: label が null の場合は edgeType を使用
   const displayLabel = edgeData.label ?? edgeData.edgeType;

--- a/src/components/graph/RelationshipEdge.tsx
+++ b/src/components/graph/RelationshipEdge.tsx
@@ -165,7 +165,9 @@ export const RelationshipEdge = memo((props: EdgeProps) => {
   if (selected) {
     edgeStyle = { stroke: '#3b82f6', strokeWidth: 3.5, strokeDasharray };
   } else if (diffStyle) {
-    edgeStyle = { stroke: diffStyle.stroke, strokeWidth: diffStyle.strokeWidth, strokeDasharray };
+    // diffハイライト時はbaseStrokeWidthと比較して大きい方を採用する
+    // （closeness=1.0 の4pxより細くなるケースを防ぐため）
+    edgeStyle = { stroke: diffStyle.stroke, strokeWidth: Math.max(diffStyle.strokeWidth, baseStrokeWidth), strokeDasharray };
   } else {
     edgeStyle = { stroke: color, strokeWidth: baseStrokeWidth, strokeDasharray };
   }

--- a/src/components/graph/RelationshipEdge.tsx
+++ b/src/components/graph/RelationshipEdge.tsx
@@ -161,11 +161,14 @@ export const RelationshipEdge = memo((props: EdgeProps) => {
   // エッジのスタイル（優先順位: selected > diffStatus > visual）
   // 破線スタイル（secrecy >= 0.5 のとき破線）
   const strokeDasharray = dashed ? '8 4' : undefined;
-  const edgeStyle = selected
-    ? { stroke: '#3b82f6', strokeWidth: 3.5, strokeDasharray }
-    : diffStyle
-      ? { stroke: diffStyle.stroke, strokeWidth: diffStyle.strokeWidth, strokeDasharray }
-      : { stroke: color, strokeWidth: baseStrokeWidth, strokeDasharray };
+  let edgeStyle: { stroke: string; strokeWidth: number; strokeDasharray: string | undefined };
+  if (selected) {
+    edgeStyle = { stroke: '#3b82f6', strokeWidth: 3.5, strokeDasharray };
+  } else if (diffStyle) {
+    edgeStyle = { stroke: diffStyle.stroke, strokeWidth: diffStyle.strokeWidth, strokeDasharray };
+  } else {
+    edgeStyle = { stroke: color, strokeWidth: baseStrokeWidth, strokeDasharray };
+  }
 
   // 表示ラベル: label が null の場合は edgeType を使用
   const displayLabel = edgeData.label ?? edgeData.edgeType;

--- a/src/components/graph/useGraphDataSync.ts
+++ b/src/components/graph/useGraphDataSync.ts
@@ -8,8 +8,10 @@ import { useNodesState, useEdgesState, useReactFlow } from '@xyflow/react';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { personsToNodes, relationshipsToEdges, syncNodePositionsToStore } from '@/lib/graph-utils';
 import { resolveCollisions, DEFAULT_COLLISION_OPTIONS } from '@/lib/collision-resolver';
+import { computeSnapshotDiff } from '@/lib/snapshot-diff';
 import type { Node } from '@xyflow/react';
 import type { GraphNode, RelationshipEdge } from '@/types/graph';
+import type { DiffStatus } from '@/lib/diff-highlight';
 
 /**
  * グラフデータ同期フック
@@ -28,6 +30,10 @@ export function useGraphDataSync() {
   const selectedPersonIds = useGraphStore((state) => state.selectedPersonIds);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
   const edgeFilter = useGraphStore((state) => state.edgeFilter);
+  const timelineMode = useGraphStore((state) => state.timelineMode);
+  const activeSnapshotIndex = useGraphStore((state) => state.activeSnapshotIndex);
+  const previousSnapshotIndex = useGraphStore((state) => state.previousSnapshotIndex);
+  const snapshots = useGraphStore((state) => state.snapshots);
 
   // React Flowのノード/エッジ状態
   const [nodes, setNodes, onNodesChange] = useNodesState<GraphNode>([]);
@@ -137,14 +143,43 @@ export function useGraphDataSync() {
       return updatedNodes;
     });
 
-    // エッジの選択状態は既存エッジから引き継ぐ
+    // タイムラインモード時にdiffStatusマップを構築する
+    // previousSnapshotIndex と activeSnapshotIndex が両方 null でない場合のみdiff計算を行う
+    const diffStatusMap = new Map<string, DiffStatus>();
+    if (
+      timelineMode &&
+      previousSnapshotIndex !== null &&
+      activeSnapshotIndex !== null
+    ) {
+      const fromSnapshot = snapshots[previousSnapshotIndex];
+      const toSnapshot = snapshots[activeSnapshotIndex];
+      if (fromSnapshot && toSnapshot) {
+        const diff = computeSnapshotDiff(fromSnapshot, toSnapshot);
+        for (const rel of diff.relationships.added) {
+          diffStatusMap.set(rel.relationshipId, 'added');
+        }
+        for (const rel of diff.relationships.changed) {
+          diffStatusMap.set(rel.relationshipId, 'changed');
+        }
+        // removed エッジはストア確定後には存在しないため、diffStatusMapには含めない
+      }
+    }
+
+    // エッジの選択状態は既存エッジから引き継ぐ。タイムラインモード時はdiffStatusも付与する
     setEdges((prevEdges) => {
       const prevEdgeMap = new Map(prevEdges.map((edge) => [edge.id, edge]));
       const updatedEdges = newEdges.map((newEdge) => {
         const existingEdge = prevEdgeMap.get(newEdge.id);
+        // タイムラインモードのdiff表示: diffStatusMapに存在するIDのみハイライト
+        const diffStatus = diffStatusMap.size > 0
+          ? (diffStatusMap.get(newEdge.id) ?? null)
+          : undefined;
         return {
           ...newEdge,
           selected: existingEdge?.selected ?? false,
+          data: newEdge.data
+            ? { ...newEdge.data, diffStatus }
+            : newEdge.data,
         };
       });
       return updatedEdges;
@@ -157,7 +192,7 @@ export function useGraphDataSync() {
         collisionResolutionRafIdRef.current = null;
       }
     };
-  }, [persons, relationships, setNodes, setEdges, forceEnabled, updatePersonPositions, edgeFilter]);
+  }, [persons, relationships, setNodes, setEdges, forceEnabled, updatePersonPositions, edgeFilter, timelineMode, activeSnapshotIndex, previousSnapshotIndex, snapshots]);
 
   // 選択状態の変更時に既存ノード/エッジのselectedプロパティのみ更新
   // 配列参照を変更しないようにhasChangedフラグで最適化

--- a/src/components/graph/useGraphDataSync.ts
+++ b/src/components/graph/useGraphDataSync.ts
@@ -177,10 +177,10 @@ export function useGraphDataSync() {
         return {
           ...newEdge,
           selected: existingEdge?.selected ?? false,
-          data: newEdge.data
-            ? { ...newEdge.data, diffStatus }
-            : newEdge.data,
-        };
+          // newEdge.data が存在する場合は diffStatus を付与する。
+          // data が undefined の場合（通常は発生しない）はそのまま渡す
+          ...(newEdge.data ? { data: { ...newEdge.data, diffStatus } } : {}),
+        } as RelationshipEdge;
       });
       return updatedEdges;
     });

--- a/src/components/graph/useGraphDataSync.ts
+++ b/src/components/graph/useGraphDataSync.ts
@@ -33,7 +33,10 @@ export function useGraphDataSync() {
   const timelineMode = useGraphStore((state) => state.timelineMode);
   const activeSnapshotIndex = useGraphStore((state) => state.activeSnapshotIndex);
   const previousSnapshotIndex = useGraphStore((state) => state.previousSnapshotIndex);
-  const snapshots = useGraphStore((state) => state.snapshots);
+  // タイムラインモード時のみ snapshots を購読する
+  // timelineMode=false の場合は null を返す安定したセレクターにして、
+  // スナップショット追加/編集時の不要なuseEffect再実行を防ぐ
+  const snapshots = useGraphStore((state) => state.timelineMode ? state.snapshots : null);
 
   // React Flowのノード/エッジ状態
   const [nodes, setNodes, onNodesChange] = useNodesState<GraphNode>([]);
@@ -149,7 +152,8 @@ export function useGraphDataSync() {
     if (
       timelineMode &&
       previousSnapshotIndex !== null &&
-      activeSnapshotIndex !== null
+      activeSnapshotIndex !== null &&
+      snapshots !== null
     ) {
       const fromSnapshot = snapshots[previousSnapshotIndex];
       const toSnapshot = snapshots[activeSnapshotIndex];

--- a/src/components/graph/useSnapshotTransition.ts
+++ b/src/components/graph/useSnapshotTransition.ts
@@ -24,9 +24,11 @@ import { useReactFlow } from '@xyflow/react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { deriveEdgeVisual } from '@/lib/relationship-visual';
+import { computeSnapshotDiff } from '@/lib/snapshot-diff';
 import type { GraphNode, RelationshipEdge } from '@/types/graph';
 import type { SnapshotRelationship } from '@/types/snapshot';
 import type { Relationship } from '@/types/relationship';
+import type { DiffStatus } from '@/lib/diff-highlight';
 
 /** アニメーション時間（ミリ秒） */
 const TRANSITION_DURATION_MS = 300;
@@ -102,11 +104,12 @@ function snapshotRelationshipsToEdges(relationships: SnapshotRelationship[]): Re
 export function useSnapshotTransition(): UseSnapshotTransitionResult {
   const { getNodes, setNodes, getEdges, setEdges } = useReactFlow();
 
-  const { snapshots, _livePersons, goToSnapshot } = useGraphStore(
+  const { snapshots, _livePersons, goToSnapshot, activeSnapshotIndex } = useGraphStore(
     useShallow((state) => ({
       snapshots: state.snapshots,
       _livePersons: state._livePersons,
       goToSnapshot: state.goToSnapshot,
+      activeSnapshotIndex: state.activeSnapshotIndex,
     }))
   );
 
@@ -117,8 +120,8 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // useCallback の依存配列に入れられない値をrefで保持する
-  const storeRef = useRef({ snapshots, _livePersons, goToSnapshot });
-  storeRef.current = { snapshots, _livePersons, goToSnapshot };
+  const storeRef = useRef({ snapshots, _livePersons, goToSnapshot, activeSnapshotIndex });
+  storeRef.current = { snapshots, _livePersons, goToSnapshot, activeSnapshotIndex };
 
   // アンマウント時に rAF と setTimeout をクリーンアップする
   // これにより unmount 後に setNodes / setIsTransitioning / goToSnapshot が呼ばれるリークを防ぐ
@@ -137,8 +140,12 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
 
   const transitionToSnapshot = useCallback(
     (targetIndex: number) => {
-      const { snapshots: currentSnapshots, _livePersons: livePersons, goToSnapshot: storeGoToSnapshot } =
-        storeRef.current;
+      const {
+        snapshots: currentSnapshots,
+        _livePersons: livePersons,
+        goToSnapshot: storeGoToSnapshot,
+        activeSnapshotIndex: currentSnapshotIndex,
+      } = storeRef.current;
 
       const targetSnapshot = currentSnapshots[targetIndex];
       // 存在しないインデックスは何もしない（Fail-Fast）
@@ -181,6 +188,23 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
       // 遷移先スナップショットからターゲットエッジを構築する
       const targetEdges = snapshotRelationshipsToEdges(targetSnapshot.relationships);
       const targetEdgeMap = new Map(targetEdges.map((e) => [e.id, e]));
+
+      // スナップショット間のdiffを計算してdiffStatusマップを構築する
+      // ライブ→スナップショット遷移時（currentSnapshotIndex=null）はdiffなし
+      const diffStatusMap = new Map<string, DiffStatus>();
+      if (currentSnapshotIndex !== null) {
+        const fromSnapshot = currentSnapshots[currentSnapshotIndex];
+        if (fromSnapshot) {
+          const diff = computeSnapshotDiff(fromSnapshot, targetSnapshot);
+          for (const rel of diff.relationships.added) {
+            diffStatusMap.set(rel.relationshipId, 'added');
+          }
+          for (const rel of diff.relationships.changed) {
+            diffStatusMap.set(rel.relationshipId, 'changed');
+          }
+          // removed は削除エッジのフェードアウト中に 'removed' を設定する（下記で対応）
+        }
+      }
 
       // アニメーション開始位置を記録（移動ノードの補間用）
       const startPositions = new Map(
@@ -239,11 +263,15 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
         // エッジアニメーション
         const animatedEdges: RelationshipEdge[] = [];
 
-        // ターゲットエッジ（維持/追加）: フェードイン
+        // ターゲットエッジ（維持/追加）: フェードイン + diffStatus付与
         for (const targetEdge of targetEdges) {
           const isNewEdge = !currentEdgeMap.has(targetEdge.id);
+          const diffStatus = diffStatusMap.get(targetEdge.id) ?? null;
           animatedEdges.push({
             ...targetEdge,
+            data: targetEdge.data
+              ? { ...targetEdge.data, diffStatus }
+              : targetEdge.data,
             style: {
               // 新規エッジはフェードイン、既存エッジは不透明のまま
               opacity: isNewEdge ? easedProgress : 1,
@@ -251,11 +279,15 @@ export function useSnapshotTransition(): UseSnapshotTransitionResult {
           });
         }
 
-        // 削除エッジ: フェードアウト（ターゲットに存在しないもの）
+        // 削除エッジ: フェードアウト（ターゲットに存在しないもの）+ diffStatus='removed'
         for (const [id, currentEdge] of currentEdgeMap) {
           if (!targetEdgeMap.has(id)) {
+            const edge = currentEdge as RelationshipEdge;
             animatedEdges.push({
-              ...(currentEdge as RelationshipEdge),
+              ...edge,
+              data: edge.data
+                ? { ...edge.data, diffStatus: 'removed' as DiffStatus }
+                : edge.data,
               style: {
                 opacity: 1 - easedProgress,
               },

--- a/src/lib/diff-highlight.test.ts
+++ b/src/lib/diff-highlight.test.ts
@@ -1,0 +1,75 @@
+/**
+ * diff-highlight モジュールのテスト
+ *
+ * getDiffEdgeStyle / getDiffMarkerKey の各diffStatusに対する返却値を検証する
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getDiffEdgeStyle, getDiffMarkerKey, DIFF_HIGHLIGHT_COLORS } from './diff-highlight';
+
+describe('DIFF_HIGHLIGHT_COLORS', () => {
+  it('added は緑色である', () => {
+    expect(DIFF_HIGHLIGHT_COLORS.added).toBe('#22c55e');
+  });
+
+  it('removed は赤色である', () => {
+    expect(DIFF_HIGHLIGHT_COLORS.removed).toBe('#ef4444');
+  });
+
+  it('changed は青色である', () => {
+    expect(DIFF_HIGHLIGHT_COLORS.changed).toBe('#3b82f6');
+  });
+});
+
+describe('getDiffEdgeStyle', () => {
+  it('diffStatus が "added" のとき緑色とハイライト線幅を返す', () => {
+    const style = getDiffEdgeStyle('added');
+    expect(style).not.toBeNull();
+    expect(style?.stroke).toBe('#22c55e');
+    expect(style?.strokeWidth).toBeGreaterThan(1);
+  });
+
+  it('diffStatus が "removed" のとき赤色とハイライト線幅を返す', () => {
+    const style = getDiffEdgeStyle('removed');
+    expect(style).not.toBeNull();
+    expect(style?.stroke).toBe('#ef4444');
+    expect(style?.strokeWidth).toBeGreaterThan(1);
+  });
+
+  it('diffStatus が "changed" のとき青色とハイライト線幅を返す', () => {
+    const style = getDiffEdgeStyle('changed');
+    expect(style).not.toBeNull();
+    expect(style?.stroke).toBe('#3b82f6');
+    expect(style?.strokeWidth).toBeGreaterThan(1);
+  });
+
+  it('diffStatus が null のとき null を返す', () => {
+    expect(getDiffEdgeStyle(null)).toBeNull();
+  });
+
+  it('diffStatus が undefined のとき null を返す', () => {
+    expect(getDiffEdgeStyle(undefined)).toBeNull();
+  });
+});
+
+describe('getDiffMarkerKey', () => {
+  it('diffStatus が "added" のとき "green" を返す', () => {
+    expect(getDiffMarkerKey('added')).toBe('green');
+  });
+
+  it('diffStatus が "removed" のとき "red" を返す', () => {
+    expect(getDiffMarkerKey('removed')).toBe('red');
+  });
+
+  it('diffStatus が "changed" のとき "blue" を返す', () => {
+    expect(getDiffMarkerKey('changed')).toBe('blue');
+  });
+
+  it('diffStatus が null のとき null を返す', () => {
+    expect(getDiffMarkerKey(null)).toBeNull();
+  });
+
+  it('diffStatus が undefined のとき null を返す', () => {
+    expect(getDiffMarkerKey(undefined)).toBeNull();
+  });
+});

--- a/src/lib/diff-highlight.ts
+++ b/src/lib/diff-highlight.ts
@@ -32,6 +32,16 @@ export const DIFF_HIGHLIGHT_COLORS = {
 const DIFF_STROKE_WIDTH = 3;
 
 /**
+ * diffStatusに対応するSVGマーカーキーのマップ
+ * RelationshipGraph の固定6色マーカー定義と対応する
+ */
+const DIFF_MARKER_MAP = {
+  added: 'green',
+  removed: 'red',
+  changed: 'blue',
+} as const;
+
+/**
  * diffStatusに対応するエッジのstyleを返す
  *
  * @param diffStatus - エッジのdiff状態
@@ -58,10 +68,5 @@ export function getDiffMarkerKey(
   diffStatus: DiffStatus | undefined
 ): 'green' | 'red' | 'blue' | null {
   if (!diffStatus) return null;
-  const markerMap = {
-    added: 'green',
-    removed: 'red',
-    changed: 'blue',
-  } as const;
-  return markerMap[diffStatus];
+  return DIFF_MARKER_MAP[diffStatus];
 }

--- a/src/lib/diff-highlight.ts
+++ b/src/lib/diff-highlight.ts
@@ -1,0 +1,67 @@
+/**
+ * スナップショットdiffハイライトのスタイルユーティリティ
+ *
+ * スナップショット間の差分（追加/削除/変更）に対応する色・スタイルを提供する。
+ * RelationshipEdge コンポーネントから参照され、エッジの視覚的なdiff表示に使用する。
+ *
+ * 色定義:
+ *   - 追加エッジ: 緑色 (#22c55e)
+ *   - 削除エッジ: 赤色 (#ef4444)
+ *   - 変更エッジ: 青色 (#3b82f6)
+ */
+
+/**
+ * エッジのdiff状態を表す型
+ * null / undefined はdiffハイライトなし（通常表示）
+ */
+export type DiffStatus = 'added' | 'removed' | 'changed' | null;
+
+/**
+ * diffStatusに対応するエッジストローク色の定数
+ */
+export const DIFF_HIGHLIGHT_COLORS = {
+  /** 追加エッジ: 緑色 */
+  added: '#22c55e',
+  /** 削除エッジ: 赤色 */
+  removed: '#ef4444',
+  /** 変更エッジ: 青色 */
+  changed: '#3b82f6',
+} as const;
+
+/** diffハイライト時のストローク幅 */
+const DIFF_STROKE_WIDTH = 3;
+
+/**
+ * diffStatusに対応するエッジのstyleを返す
+ *
+ * @param diffStatus - エッジのdiff状態
+ * @returns エッジのstyle（stroke / strokeWidth）、diffなしの場合は null
+ */
+export function getDiffEdgeStyle(
+  diffStatus: DiffStatus | undefined
+): { stroke: string; strokeWidth: number } | null {
+  if (!diffStatus) return null;
+  return {
+    stroke: DIFF_HIGHLIGHT_COLORS[diffStatus],
+    strokeWidth: DIFF_STROKE_WIDTH,
+  };
+}
+
+/**
+ * diffStatusに対応するSVGマーカーキーを返す
+ * RelationshipGraph に定義された固定6色マーカー（red/blue/green等）と対応する。
+ *
+ * @param diffStatus - エッジのdiff状態
+ * @returns マーカーキー文字列、diffなしの場合は null
+ */
+export function getDiffMarkerKey(
+  diffStatus: DiffStatus | undefined
+): 'green' | 'red' | 'blue' | null {
+  if (!diffStatus) return null;
+  const markerMap = {
+    added: 'green',
+    removed: 'red',
+    changed: 'blue',
+  } as const;
+  return markerMap[diffStatus];
+}

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3734,6 +3734,32 @@ describe('useGraphStore', () => {
         });
         expect(result.current.previousSnapshotIndex).toBeNull();
       });
+
+      it('同じインデックスで goToSnapshot を2回呼ぶと previousSnapshotIndex は直前のインデックスになる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        // 2つのスナップショットを作成して第1話から第1話へ再移動するエッジケースを検証
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+          result.current.goToSnapshot(1);
+        });
+        // activeSnapshotIndex=1, previousSnapshotIndex=null（ライブから移動）
+        expect(result.current.previousSnapshotIndex).toBeNull();
+        expect(result.current.activeSnapshotIndex).toBe(1);
+
+        // 同じインデックスに再移動
+        act(() => {
+          result.current.goToSnapshot(1);
+        });
+        // previousSnapshotIndex は呼び出し前の activeSnapshotIndex（=1）になる
+        expect(result.current.previousSnapshotIndex).toBe(1);
+        expect(result.current.activeSnapshotIndex).toBe(1);
+      });
     });
 
     describe('isPlaying / playbackSpeed', () => {

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -3648,6 +3648,94 @@ describe('useGraphStore', () => {
       });
     });
 
+    describe('previousSnapshotIndex', () => {
+      it('初期状態では previousSnapshotIndex が null である', () => {
+        const { result } = renderHook(() => useGraphStore());
+        expect(result.current.previousSnapshotIndex).toBeNull();
+      });
+
+      it('goToSnapshot で activeSnapshotIndex が previousSnapshotIndex に保存される', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        // 第1話・第2話・第3話を作成
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+          result.current.captureSnapshot('第3話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+        });
+
+        // 第1話に移動（直前のactiveSnapshotIndexはnull）
+        act(() => {
+          result.current.goToSnapshot(0);
+        });
+
+        // 第2話に移動（直前のactiveSnapshotIndexは0）
+        act(() => {
+          result.current.goToSnapshot(1);
+        });
+        expect(result.current.previousSnapshotIndex).toBe(0);
+        expect(result.current.activeSnapshotIndex).toBe(1);
+
+        // 第3話に移動（直前のactiveSnapshotIndexは1）
+        act(() => {
+          result.current.goToSnapshot(2);
+        });
+        expect(result.current.previousSnapshotIndex).toBe(1);
+        expect(result.current.activeSnapshotIndex).toBe(2);
+      });
+
+      it('goToLive で previousSnapshotIndex が null にリセットされる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+          result.current.goToSnapshot(0);
+          result.current.goToSnapshot(1);
+        });
+
+        // previousSnapshotIndexが設定されていること
+        expect(result.current.previousSnapshotIndex).toBe(0);
+
+        // ライブに戻るとリセットされること
+        act(() => {
+          result.current.goToLive();
+        });
+        expect(result.current.previousSnapshotIndex).toBeNull();
+      });
+
+      it('setTimelineMode(false) で previousSnapshotIndex が null にリセットされる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.captureSnapshot('第1話');
+          result.current.captureSnapshot('第2話');
+        });
+
+        act(() => {
+          result.current.setTimelineMode(true);
+          result.current.goToSnapshot(0);
+          result.current.goToSnapshot(1);
+        });
+
+        expect(result.current.previousSnapshotIndex).toBe(0);
+
+        // タイムラインモード終了でリセットされること
+        act(() => {
+          result.current.setTimelineMode(false);
+        });
+        expect(result.current.previousSnapshotIndex).toBeNull();
+      });
+    });
+
     describe('isPlaying / playbackSpeed', () => {
       it('setPlaying(true) で isPlaying が true になる', () => {
         // GIVEN: 初期状態（isPlaying=false）

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -103,6 +103,11 @@ type GraphState = {
   isPlaying: boolean;
   /** 自動再生の再生間隔（ミリ秒）。PLAYBACK_SPEEDS で定義された3段階のみ有効 */
   playbackSpeed: PlaybackSpeed;
+  /**
+   * 直前に表示していたスナップショットのインデックス
+   * diffハイライト計算に使用する。null = 直前のスナップショットなし（diffハイライトなし）
+   */
+  previousSnapshotIndex: number | null;
 };
 
 /**
@@ -130,6 +135,7 @@ const INITIAL_STATE: GraphState = {
   _liveRelationships: null,
   isPlaying: false,
   playbackSpeed: 2000,
+  previousSnapshotIndex: null,
 };
 
 
@@ -1206,10 +1212,12 @@ export const useGraphStore = create<GraphStore>()(
           } else {
             // タイムラインモードを終了: ライブデータを復元してpauseAutoSave=false
             // isPlayingもリセットして再生を確実に停止する
+            // previousSnapshotIndexもリセットしてdiffハイライトをクリアする
             set((s) => ({
               timelineMode: false,
               pauseAutoSave: false,
               activeSnapshotIndex: null,
+              previousSnapshotIndex: null,
               isPlaying: false,
               persons: s._livePersons ?? s.persons,
               relationships: s._liveRelationships ?? s.relationships,
@@ -1278,8 +1286,11 @@ export const useGraphStore = create<GraphStore>()(
             updatedAt: snapshot.createdAt,
           }));
 
+          // 直前のスナップショットインデックスを保存してdiffハイライト計算に使用する
+          const previousIndex = state.activeSnapshotIndex;
           set(() => ({
             activeSnapshotIndex: index,
+            previousSnapshotIndex: previousIndex,
             persons: restoredPersons,
             relationships: restoredRelationships,
           }));
@@ -1292,6 +1303,7 @@ export const useGraphStore = create<GraphStore>()(
 
           set((s) => ({
             activeSnapshotIndex: null,
+            previousSnapshotIndex: null,
             persons: s._livePersons ?? s.persons,
             relationships: s._liveRelationships ?? s.relationships,
           }));

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -5,6 +5,7 @@
 
 import type { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
 import type { EdgeVisual } from '@/lib/relationship-visual';
+import type { DiffStatus } from '@/lib/diff-highlight';
 
 /**
  * カスタムノードのデータ型
@@ -41,6 +42,12 @@ export type RelationshipEdgeData = {
   edgeIndex: number;
   /** 同一ペア内のエッジ総数。並列描画オフセットの計算に使用 */
   totalEdgesInPair: number;
+  /**
+   * スナップショット間のdiff状態
+   * タイムラインモード中のスナップショット切り替え時にのみ設定される。
+   * null / undefined は通常表示（diffハイライトなし）
+   */
+  diffStatus?: DiffStatus;
 };
 
 /**


### PR DESCRIPTION
## Summary

- スナップショット切り替え時に「変化したエッジ」を色でハイライト表示する機能を追加
- 追加されたエッジ: 緑色で強調
- 変更されたエッジ（プロパティ変更）: 青色で強調
- 削除されたエッジ: アニメーション中に赤色でフェードアウト

## 実装内容

### 新規ファイル
- `src/lib/diff-highlight.ts` - DiffStatus型・色定数・スタイル取得関数
- `src/lib/diff-highlight.test.ts` - TDDで13テスト

### 変更ファイル
- `src/types/graph.ts` - `RelationshipEdgeData` に `diffStatus?: DiffStatus` を追加
- `src/stores/useGraphStore.ts` - `previousSnapshotIndex` を追加（直前スナップショットの追跡）
- `src/components/graph/useSnapshotTransition.ts` - アニメーション中のdiffStatus付与
- `src/components/graph/useGraphDataSync.ts` - ストア確定後のdiffStatus付与
- `src/components/graph/RelationshipEdge.tsx` - diffStatusに応じた色・マーカー変更

## Test plan

- [x] `npm run lint` 警告ゼロ
- [x] `npm run type-check` エラーゼロ
- [x] `npm test` 1071テスト全通過
- [x] `npm run build` 成功
- [x] ブラウザ手動確認: 第1話→第2話切り替え時に追加エッジ（緑）・変更エッジ（青）が表示される
- [x] ライブへ戻るとdiffハイライトがクリアされる

Refs #94 (Phase 3-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)