### PR TITLE
feat: turningPoints からスナップショットへのジャンプ機能を追加 (#94 Phase 3-5)

### DIFF
--- a/src/components/panel/PairSelectionPanel.test.tsx
+++ b/src/components/panel/PairSelectionPanel.test.tsx
@@ -1261,4 +1261,118 @@ describe('PairSelectionPanel', () => {
       expect(screen.getByLabelText('エッジの色')).toBeInTheDocument();
     });
   });
+
+  // ─── スナップショットジャンプ ─────────────────────────────────────────────
+
+  describe('スナップショットジャンプ', () => {
+    /** スナップショットの at と同名のラベルを持つスナップショット */
+    const testSnapshot = {
+      id: 'snap-1',
+      label: '第1話',
+      persons: [],
+      relationships: [],
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    const relWithTurningPoint = makeRel({
+      id: 'rel-1',
+      type: '友人',
+      sourceId: person1.id,
+      targetId: person2.id,
+      narrative: {
+        summary: null,
+        notes: null,
+        turningPoints: [{ at: '第1話', note: '出会いのエピソード' }],
+      },
+    });
+
+    beforeEach(() => {
+      useGraphStore.setState({
+        persons: [person1, person2],
+        relationships: [relWithTurningPoint],
+        selectedPersonIds: [person1.id, person2.id],
+        snapshots: [testSnapshot],
+        timelineMode: false,
+        activeSnapshotIndex: null,
+      });
+    });
+
+    it('turningPoints[].at がスナップショットのラベルに一致するとき、ジャンプボタンが表示される', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      // 物語的情報アコーディオンを開く
+      await user.click(screen.getByText('物語的情報'));
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /スナップショットへジャンプ/ })).toBeInTheDocument()
+      );
+    });
+
+    it('ジャンプボタンをクリックするとタイムラインモードが有効になり、対応スナップショットに移動する', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      await user.click(screen.getByText('物語的情報'));
+      const jumpButton = await screen.findByRole('button', { name: /スナップショットへジャンプ/ });
+      await user.click(jumpButton);
+
+      await waitFor(() => {
+        const state = useGraphStore.getState();
+        expect(state.timelineMode).toBe(true);
+        expect(state.activeSnapshotIndex).toBe(0);
+      });
+    });
+
+    it('スナップショットが存在しない場合はジャンプボタンが表示されない', async () => {
+      useGraphStore.setState({ snapshots: [] });
+
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      await user.click(screen.getByText('物語的情報'));
+      await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      expect(screen.queryByRole('button', { name: /スナップショットへジャンプ/ })).not.toBeInTheDocument();
+    });
+
+    it('turningPoints[].at がどのスナップショットラベルにも一致しない場合はジャンプボタンが表示されない', async () => {
+      useGraphStore.setState({
+        relationships: [makeRel({
+          id: 'rel-1',
+          type: '友人',
+          sourceId: person1.id,
+          targetId: person2.id,
+          narrative: {
+            summary: null,
+            notes: null,
+            turningPoints: [{ at: '存在しない時点', note: '出来事' }],
+          },
+        })],
+      });
+
+      const user = userEvent.setup();
+      render(
+        <ReactFlowProvider>
+          <PairSelectionPanel persons={[person1, person2]} />
+        </ReactFlowProvider>
+      );
+
+      await user.click(screen.getByText('物語的情報'));
+      await waitFor(() => screen.getByRole('button', { name: /ターニングポイントを追加/ }));
+
+      expect(screen.queryByRole('button', { name: /スナップショットへジャンプ/ })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -13,7 +13,7 @@
 
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { nanoid } from 'nanoid';
 import { useReactFlow } from '@xyflow/react';
 import { ArrowRight, Minus, Plus } from 'lucide-react';
@@ -25,6 +25,7 @@ import { PersonMiniIcon } from '@/components/panel/PersonMiniIcon';
 import { AWARENESS_OPTIONS } from '@/components/panel/pairSelectionHelpers';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { MAX_RELATIONSHIP_LABEL_LENGTH } from '@/lib/validation-constants';
+import { findSnapshotIndexByLabel } from '@/lib/snapshot-lookup';
 import { getNodeCenter, VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils';
 import { deriveNodeVisual } from '@/lib/node-visual';
 import type { Person } from '@/types/person';
@@ -53,6 +54,10 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
   const removeRelationship = useGraphStore((state) => state.removeRelationship);
   const clearSelection = useGraphStore((state) => state.clearSelection);
   const selectPerson = useGraphStore((state) => state.selectPerson);
+  const snapshots = useGraphStore((state) => state.snapshots);
+  const timelineMode = useGraphStore((state) => state.timelineMode);
+  const setTimelineMode = useGraphStore((state) => state.setTimelineMode);
+  const goToSnapshot = useGraphStore((state) => state.goToSnapshot);
 
   const { getNode, setCenter } = useReactFlow();
 
@@ -160,6 +165,30 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
   useEffect(() => {
     setSelectedRelId(edgesForPair[0]?.id ?? 'new');
   }, [person1.id, person2.id]); // edgesForPair は意図的に除外
+
+  /**
+   * at 文字列から対応するスナップショットのインデックスを返す。
+   * snapshots が変わった場合のみ再生成する。
+   */
+  const findSnapshotIndexByAt = useCallback(
+    (at: string) => findSnapshotIndexByLabel(at, snapshots),
+    [snapshots]
+  );
+
+  /**
+   * 指定インデックスのスナップショットへジャンプする。
+   * タイムラインモード外の場合はモードを有効化してからジャンプする。
+   * 2人選択状態は維持する（タイムラインモード中でも関係パネルを確認できるよう）。
+   */
+  const handleJumpToSnapshot = useCallback(
+    (index: number) => {
+      if (!timelineMode) {
+        setTimelineMode(true);
+      }
+      goToSnapshot(index);
+    },
+    [timelineMode, setTimelineMode, goToSnapshot]
+  );
 
   /** ノードを画面中央に移動する */
   const focusNode = (personId: string) => {
@@ -573,7 +602,12 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
                 className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded resize-none focus:outline-none focus:ring-1 focus:ring-blue-500"
               />
             </div>
-            <TurningPointsEditor value={turningPoints} onChange={setTurningPoints} />
+            <TurningPointsEditor
+              value={turningPoints}
+              onChange={setTurningPoints}
+              findSnapshotIndexByAt={findSnapshotIndexByAt}
+              onJumpToSnapshot={handleJumpToSnapshot}
+            />
           </div>
         </details>
 

--- a/src/components/panel/PairSelectionPanel.tsx
+++ b/src/components/panel/PairSelectionPanel.tsx
@@ -55,7 +55,6 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
   const clearSelection = useGraphStore((state) => state.clearSelection);
   const selectPerson = useGraphStore((state) => state.selectPerson);
   const snapshots = useGraphStore((state) => state.snapshots);
-  const timelineMode = useGraphStore((state) => state.timelineMode);
   const setTimelineMode = useGraphStore((state) => state.setTimelineMode);
   const goToSnapshot = useGraphStore((state) => state.goToSnapshot);
 
@@ -177,17 +176,15 @@ export function PairSelectionPanel({ persons }: PairSelectionPanelProps) {
 
   /**
    * 指定インデックスのスナップショットへジャンプする。
-   * タイムラインモード外の場合はモードを有効化してからジャンプする。
+   * setTimelineMode(true) は既にモード中でも副作用なく呼べるため常に呼び出す。
    * 2人選択状態は維持する（タイムラインモード中でも関係パネルを確認できるよう）。
    */
   const handleJumpToSnapshot = useCallback(
     (index: number) => {
-      if (!timelineMode) {
-        setTimelineMode(true);
-      }
+      setTimelineMode(true);
       goToSnapshot(index);
     },
-    [timelineMode, setTimelineMode, goToSnapshot]
+    [setTimelineMode, goToSnapshot]
   );
 
   /** ノードを画面中央に移動する */

--- a/src/components/panel/TurningPointsEditor.test.tsx
+++ b/src/components/panel/TurningPointsEditor.test.tsx
@@ -134,7 +134,7 @@ describe('TurningPointsEditor', () => {
         />
       );
 
-      expect(screen.getByRole('button', { name: /スナップショットへジャンプ/ })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /スナップショットへジャンプ/ })).toBeInTheDocument();
     });
 
     it('at が空文字の行にはジャンプボタンが表示されない', () => {

--- a/src/components/panel/TurningPointsEditor.test.tsx
+++ b/src/components/panel/TurningPointsEditor.test.tsx
@@ -14,6 +14,8 @@ function makeRow(id: string, at: string, note: string): TurningPointRow {
   return { id, at, note };
 }
 
+const noopChange = () => {};
+
 describe('TurningPointsEditor', () => {
   describe('描画', () => {
     it('「ターニングポイント」ラベルが表示される', () => {
@@ -97,6 +99,117 @@ describe('TurningPointsEditor', () => {
       fireEvent.change(noteInput, { target: { value: '再会' } });
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith([{ id: 'r1', at: '2020年', note: '再会' }]);
+    });
+  });
+
+  describe('スナップショットジャンプボタン', () => {
+    it('findSnapshotIndexByAt が null を返す行にはジャンプボタンが表示されない', () => {
+      const rows = [makeRow('r1', '第1話', '出来事')];
+      const findSnapshotIndexByAt = vi.fn().mockReturnValue(null);
+      const onJumpToSnapshot = vi.fn();
+
+      render(
+        <TurningPointsEditor
+          value={rows}
+          onChange={noopChange}
+          findSnapshotIndexByAt={findSnapshotIndexByAt}
+          onJumpToSnapshot={onJumpToSnapshot}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /スナップショットへジャンプ/ })).toBeNull();
+    });
+
+    it('findSnapshotIndexByAt が 0 以上の値を返す行にはジャンプボタンが表示される', () => {
+      const rows = [makeRow('r1', '第1話', '出来事')];
+      const findSnapshotIndexByAt = vi.fn().mockReturnValue(0);
+      const onJumpToSnapshot = vi.fn();
+
+      render(
+        <TurningPointsEditor
+          value={rows}
+          onChange={noopChange}
+          findSnapshotIndexByAt={findSnapshotIndexByAt}
+          onJumpToSnapshot={onJumpToSnapshot}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /スナップショットへジャンプ/ })).toBeTruthy();
+    });
+
+    it('at が空文字の行にはジャンプボタンが表示されない', () => {
+      const rows = [makeRow('r1', '', '出来事')];
+      const findSnapshotIndexByAt = vi.fn().mockReturnValue(0);
+      const onJumpToSnapshot = vi.fn();
+
+      render(
+        <TurningPointsEditor
+          value={rows}
+          onChange={noopChange}
+          findSnapshotIndexByAt={findSnapshotIndexByAt}
+          onJumpToSnapshot={onJumpToSnapshot}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /スナップショットへジャンプ/ })).toBeNull();
+    });
+
+    it('ジャンプボタンをクリックすると onJumpToSnapshot がマッチしたインデックスで呼ばれる', async () => {
+      const user = userEvent.setup();
+      const rows = [makeRow('r1', '第1話', '出来事')];
+      const findSnapshotIndexByAt = vi.fn().mockReturnValue(2);
+      const onJumpToSnapshot = vi.fn();
+
+      render(
+        <TurningPointsEditor
+          value={rows}
+          onChange={noopChange}
+          findSnapshotIndexByAt={findSnapshotIndexByAt}
+          onJumpToSnapshot={onJumpToSnapshot}
+        />
+      );
+
+      const jumpButton = screen.getByRole('button', { name: /スナップショットへジャンプ/ });
+      await user.click(jumpButton);
+
+      expect(onJumpToSnapshot).toHaveBeenCalledOnce();
+      expect(onJumpToSnapshot).toHaveBeenCalledWith(2);
+    });
+
+    it('findSnapshotIndexByAt と onJumpToSnapshot を渡さない場合（後方互換）、ジャンプボタンが表示されない', () => {
+      const rows = [makeRow('r1', '第1話', '出来事')];
+
+      render(
+        <TurningPointsEditor
+          value={rows}
+          onChange={noopChange}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /スナップショットへジャンプ/ })).toBeNull();
+    });
+
+    it('複数行のうちマッチする行にだけジャンプボタンが表示される', () => {
+      const rows = [
+        makeRow('r1', '第1話', '出来事A'),
+        makeRow('r2', '該当なし', '出来事B'),
+      ];
+      const findSnapshotIndexByAt = vi.fn().mockImplementation((at: string) => {
+        return at === '第1話' ? 0 : null;
+      });
+      const onJumpToSnapshot = vi.fn();
+
+      render(
+        <TurningPointsEditor
+          value={rows}
+          onChange={noopChange}
+          findSnapshotIndexByAt={findSnapshotIndexByAt}
+          onJumpToSnapshot={onJumpToSnapshot}
+        />
+      );
+
+      const jumpButtons = screen.queryAllByRole('button', { name: /スナップショットへジャンプ/ });
+      expect(jumpButtons).toHaveLength(1);
     });
   });
 });

