### PR TITLE
feat: スナップショット一覧のラベルインライン編集機能を追加 (#94 Phase 3-3)

### DIFF
--- a/src/components/panel/SnapshotList.tsx
+++ b/src/components/panel/SnapshotList.tsx
@@ -72,6 +72,7 @@ export function SnapshotList() {
     goToLive,
     deleteSnapshot,
     reorderSnapshots,
+    updateSnapshot,
   } = useGraphStore(
     useShallow((state) => ({
       snapshots: state.snapshots,
@@ -82,6 +83,7 @@ export function SnapshotList() {
       goToLive: state.goToLive,
       deleteSnapshot: state.deleteSnapshot,
       reorderSnapshots: state.reorderSnapshots,
+      updateSnapshot: state.updateSnapshot,
     }))
   );
 
@@ -177,6 +179,7 @@ export function SnapshotList() {
                     onSetTimelineMode={setTimelineMode}
                     onGoToLive={goToLive}
                     onDelete={deleteSnapshot}
+                    onRenameSnapshot={(id, label) => updateSnapshot(id, { label })}
                   />
                 );
               })}

--- a/src/components/panel/SortableSnapshotItem.test.tsx
+++ b/src/components/panel/SortableSnapshotItem.test.tsx
@@ -11,6 +11,7 @@ import { userEvent } from '@testing-library/user-event';
 import { DndContext } from '@dnd-kit/core';
 import { SortableSnapshotItem } from './SortableSnapshotItem';
 import type { Snapshot } from '@/types/snapshot';