--- a/src/components/panel/TurningPointsEditor.tsx
+++ b/src/components/panel/TurningPointsEditor.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback } from 'react';
 import { nanoid } from 'nanoid';
+import { SkipForward } from 'lucide-react';
 
 /** ターニングポイントの行（ローカルステート用） */
 export type TurningPointRow = {
@@ -24,13 +25,23 @@ export type TurningPointsEditorProps = {
   value: TurningPointRow[];
   /** 変更時に呼ばれるコールバック */
   onChange: (rows: TurningPointRow[]) => void;
+  /**
+   * at 文字列から対応するスナップショットのインデックスを解決する関数（省略可）。
+   * null を返した場合はジャンプボタンを非表示にする。
+   */
+  findSnapshotIndexByAt?: (at: string) => number | null;
+  /**
+   * スナップショットへジャンプするコールバック（省略可）。
+   * @param index - ジャンプ先スナップショットのインデックス
+   */
+  onJumpToSnapshot?: (index: number) => void;
 };
 
 /**
  * ターニングポイント動的リストエディタ
  * 行の追加・削除・編集を提供する
  */
-export function TurningPointsEditor({ value, onChange }: TurningPointsEditorProps) {
+export function TurningPointsEditor({ value, onChange, findSnapshotIndexByAt, onJumpToSnapshot }: TurningPointsEditorProps) {
   const handleAdd = useCallback(() => {
     onChange([...value, { id: nanoid(), at: '', note: '' }]);
   }, [value, onChange]);
@@ -64,6 +75,22 @@ export function TurningPointsEditor({ value, onChange }: TurningPointsEditorProp
             placeholder="出来事"
             className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
+          {/* at が空でなく、かつスナップショットに一致する場合のみジャンプボタンを表示する */}
+          {row.at.trim() && findSnapshotIndexByAt && onJumpToSnapshot && (() => {
+            const snapshotIndex = findSnapshotIndexByAt(row.at);
+            if (snapshotIndex === null) return null;
+            return (
+              <button
+                type="button"
+                onClick={() => onJumpToSnapshot(snapshotIndex)}
+                aria-label={`「${row.at}」のスナップショットへジャンプ`}
+                title={`「${row.at}」のスナップショットへジャンプ`}
+                className="shrink-0 text-blue-400 hover:text-blue-600 px-1 py-1"
+              >
+                <SkipForward size={12} />
+              </button>
+            );
+          })()}
           <button
             type="button"
             onClick={() => handleRemove(row.id)}

--- a/src/components/panel/TurningPointsEditor.tsx
+++ b/src/components/panel/TurningPointsEditor.tsx
@@ -38,6 +38,37 @@ export type TurningPointsEditorProps = {
 };
 
 /**
+ * スナップショットジャンプボタン
+ *
+ * at が空でなく、かつ対応するスナップショットが存在するときのみ表示する。
+ */
+type JumpButtonProps = {
+  at: string;
+  findSnapshotIndexByAt: (at: string) => number | null;
+  onJumpToSnapshot: (index: number) => void;
+};
+
+function JumpButton({ at, findSnapshotIndexByAt, onJumpToSnapshot }: JumpButtonProps) {
+  const trimmedAt = at.trim();
+  if (!trimmedAt) return null;
+
+  const snapshotIndex = findSnapshotIndexByAt(trimmedAt);
+  if (snapshotIndex === null) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onJumpToSnapshot(snapshotIndex)}
+      aria-label={`「${trimmedAt}」のスナップショットへジャンプ`}
+      title={`「${trimmedAt}」のスナップショットへジャンプ`}
+      className="shrink-0 text-blue-400 hover:text-blue-600 px-1 py-1"
+    >
+      <SkipForward size={12} />
+    </button>
+  );
+}
+
+/**
  * ターニングポイント動的リストエディタ
  * 行の追加・削除・編集を提供する
  */
@@ -75,22 +106,13 @@ export function TurningPointsEditor({ value, onChange, findSnapshotIndexByAt, on
             placeholder="出来事"
             className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
-          {/* at が空でなく、かつスナップショットに一致する場合のみジャンプボタンを表示する */}
-          {row.at.trim() && findSnapshotIndexByAt && onJumpToSnapshot && (() => {
-            const snapshotIndex = findSnapshotIndexByAt(row.at);
-            if (snapshotIndex === null) return null;
-            return (
-              <button
-                type="button"
-                onClick={() => onJumpToSnapshot(snapshotIndex)}
-                aria-label={`「${row.at}」のスナップショットへジャンプ`}
-                title={`「${row.at}」のスナップショットへジャンプ`}
-                className="shrink-0 text-blue-400 hover:text-blue-600 px-1 py-1"
-              >
-                <SkipForward size={12} />
-              </button>
-            );
-          })()}
+          {findSnapshotIndexByAt && onJumpToSnapshot && (
+            <JumpButton
+              at={row.at}
+              findSnapshotIndexByAt={findSnapshotIndexByAt}
+              onJumpToSnapshot={onJumpToSnapshot}
+            />
+          )}
           <button
             type="button"
             onClick={() => handleRemove(row.id)}

--- a/src/lib/snapshot-lookup.test.ts
+++ b/src/lib/snapshot-lookup.test.ts
@@ -1,0 +1,78 @@
+/**
+ * snapshot-lookup ユーティリティのテスト
+ *
+ * findSnapshotIndexByLabel の正規化済み完全一致マッチングを検証する
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findSnapshotIndexByLabel } from './snapshot-lookup';
+import type { Snapshot } from '@/types/snapshot';
+
+/** テスト用スナップショットのファクトリ */
+function makeSnapshot(id: string, label: string): Snapshot {
+  return {
+    id,
+    label,
+    persons: [],
+    relationships: [],
+    createdAt: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+describe('findSnapshotIndexByLabel', () => {
+  const snapshots = [
+    makeSnapshot('s1', '第1話'),
+    makeSnapshot('s2', '第2話'),
+    makeSnapshot('s3', '2024年春'),
+    makeSnapshot('s4', 'ラスト'),
+  ];
+
+  it('完全一致するラベルのインデックスを返す', () => {
+    expect(findSnapshotIndexByLabel('第1話', snapshots)).toBe(0);
+    expect(findSnapshotIndexByLabel('2024年春', snapshots)).toBe(2);
+    expect(findSnapshotIndexByLabel('ラスト', snapshots)).toBe(3);
+  });
+
+  it('前後の空白を正規化して一致させる', () => {
+    expect(findSnapshotIndexByLabel('  第1話  ', snapshots)).toBe(0);
+    expect(findSnapshotIndexByLabel('\t第2話\t', snapshots)).toBe(1);
+  });
+
+  it('連続する全角・半角スペースを正規化して一致させる', () => {
+    const snapshotsWithSpace = [makeSnapshot('s1', '2024 年春')];
+    expect(findSnapshotIndexByLabel('2024　年春', snapshotsWithSpace)).toBe(0);
+    expect(findSnapshotIndexByLabel('2024  年春', snapshotsWithSpace)).toBe(0);
+  });
+
+  it('大文字小文字を無視して一致させる', () => {
+    const snapshotsEN = [makeSnapshot('s1', 'Chapter One')];
+    expect(findSnapshotIndexByLabel('chapter one', snapshotsEN)).toBe(0);
+    expect(findSnapshotIndexByLabel('CHAPTER ONE', snapshotsEN)).toBe(0);
+  });
+
+  it('一致しないラベルのときは null を返す', () => {
+    expect(findSnapshotIndexByLabel('第10話', snapshots)).toBeNull();
+    expect(findSnapshotIndexByLabel('存在しない', snapshots)).toBeNull();
+  });
+
+  it('空文字列のときは null を返す', () => {
+    expect(findSnapshotIndexByLabel('', snapshots)).toBeNull();
+  });
+
+  it('スナップショット配列が空のときは null を返す', () => {
+    expect(findSnapshotIndexByLabel('第1話', [])).toBeNull();
+  });
+
+  it('複数のスナップショットが同じ正規化済みラベルを持つとき、最初のインデックスを返す', () => {
+    const duplicates = [
+      makeSnapshot('a', '第1話'),
+      makeSnapshot('b', '第1話'),
+    ];
+    expect(findSnapshotIndexByLabel('第1話', duplicates)).toBe(0);
+  });
+
+  it('部分一致ではマッチしない（完全一致のみ）', () => {
+    expect(findSnapshotIndexByLabel('第1', snapshots)).toBeNull();
+    expect(findSnapshotIndexByLabel('話', snapshots)).toBeNull();
+  });
+});

--- a/src/lib/snapshot-lookup.ts
+++ b/src/lib/snapshot-lookup.ts
@@ -1,0 +1,28 @@
+/**
+ * スナップショット検索ユーティリティ
+ *
+ * turningPoints[].at 文字列と snapshot.label を照合して
+ * 該当スナップショットのインデックスを返す。
+ *
+ * マッチング方式: 正規化済み完全一致（normalizeName を流用）
+ *   - trim
+ *   - 連続する空白（全角・半角）を半角スペース1つに正規化
+ *   - 大文字小文字を無視（toLowerCase）
+ */
+
+import { normalizeName } from './person-matching';
+import type { Snapshot } from '@/types/snapshot';
+
+/**
+ * スナップショット配列からラベルが一致する最初のインデックスを返す。
+ *
+ * @param label - 検索するラベル文字列（turningPoints[].at 等）
+ * @param snapshots - 検索対象のスナップショット配列
+ * @returns 一致したスナップショットの 0 始まりインデックス。見つからない場合は null
+ */
+export function findSnapshotIndexByLabel(label: string, snapshots: Snapshot[]): number | null {
+  if (!label.trim()) return null;
+  const normalizedLabel = normalizeName(label);
+  const index = snapshots.findIndex((s) => normalizeName(s.label) === normalizedLabel);
+  return index === -1 ? null : index;
+}


### PR DESCRIPTION
## Summary

- `TurningPointsEditor` の各行に `SkipForward` ボタンを追加し、`at` の値と一致する `label` を持つスナップショットへワンクリックでジャンプできるようにした
- マッチング方式は `normalizeName`（既存ユーティリティ）を流用した正規化済み完全一致
- ジャンプ時は `setTimelineMode(true)` → `goToSnapshot(index)` で即時遷移し、2人選択状態は維持される

## Changes

- `src/lib/snapshot-lookup.ts` - `findSnapshotIndexByLabel` 純関数を新規追加
- `src/lib/snapshot-lookup.test.ts` - 9件のユニットテスト
- `src/components/panel/TurningPointsEditor.tsx` - `JumpButton` サブコンポーネント追加、props に `findSnapshotIndexByAt` / `onJumpToSnapshot` を追加
- `src/components/panel/TurningPointsEditor.test.tsx` - スナップショットジャンプ関連テストを追加
- `src/components/panel/PairSelectionPanel.tsx` - snapshots・setTimelineMode・goToSnapshot を store から取得し、ジャンプ処理を実装

## Test plan

- [ ] 2人選択 → 物語的情報アコーディオン → ターニングポイントの `at` にスナップショットの `label` と同じ値を入力
- [ ] SkipForward ボタンが表示されること
- [ ] クリックでタイムラインモードに切り替わり、該当スナップショットが表示されること
- [ ] `at` が空文字・マッチなしの行にはボタンが表示されないこと
- [ ] 前後スペース・全角スペースがあっても正規化して一致すること

Refs #94 (Phase 3-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)