+import type { SortableSnapshotItemProps } from './SortableSnapshotItem';
 
 /** テスト用スナップショットを生成する */
 const createMockSnapshot = (overrides: Partial<Snapshot> = {}): Snapshot => ({
@@ -27,12 +28,14 @@ describe('SortableSnapshotItem', () => {
   const mockOnSetTimelineMode = vi.fn();
   const mockOnGoToLive = vi.fn();
   const mockOnDelete = vi.fn();
+  const mockOnRenameSnapshot = vi.fn();
 
   beforeEach(() => {
     mockOnGoToSnapshot.mockClear();
     mockOnSetTimelineMode.mockClear();
     mockOnGoToLive.mockClear();
     mockOnDelete.mockClear();
+    mockOnRenameSnapshot.mockClear();
   });
 
   /** デフォルトのpropsでコンポーネントを描画するヘルパー */
@@ -43,18 +46,20 @@ describe('SortableSnapshotItem', () => {
     timelineMode?: boolean;
   } = {}) => {
     const snapshot = createMockSnapshot(overrides.snapshot);
+    const props: SortableSnapshotItemProps = {
+      snapshot,
+      index: overrides.index ?? 0,
+      isActive: overrides.isActive ?? false,
+      timelineMode: overrides.timelineMode ?? false,
+      onGoToSnapshot: mockOnGoToSnapshot,
+      onSetTimelineMode: mockOnSetTimelineMode,
+      onGoToLive: mockOnGoToLive,
+      onDelete: mockOnDelete,
+      onRenameSnapshot: mockOnRenameSnapshot,
+    };
     return render(
       <DndContext>
-        <SortableSnapshotItem
-          snapshot={snapshot}
-          index={overrides.index ?? 0}
-          isActive={overrides.isActive ?? false}
-          timelineMode={overrides.timelineMode ?? false}
-          onGoToSnapshot={mockOnGoToSnapshot}
-          onSetTimelineMode={mockOnSetTimelineMode}
-          onGoToLive={mockOnGoToLive}
-          onDelete={mockOnDelete}
-        />
+        <SortableSnapshotItem {...props} />
       </DndContext>
     );
   };
@@ -143,5 +148,102 @@ describe('SortableSnapshotItem', () => {
     await user.click(screen.getByRole('button', { name: '第1話を削除' }));
 
     expect(mockOnDelete).toHaveBeenCalledWith('test-snapshot-id');
+  });
+
+  describe('ラベル編集', () => {
+    it('タイムラインモード外で編集ボタンが表示される', () => {
+      renderComponent({ snapshot: { label: '第1話' }, timelineMode: false });
+
+      expect(screen.getByRole('button', { name: '第1話を編集' })).toBeInTheDocument();
+    });
+
+    it('タイムラインモード中は編集ボタンが非表示になる', () => {
+      renderComponent({ snapshot: { label: '第1話' }, timelineMode: true });
+
+      expect(screen.queryByRole('button', { name: '第1話を編集' })).not.toBeInTheDocument();
+    });
+
+    it('編集ボタンクリックでinputが表示され、現在のラベルがvalueに入る', async () => {
+      const user = userEvent.setup();
+      renderComponent({ snapshot: { label: '第1話' }, timelineMode: false });
+
+      await user.click(screen.getByRole('button', { name: '第1話を編集' }));
+
+      const input = screen.getByRole('textbox', { name: 'ラベルを編集' });
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveValue('第1話');
+    });
+
+    it('Enterキーを押すとonRenameSnapshotが新しいラベルで呼ばれる', async () => {
+      const user = userEvent.setup();
+      renderComponent({
+        snapshot: { id: 'snap-001', label: '第1話' },
+        timelineMode: false,
+      });
+
+      await user.click(screen.getByRole('button', { name: '第1話を編集' }));
+      const input = screen.getByRole('textbox', { name: 'ラベルを編集' });
+      await user.clear(input);
+      await user.type(input, '第一章');
+      await user.keyboard('{Enter}');
+
+      expect(mockOnRenameSnapshot).toHaveBeenCalledWith('snap-001', '第一章');
+    });
+
+    it('Escapeキーを押すとキャンセルされてonRenameSnapshotが呼ばれない', async () => {
+      const user = userEvent.setup();
+      renderComponent({ snapshot: { label: '第1話' }, timelineMode: false });
+
+      await user.click(screen.getByRole('button', { name: '第1話を編集' }));
+      const input = screen.getByRole('textbox', { name: 'ラベルを編集' });
+      await user.clear(input);
+      await user.type(input, '第一章');
+      await user.keyboard('{Escape}');
+
+      expect(mockOnRenameSnapshot).not.toHaveBeenCalled();
+      // 編集モードが終了してラベルボタンが元に戻る
+      expect(screen.getByText('第1話')).toBeInTheDocument();
+    });
+
+    it('blurするとonRenameSnapshotが呼ばれる', async () => {
+      const user = userEvent.setup();
+      renderComponent({
+        snapshot: { id: 'snap-001', label: '第1話' },
+        timelineMode: false,
+      });
+
+      await user.click(screen.getByRole('button', { name: '第1話を編集' }));
+      const input = screen.getByRole('textbox', { name: 'ラベルを編集' });
+      await user.clear(input);
+      await user.type(input, '第一章');
+      // inputからフォーカスを外す（blur）
+      await user.tab();
+
+      expect(mockOnRenameSnapshot).toHaveBeenCalledWith('snap-001', '第一章');
+    });
+
+    it('空白のみのラベルでは保存されずonRenameSnapshotが呼ばれない', async () => {
+      const user = userEvent.setup();
+      renderComponent({ snapshot: { label: '第1話' }, timelineMode: false });
+
+      await user.click(screen.getByRole('button', { name: '第1話を編集' }));
+      const input = screen.getByRole('textbox', { name: 'ラベルを編集' });
+      await user.clear(input);
+      await user.type(input, '   ');
+      await user.keyboard('{Enter}');
+
+      expect(mockOnRenameSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('ラベルを変更せずにEnterを押してもonRenameSnapshotが呼ばれない', async () => {
+      const user = userEvent.setup();
+      renderComponent({ snapshot: { label: '第1話' }, timelineMode: false });
+
+      await user.click(screen.getByRole('button', { name: '第1話を編集' }));
+      // 変更せずにEnter
+      await user.keyboard('{Enter}');
+
+      expect(mockOnRenameSnapshot).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/panel/SortableSnapshotItem.tsx
+++ b/src/components/panel/SortableSnapshotItem.tsx
@@ -4,15 +4,16 @@
  * @dnd-kit/sortableを使用してドラッグ&ドロップで並び替え可能なスナップショット項目。
  * SnapshotList内で使用され、GripVerticalアイコンのドラッグハンドルで並び替えを行う。
  *
- * 注意: タイムラインモード中はドラッグハンドルを非表示にする。
+ * 注意: タイムラインモード中はドラッグハンドル・編集ボタン・削除ボタンを非表示にする。
  * activeSnapshotIndexがインデックスベースのため、再生中の並び替えは禁止。
  */
 
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Trash2, GripVertical } from 'lucide-react';
+import { Trash2, GripVertical, Pencil } from 'lucide-react';
 import type { Snapshot } from '@/types/snapshot';
 
 /**
@@ -35,6 +36,8 @@ export type SortableSnapshotItemProps = {
   onGoToLive: () => void;
   /** スナップショットを削除するハンドラー */
   onDelete: (snapshotId: string) => void;
+  /** スナップショットのラベルを変更するハンドラー */
+  onRenameSnapshot: (snapshotId: string, newLabel: string) => void;
 };
 
 /**
@@ -49,6 +52,7 @@ export function SortableSnapshotItem({
   onSetTimelineMode,
   onGoToLive,
   onDelete,
+  onRenameSnapshot,
 }: SortableSnapshotItemProps) {
   const {
     attributes,
@@ -58,6 +62,84 @@ export function SortableSnapshotItem({
     transition,
     isDragging,
   } = useSortable({ id: snapshot.id });
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editLabel, setEditLabel] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  /** blur/Enter/Escapeの競合を防ぐフラグ */
+  const isSavingRef = useRef<boolean>(false);
+
+  // 編集モードに切り替わった時に入力フィールドにフォーカスして全選択
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  /**
+   * 編集ボタンクリックで編集モード開始
+   */
+  const handleEditClick = () => {
+    setEditLabel(snapshot.label);
+    setIsEditing(true);
+  };
+
+  /**
+   * ラベル変更を保存する。
+   * 空文字・変更なしの場合は保存しない。
+   */
+  const handleRenameSave = () => {
+    // 既に保存処理中またはキャンセル済みの場合は何もしない
+    if (isSavingRef.current) return;
+
+    isSavingRef.current = true;
+
+    const trimmedLabel = editLabel.trim();
+    if (trimmedLabel && trimmedLabel !== snapshot.label) {
+      onRenameSnapshot(snapshot.id, trimmedLabel);
+    }
+    setIsEditing(false);
+
+    setTimeout(() => {
+      isSavingRef.current = false;
+    }, 0);
+  };
+
+  /**
+   * ラベル変更をキャンセルする。
+   * Escapeキー押下時に呼ばれ、blurによる誤保存を防ぐためisSavingRefを先にセットする。
+   */
+  const handleRenameCancel = () => {
+    // 保存処理をブロック（Escape→blurの順で発火した場合にblur側の保存を防ぐ）
+    isSavingRef.current = true;
+
+    setIsEditing(false);
+    setEditLabel(snapshot.label);
+
+    setTimeout(() => {
+      isSavingRef.current = false;
+    }, 0);
+  };
+
+  /**
+   * 入力フィールドのキーダウンイベント処理
+   */
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      // IME変換中のEnterは無視（日本語入力の変換確定時の誤動作を防ぐ）
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+      e.preventDefault();
+      handleRenameSave();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      // Escapeキーが押された時点で保存処理をブロック（blurより先に設定）
+      isSavingRef.current = true;
+      handleRenameCancel();
+    }
+  };
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -92,21 +174,36 @@ export function SortableSnapshotItem({
         {index + 1}.
       </span>
 
-      {/* ラベル（クリックでジャンプ） */}
-      <button
-        onClick={() => {
-          if (!timelineMode) {
-            onSetTimelineMode(true);
-          }
-          onGoToSnapshot(index);
-        }}
-        className={`flex-1 text-left text-sm truncate ${
-          isActive ? 'text-blue-700 font-medium' : 'text-gray-700 hover:text-gray-900'
-        }`}
-        title={snapshot.description ?? snapshot.label}
-      >
-        {snapshot.label}
-      </button>
+      {/* ラベル（編集モードでinputに切り替わる） */}
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={editLabel}
+          onChange={(e) => setEditLabel(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleRenameSave}
+          onClick={(e) => e.stopPropagation()}
+          maxLength={50}
+          className="flex-1 px-1 py-0.5 text-sm border border-blue-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 min-w-0"
+          aria-label="ラベルを編集"
+        />
+      ) : (
+        <button
+          onClick={() => {
+            if (!timelineMode) {
+              onSetTimelineMode(true);
+            }
+            onGoToSnapshot(index);
+          }}
+          className={`flex-1 text-left text-sm truncate ${
+            isActive ? 'text-blue-700 font-medium' : 'text-gray-700 hover:text-gray-900'
+          }`}
+          title={snapshot.description ?? snapshot.label}
+        >
+          {snapshot.label}
+        </button>
+      )}
 
       {/* ライブに戻るボタン（タイムラインモード中のアクティブ項目） */}
       {isActive && (
@@ -115,6 +212,18 @@ export function SortableSnapshotItem({
           className="text-xs text-blue-500 hover:text-blue-700 whitespace-nowrap transition-colors"
         >
           ライブへ
+        </button>
+      )}
+
+      {/* 編集ボタン（タイムラインモード外かつ非編集中のみ表示） */}
+      {!timelineMode && !isEditing && (
+        <button
+          onClick={handleEditClick}
+          className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-blue-500 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 rounded"
+          aria-label={`${snapshot.label}を編集`}
+          title={`${snapshot.label}を編集`}
+        >
+          <Pencil size={14} />
         </button>
       )}
 


### PR DESCRIPTION
## Summary

- スナップショット項目にPencilアイコンの編集ボタンを追加（ホバーで表示）
- 編集ボタンクリックでinputフィールドに切り替え、既存ラベルが入力済み状態で表示
- Enter/blur で保存、Escape でキャンセル
- IME変換中のEnterキーは誤動作防止のため無視（`isComposing` チェック）
- タイムラインモード中は編集ボタンを非表示（閲覧専用モードの一貫性）
- 空ラベル・変更なしの場合は保存しない

## 変更ファイル

- `src/components/panel/SortableSnapshotItem.tsx` - インライン編集UI追加
- `src/components/panel/SortableSnapshotItem.test.tsx` - ラベル編集テスト追加（8件）
- `src/components/panel/SnapshotList.tsx` - `updateSnapshot` をストアから取得して渡す

## Test plan

- [x] `npm test` 全テストパス（1079件）
- [x] `npm run lint` エラーなし
- [x] `npm run type-check` エラーなし
- [x] `npm run build` 成功

Refs #94 (Phase 3-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)