### PR TITLE
feat: Episodeノード・参加エッジ機能を追加（#94）

### DIFF
--- a/src/components/graph/EpisodeNodeComponent.test.tsx
+++ b/src/components/graph/EpisodeNodeComponent.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * EpisodeNodeComponentのテスト
+ * エピソードノードの表示内容とインタラクションを検証
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EpisodeNodeComponent } from './EpisodeNodeComponent';
+
+// React FlowのHandleはzustandプロバイダを必要とするためモック
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react');
+  return {
+    ...actual,
+    Handle: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
+      <div data-testid={`handle-${props.type}-${props.id}`} {...props}>
+        {children}
+      </div>
+    ),
+  };
+});
+
+// React FlowのNodePropsの最小限モック
+function makeNodeProps(data: Record<string, unknown>, selected = false) {
+  return {
+    id: 'ep-001',
+    data,
+    selected,
+    type: 'episode',
+    dragging: false,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    zIndex: 0,
+  } as Parameters<typeof EpisodeNodeComponent>[0];
+}
+
+describe('EpisodeNodeComponent', () => {
+  describe('タイトル表示', () => {
+    it('エピソードのタイトルを表示する', () => {
+      render(
+        <EpisodeNodeComponent
+          {...makeNodeProps({ title: '初めての出会い', relatedRelationshipIds: [] })}
+        />
+      );
+
+      expect(screen.getByText('初めての出会い')).toBeInTheDocument();
+    });
+  });
+
+  describe('発生日時の表示', () => {
+    it('occurredAtが指定されている場合は表示する', () => {
+      render(
+        <EpisodeNodeComponent
+          {...makeNodeProps({ title: '再会', occurredAt: '第5話', relatedRelationshipIds: [] })}
+        />
+      );
+
+      expect(screen.getByText('第5話')).toBeInTheDocument();
+    });
+
+    it('occurredAtが指定されていない場合は表示しない', () => {
+      const { container } = render(
+        <EpisodeNodeComponent
+          {...makeNodeProps({ title: '別れ', relatedRelationshipIds: [] })}
+        />
+      );
+
+      // 日時バッジが存在しないこと
+      expect(container.querySelector('[data-testid="episode-date"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('説明文の表示', () => {
+    it('descriptionがある場合は表示する', () => {
+      render(
+        <EpisodeNodeComponent
+          {...makeNodeProps({
+            title: '決別',
+            description: '二人の関係が決定的に壊れた場面',
+            relatedRelationshipIds: [],
+          })}
+        />
+      );
+
+      expect(screen.getByText('二人の関係が決定的に壊れた場面')).toBeInTheDocument();
+    });
+
+    it('descriptionがない場合は説明テキストを表示しない', () => {
+      const { container } = render(
+        <EpisodeNodeComponent
+          {...makeNodeProps({ title: '邂逅', relatedRelationshipIds: [] })}
+        />
+      );
+
+      expect(container.querySelector('[data-testid="episode-description"]')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/graph/EpisodeNodeComponent.tsx
+++ b/src/components/graph/EpisodeNodeComponent.tsx
@@ -1,0 +1,77 @@
+/**
+ * EpisodeNodeComponentコンポーネント
+ * エピソードをグラフ上の付箋風カードノードとして表示する
+ * Person ノードと並んでキャンバスに配置され、EpisodeParticipation エッジで人物と繋がる
+ */
+
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { BookOpen } from 'lucide-react';
+import type { EpisodeNodeData } from '@/types/graph';
+
+/**
+ * エピソードノードコンポーネント
+ * @param props - React Flowから渡されるノードプロパティ
+ */
+export const EpisodeNodeComponent = memo(({ data, selected }: NodeProps) => {
+  const nodeData = data as EpisodeNodeData;
+
+  return (
+    <div
+      className={`relative cursor-grab active:cursor-grabbing rounded-xl border-2 bg-amber-50 shadow-lg transition-shadow duration-200 ${
+        selected
+          ? 'border-blue-500 shadow-blue-200 shadow-xl'
+          : 'border-amber-200 hover:border-amber-400'
+      }`}
+      style={{ width: 180, minHeight: 72, padding: '10px 12px' }}
+    >
+      {/* 参加エッジ用ハンドル（source） */}
+      <Handle
+        type="source"
+        id="participation-source"
+        position={Position.Top}
+        className="!w-3 !h-3 !bg-amber-400 !border-2 !border-white !rounded-full"
+        style={{ top: -6 }}
+      />
+
+      {/* 参加エッジ用ハンドル（target） */}
+      <Handle
+        type="target"
+        id="participation-target"
+        position={Position.Bottom}
+        className="!w-3 !h-3 !bg-amber-400 !border-2 !border-white !rounded-full"
+        style={{ bottom: -6 }}
+      />
+
+      {/* ヘッダー: アイコン + タイトル */}
+      <div className="flex items-start gap-1.5">
+        <BookOpen className="w-3.5 h-3.5 text-amber-600 mt-0.5 shrink-0" />
+        <span className="text-xs font-semibold text-gray-800 leading-tight line-clamp-2 flex-1">
+          {nodeData.title}
+        </span>
+      </div>
+
+      {/* 発生日時バッジ */}
+      {nodeData.occurredAt && (
+        <div
+          data-testid="episode-date"
+          className="mt-1.5 inline-block text-[10px] bg-amber-200 text-amber-800 px-1.5 py-0.5 rounded-full font-medium"
+        >
+          {nodeData.occurredAt}
+        </div>
+      )}
+
+      {/* 説明文プレビュー（2行まで） */}
+      {nodeData.description && (
+        <p
+          data-testid="episode-description"
+          className="mt-1 text-[10px] text-gray-500 leading-relaxed line-clamp-2"
+        >
+          {nodeData.description}
+        </p>
+      )}
+    </div>
+  );
+});
+
+EpisodeNodeComponent.displayName = 'EpisodeNodeComponent';

--- a/src/components/graph/ParticipationEdge.test.tsx
+++ b/src/components/graph/ParticipationEdge.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * ParticipationEdgeコンポーネントのテスト
+ * エピソード↔人物の参加エッジの表示スタイルを検証する
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { ParticipationEdge } from './ParticipationEdge';
+import type { EdgeProps } from '@xyflow/react';
+
+// React FlowのBaseEdgeはzustandプロバイダを必要とするためモック
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react');
+  return {
+    ...actual,
+    BaseEdge: ({ style, ...props }: { style?: React.CSSProperties; [key: string]: unknown }) => (
+      <path data-testid="base-edge" style={style} {...props} />
+    ),
+    getStraightPath: () => ['M 0 0 L 100 100', 50, 50],
+  };
+});
+
+// EdgePropsの最小限モック
+function makeEdgeProps(overrides: Partial<EdgeProps> = {}): EdgeProps {
+  return {
+    id: 'part-001',
+    source: 'ep-001',
+    target: 'person-001',
+    sourceX: 0,
+    sourceY: 0,
+    targetX: 100,
+    targetY: 100,
+    sourcePosition: 'bottom' as const,
+    targetPosition: 'top' as const,
+    selected: false,
+    animated: false,
+    data: {},
+    style: {},
+    markerEnd: '',
+    markerStart: '',
+    pathOptions: undefined,
+    interactionWidth: 20,
+    ...overrides,
+  } as EdgeProps;
+}
+
+describe('ParticipationEdge', () => {
+  describe('破線スタイル', () => {
+    it('strokeDasharrayが設定されている（破線表示）', () => {
+      const { getByTestId } = render(<ParticipationEdge {...makeEdgeProps()} />);
+
+      const edge = getByTestId('base-edge');
+      const style = edge.getAttribute('style') ?? '';
+      // strokeDasharrayが含まれること
+      expect(style).toContain('stroke-dasharray');
+    });
+
+    it('マーカーなし（向きなしエッジ）', () => {
+      const { getByTestId } = render(<ParticipationEdge {...makeEdgeProps()} />);
+
+      const edge = getByTestId('base-edge');
+      // markerEndが渡されていないこと（向きを示す矢印なし）
+      const markerEnd = edge.getAttribute('marker-end') ?? '';
+      expect(markerEnd).toBe('');
+    });
+  });
+
+  describe('グレー系の色', () => {
+    it('strokeがグレー系の色である', () => {
+      const { getByTestId } = render(<ParticipationEdge {...makeEdgeProps()} />);
+
+      const edge = getByTestId('base-edge');
+      const style = edge.getAttribute('style') ?? '';
+      // strokeにグレー系の色（rgb(156 163 175)はtailwindのgray-400に相当）が含まれること
+      expect(style).toMatch(/stroke:\s*(?:rgb\(156,?\s*163,?\s*175\)|#9ca3af)/i);
+    });
+  });
+});

--- a/src/components/graph/ParticipationEdge.tsx
+++ b/src/components/graph/ParticipationEdge.tsx
@@ -1,0 +1,42 @@
+/**
+ * ParticipationEdgeコンポーネント
+ * エピソード↔人物の参加関係を表示するカスタムエッジ
+ *
+ * 設計方針:
+ * - 破線（strokeDasharray）でRelationshipエッジと視覚的に区別
+ * - グレー系の色で主張を抑える
+ * - マーカーなし（向きを持たないエッジ）
+ */
+
+'use client';
+
+import { memo } from 'react';
+import { BaseEdge, EdgeProps, getStraightPath } from '@xyflow/react';
+
+/**
+ * エピソード参加エッジコンポーネント
+ * @param props - React Flowから渡されるエッジプロパティ
+ */
+export const ParticipationEdge = memo((props: EdgeProps) => {
+  const { sourceX, sourceY, targetX, targetY } = props;
+
+  const [edgePath] = getStraightPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+  });
+
+  return (
+    <BaseEdge
+      path={edgePath}
+      style={{
+        stroke: '#9ca3af', // gray-400
+        strokeWidth: 1.5,
+        strokeDasharray: '5 4',
+      }}
+    />
+  );
+});
+
+ParticipationEdge.displayName = 'ParticipationEdge';

--- a/src/components/graph/RelationshipGraph.tsx
+++ b/src/components/graph/RelationshipGraph.tsx
@@ -22,6 +22,8 @@ import {
 import '@xyflow/react/dist/style.css';
 import { GraphNodeComponent } from './GraphNodeComponent';
 import { RelationshipEdge as RelationshipEdgeComponent } from './RelationshipEdge';
+import { EpisodeNodeComponent } from './EpisodeNodeComponent';
+import { ParticipationEdge } from './ParticipationEdge';
 import { ConnectionLine } from './ConnectionLine';
 import { ForceLayoutPanel } from './ForceLayoutPanel';
 import ShareButton from './ShareButton';
@@ -53,16 +55,18 @@ const EDGE_MARKER_COLORS = [
 ] as const;
 import { resolveCollisions, DEFAULT_COLLISION_OPTIONS } from '@/lib/collision-resolver';
 import { syncNodePositionsToStore } from '@/lib/graph-utils';
-import type { GraphNode } from '@/types/graph';
+import type { AnyGraphNode } from '@/types/graph';
 
 // カスタムノードタイプの定義（プロパティグラフ方式: 全ノードを単一の 'graph' タイプで扱う）
 const nodeTypes: NodeTypes = {
   graph: GraphNodeComponent,
+  episode: EpisodeNodeComponent,
 };
 
 // カスタムエッジタイプの定義
 const edgeTypes: EdgeTypes = {
   relationship: RelationshipEdgeComponent,
+  participation: ParticipationEdge,
 };
 
 /**
@@ -74,6 +78,7 @@ export function RelationshipGraph() {
   const relationships = useGraphStore((state) => state.relationships);
   const forceParams = useGraphStore((state) => state.forceParams);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
+  const updateEpisodePosition = useGraphStore((state) => state.updateEpisodePosition);
 
   // React Flow APIを取得
   const { screenToFlowPosition, getNodes } = useReactFlow();
@@ -184,17 +189,17 @@ export function RelationshipGraph() {
         const resolvedNodes = resolveCollisions(currentNodes, DEFAULT_COLLISION_OPTIONS);
         // 位置が変更されたノードがあれば更新
         if (resolvedNodes !== currentNodes) {
-          setNodes(resolvedNodes as GraphNode[]);
+          setNodes(resolvedNodes as AnyGraphNode[]);
         }
         // 衝突解消後の位置をストアに書き戻す
-        syncNodePositionsToStore(resolvedNodes, updatePersonPositions);
+        syncNodePositionsToStore(resolvedNodes, updatePersonPositions, updateEpisodePosition);
       } else {
         // Force Layout有効時は全ノードの位置を書き戻す（他ノードもシミュレーションで移動するため）
         const currentNodes = getNodesRef.current();
-        syncNodePositionsToStore(currentNodes, updatePersonPositions);
+        syncNodePositionsToStore(currentNodes, updatePersonPositions, updateEpisodePosition);
       }
     },
-    [handleNodeDragEnd, forceEnabled, setNodes, updatePersonPositions]
+    [handleNodeDragEnd, forceEnabled, setNodes, updatePersonPositions, updateEpisodePosition]
   );
 
   // Force Layout無効化時の位置書き戻し
@@ -203,10 +208,10 @@ export function RelationshipGraph() {
     // forceEnabledがtrue→falseに変わった時
     if (prevForceEnabledRef.current && !forceEnabled) {
       const currentNodes = getNodesRef.current();
-      syncNodePositionsToStore(currentNodes, updatePersonPositions);
+      syncNodePositionsToStore(currentNodes, updatePersonPositions, updateEpisodePosition);
     }
     prevForceEnabledRef.current = forceEnabled;
-  }, [forceEnabled, updatePersonPositions]);
+  }, [forceEnabled, updatePersonPositions, updateEpisodePosition]);
 
   return (
     <div className="w-full h-screen relative" onDrop={handleDrop} onDragOver={handleDragOver}>

--- a/src/components/graph/RelationshipGraph.tsx
+++ b/src/components/graph/RelationshipGraph.tsx
@@ -5,7 +5,7 @@
 
 'use client';
 
-import { useMemo, useRef, useCallback, useEffect } from 'react';
+import { useMemo, useRef, useCallback, useEffect, useState } from 'react';
 import {
   ReactFlow,
   Background,
@@ -30,6 +30,7 @@ import ShareButton from './ShareButton';
 import SearchBar from './SearchBar';
 import { PersonRegistrationModal } from './PersonRegistrationModal';
 import { RelationshipRegistrationModal } from './RelationshipRegistrationModal';
+import { EpisodeCaptureDialog, type EpisodeCaptureValues } from '@/components/ui/EpisodeCaptureDialog';
 import { useForceLayout } from './useForceLayout';
 import { useGraphDataSync } from './useGraphDataSync';
 import { useGraphInteractions } from './useGraphInteractions';
@@ -79,6 +80,11 @@ export function RelationshipGraph() {
   const forceParams = useGraphStore((state) => state.forceParams);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
   const updateEpisodePosition = useGraphStore((state) => state.updateEpisodePosition);
+  const createEpisode = useGraphStore((state) => state.createEpisode);
+  const addParticipation = useGraphStore((state) => state.addParticipation);
+
+  // エピソード追加ダイアログの状態（位置情報付き）
+  const [episodeDialogPosition, setEpisodeDialogPosition] = useState<{ x: number; y: number } | null>(null);
 
   // React Flow APIを取得
   const { screenToFlowPosition, getNodes } = useReactFlow();
@@ -140,6 +146,7 @@ export function RelationshipGraph() {
     closeContextMenu,
     switchToAddRelationshipMode,
     handleNodeContextMenu,
+    onAddEpisode: (pos) => setEpisodeDialogPosition(pos),
   });
 
   // getNodesをrefに退避（onNodeDragStopHandlerの依存配列から除外するため）
@@ -212,6 +219,23 @@ export function RelationshipGraph() {
     }
     prevForceEnabledRef.current = forceEnabled;
   }, [forceEnabled, updatePersonPositions, updateEpisodePosition]);
+
+  const handleEpisodeSave = useCallback(
+    (values: EpisodeCaptureValues) => {
+      const episodeId = createEpisode({
+        title: values.title,
+        description: values.description,
+        occurredAt: values.occurredAt,
+        relatedRelationshipIds: values.relatedRelationshipIds,
+        position: episodeDialogPosition ?? undefined,
+      });
+      for (const personId of values.participantPersonIds) {
+        addParticipation({ episodeId, personId });
+      }
+      setEpisodeDialogPosition(null);
+    },
+    [createEpisode, addParticipation, episodeDialogPosition]
+  );
 
   return (
     <div className="w-full h-screen relative" onDrop={handleDrop} onDragOver={handleDragOver}>
@@ -394,6 +418,13 @@ export function RelationshipGraph() {
 
       {/* AIインタビュアー チャットモーダル */}
       <InterviewModal />
+
+      {/* エピソード追加ダイアログ（コンテキストメニューから起動） */}
+      <EpisodeCaptureDialog
+        isOpen={episodeDialogPosition !== null}
+        onSave={handleEpisodeSave}
+        onCancel={() => setEpisodeDialogPosition(null)}
+      />
     </div>
   );
 }

--- a/src/components/graph/RelationshipGraph.tsx
+++ b/src/components/graph/RelationshipGraph.tsx
@@ -79,7 +79,7 @@ export function RelationshipGraph() {
   const relationships = useGraphStore((state) => state.relationships);
   const forceParams = useGraphStore((state) => state.forceParams);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
-  const updateEpisodePosition = useGraphStore((state) => state.updateEpisodePosition);
+  const updateEpisodePositions = useGraphStore((state) => state.updateEpisodePositions);
   const createEpisode = useGraphStore((state) => state.createEpisode);
   const addParticipation = useGraphStore((state) => state.addParticipation);
 
@@ -199,14 +199,14 @@ export function RelationshipGraph() {
           setNodes(resolvedNodes as AnyGraphNode[]);
         }
         // 衝突解消後の位置をストアに書き戻す
-        syncNodePositionsToStore(resolvedNodes, updatePersonPositions, updateEpisodePosition);
+        syncNodePositionsToStore(resolvedNodes, updatePersonPositions, updateEpisodePositions);
       } else {
         // Force Layout有効時は全ノードの位置を書き戻す（他ノードもシミュレーションで移動するため）
         const currentNodes = getNodesRef.current();
-        syncNodePositionsToStore(currentNodes, updatePersonPositions, updateEpisodePosition);
+        syncNodePositionsToStore(currentNodes, updatePersonPositions, updateEpisodePositions);
       }
     },
-    [handleNodeDragEnd, forceEnabled, setNodes, updatePersonPositions, updateEpisodePosition]
+    [handleNodeDragEnd, forceEnabled, setNodes, updatePersonPositions, updateEpisodePositions]
   );
 
   // Force Layout無効化時の位置書き戻し
@@ -215,10 +215,10 @@ export function RelationshipGraph() {
     // forceEnabledがtrue→falseに変わった時
     if (prevForceEnabledRef.current && !forceEnabled) {
       const currentNodes = getNodesRef.current();
-      syncNodePositionsToStore(currentNodes, updatePersonPositions, updateEpisodePosition);
+      syncNodePositionsToStore(currentNodes, updatePersonPositions, updateEpisodePositions);
     }
     prevForceEnabledRef.current = forceEnabled;
-  }, [forceEnabled, updatePersonPositions, updateEpisodePosition]);
+  }, [forceEnabled, updatePersonPositions, updateEpisodePositions]);
 
   const handleEpisodeSave = useCallback(
     (values: EpisodeCaptureValues) => {

--- a/src/components/graph/useGraphContextMenuActions.ts
+++ b/src/components/graph/useGraphContextMenuActions.ts
@@ -8,7 +8,7 @@ import { useReactFlow, type Node } from '@xyflow/react';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { useDialogStore } from '@/stores/useDialogStore';
 import { getNodeCenter, VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils';
-import { UserPlus, XCircle, Pencil, Trash2, Maximize2, Link, ArrowLeft } from 'lucide-react';
+import { UserPlus, XCircle, Pencil, Trash2, Maximize2, Link, ArrowLeft, BookOpen } from 'lucide-react';
 import type { ContextMenuState } from './useContextMenu';
 import type { ContextMenuItem } from './ContextMenu';
 import type { AnyGraphEdge, RelationshipEdge } from '@/types/graph';
@@ -32,6 +32,8 @@ type UseGraphContextMenuActionsParams = {
   switchToAddRelationshipMode: (sourceNodeId: string, position: { x: number; y: number }) => void;
   /** ノードコンテキストメニューハンドラ（「戻る」ボタンで使用） */
   handleNodeContextMenu: (event: React.MouseEvent, node: Node) => void;
+  /** エピソード追加ダイアログを開くコールバック（位置情報付き） */
+  onAddEpisode?: (position: { x: number; y: number }) => void;
 };
 
 /**
@@ -52,6 +54,7 @@ export function useGraphContextMenuActions({
   closeContextMenu,
   switchToAddRelationshipMode,
   handleNodeContextMenu,
+  onAddEpisode,
 }: UseGraphContextMenuActionsParams) {
   // Zustandストアから状態とアクションを取得
   const persons = useGraphStore((state) => state.persons);
@@ -290,6 +293,14 @@ export function useGraphContextMenuActions({
             closeContextMenu();
           },
         },
+        {
+          label: 'エピソードをここに追加',
+          icon: BookOpen,
+          onClick: () => {
+            onAddEpisode?.(flowPosition);
+            closeContextMenu();
+          },
+        },
       ];
 
       // 選択がある場合は「選択をすべて解除」を追加
@@ -311,7 +322,7 @@ export function useGraphContextMenuActions({
 
       return items;
     },
-    [selectedPersonIds, setPendingRegistration, closeContextMenu, clearSelection]
+    [selectedPersonIds, setPendingRegistration, closeContextMenu, clearSelection, onAddEpisode]
   );
 
   // コンテキストメニュー項目の構築

--- a/src/components/graph/useGraphContextMenuActions.ts
+++ b/src/components/graph/useGraphContextMenuActions.ts
@@ -11,7 +11,7 @@ import { getNodeCenter, VIEWPORT_ANIMATION_DURATION } from '@/lib/viewport-utils
 import { UserPlus, XCircle, Pencil, Trash2, Maximize2, Link, ArrowLeft } from 'lucide-react';
 import type { ContextMenuState } from './useContextMenu';
 import type { ContextMenuItem } from './ContextMenu';
-import type { RelationshipEdge } from '@/types/graph';
+import type { AnyGraphEdge, RelationshipEdge } from '@/types/graph';
 import type { PendingConnection, PendingRegistration } from './useGraphInteractions';
 
 /**
@@ -21,7 +21,7 @@ type UseGraphContextMenuActionsParams = {
   /** コンテキストメニューの状態 */
   contextMenu: ContextMenuState | null;
   /** グラフのエッジ配列 */
-  edges: RelationshipEdge[];
+  edges: AnyGraphEdge[];
   /** 関係登録の待機状態をセットする関数 */
   setPendingConnection: (pending: PendingConnection | null) => void;
   /** 人物登録の待機状態をセットする関数 */
@@ -263,7 +263,7 @@ export function useGraphContextMenuActions({
           onClick: async () => {
             closeContextMenu();
             const confirmed = await openConfirm({
-              message: `「${edge?.data?.label ?? edge?.data?.edgeType ?? '不明な関係'}」を削除してもよろしいですか？`,
+              message: `「${(edge as RelationshipEdge | undefined)?.data?.label ?? (edge as RelationshipEdge | undefined)?.data?.edgeType ?? '不明な関係'}」を削除してもよろしいですか？`,
               isDanger: true,
             });
             if (confirmed) {

--- a/src/components/graph/useGraphDataSync.ts
+++ b/src/components/graph/useGraphDataSync.ts
@@ -31,7 +31,7 @@ export function useGraphDataSync() {
   const forceEnabled = useGraphStore((state) => state.forceEnabled);
   const selectedPersonIds = useGraphStore((state) => state.selectedPersonIds);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
-  const updateEpisodePosition = useGraphStore((state) => state.updateEpisodePosition);
+  const updateEpisodePositions = useGraphStore((state) => state.updateEpisodePositions);
   const edgeFilter = useGraphStore((state) => state.edgeFilter);
   const timelineMode = useGraphStore((state) => state.timelineMode);
   const activeSnapshotIndex = useGraphStore((state) => state.activeSnapshotIndex);
@@ -146,7 +146,7 @@ export function useGraphDataSync() {
           if (resolvedNodes !== currentNodes) {
             // 位置が変更された場合のみ更新
             setNodes(resolvedNodes as AnyGraphNode[]);
-            syncNodePositionsToStore(resolvedNodes, updatePersonPositions, updateEpisodePosition);
+            syncNodePositionsToStore(resolvedNodes, updatePersonPositions, updateEpisodePositions);
           }
           collisionResolutionRafIdRef.current = null;
         });
@@ -205,7 +205,7 @@ export function useGraphDataSync() {
         collisionResolutionRafIdRef.current = null;
       }
     };
-  }, [persons, relationships, episodes, episodeParticipations, setNodes, setEdges, forceEnabled, updatePersonPositions, updateEpisodePosition, edgeFilter, timelineMode, activeSnapshotIndex, previousSnapshotIndex, snapshots]);
+  }, [persons, relationships, episodes, episodeParticipations, setNodes, setEdges, forceEnabled, updatePersonPositions, updateEpisodePositions, edgeFilter, timelineMode, activeSnapshotIndex, previousSnapshotIndex, snapshots]);
 
   // 選択状態の変更時に既存ノード/エッジのselectedプロパティのみ更新
   // 配列参照を変更しないようにhasChangedフラグで最適化

--- a/src/components/graph/useGraphDataSync.ts
+++ b/src/components/graph/useGraphDataSync.ts
@@ -1,16 +1,16 @@
 /**
  * useGraphDataSyncカスタムフック
- * ストアデータ（persons, relationships）をReact Flowのノード/エッジに変換し、状態を同期する
+ * ストアデータ（persons, relationships, episodes, episodeParticipations）をReact Flowのノード/エッジに変換し、状態を同期する
  */
 
 import { useEffect, useCallback, useRef } from 'react';
 import { useNodesState, useEdgesState, useReactFlow } from '@xyflow/react';
 import { useGraphStore } from '@/stores/useGraphStore';
-import { personsToNodes, relationshipsToEdges, syncNodePositionsToStore } from '@/lib/graph-utils';
+import { personsToNodes, relationshipsToEdges, syncNodePositionsToStore, episodesToNodes, participationsToEdges } from '@/lib/graph-utils';
 import { resolveCollisions, DEFAULT_COLLISION_OPTIONS } from '@/lib/collision-resolver';
 import { computeSnapshotDiff } from '@/lib/snapshot-diff';
 import type { Node } from '@xyflow/react';
-import type { GraphNode, RelationshipEdge } from '@/types/graph';
+import type { AnyGraphNode, AnyGraphEdge } from '@/types/graph';
 import type { DiffStatus } from '@/lib/diff-highlight';
 
 /**
@@ -26,9 +26,12 @@ export function useGraphDataSync() {
   // Zustandストアから状態を取得
   const persons = useGraphStore((state) => state.persons);
   const relationships = useGraphStore((state) => state.relationships);
+  const episodes = useGraphStore((state) => state.episodes);
+  const episodeParticipations = useGraphStore((state) => state.episodeParticipations);
   const forceEnabled = useGraphStore((state) => state.forceEnabled);
   const selectedPersonIds = useGraphStore((state) => state.selectedPersonIds);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
+  const updateEpisodePosition = useGraphStore((state) => state.updateEpisodePosition);
   const edgeFilter = useGraphStore((state) => state.edgeFilter);
   const timelineMode = useGraphStore((state) => state.timelineMode);
   const activeSnapshotIndex = useGraphStore((state) => state.activeSnapshotIndex);
@@ -39,8 +42,8 @@ export function useGraphDataSync() {
   const snapshots = useGraphStore((state) => state.timelineMode ? state.snapshots : null);
 
   // React Flowのノード/エッジ状態
-  const [nodes, setNodes, onNodesChange] = useNodesState<GraphNode>([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState<RelationshipEdge>([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<AnyGraphNode>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<AnyGraphEdge>([]);
 
   // React FlowのgetNodes取得
   const { getNodes } = useReactFlow();
@@ -69,18 +72,22 @@ export function useGraphDataSync() {
           };
         });
 
-        return nodesWithSelection as GraphNode[];
+        return nodesWithSelection as AnyGraphNode[];
       });
     },
     [setNodes]
   );
 
-  // ストアのデータ（persons, relationships）が変更されたらノードとエッジを更新
+  // ストアのデータ（persons, relationships, episodes, episodeParticipations）が変更されたらノードとエッジを更新
   // 選択状態の変更ではシミュレーション再初期化を避けるため、selectedPersonIdsを依存配列から除外
   useEffect(() => {
-    const newNodes = personsToNodes(persons);
+    const newPersonNodes = personsToNodes(persons);
+    const newEpisodeNodes = episodesToNodes(episodes);
+    const newNodes = [...newPersonNodes, ...newEpisodeNodes];
     // edgeFilter に基づいて表示するエッジを絞り込む
-    const newEdges = relationshipsToEdges(relationships, edgeFilter);
+    const newRelEdges = relationshipsToEdges(relationships, edgeFilter);
+    const newPartEdges = participationsToEdges(episodeParticipations);
+    const newEdges = [...newRelEdges, ...newPartEdges];
 
     // setNodesの関数型アップデータ内からRAFをスケジュールしています
     // React 18 StrictModeではアップデータが2回呼ばれる可能性がありますが、
@@ -90,6 +97,8 @@ export function useGraphDataSync() {
       const prevNodeMap = new Map(prevNodes.map((node) => [node.id, node]));
       // personsもMapに変換してO(n²)を回避
       const personMap = new Map(persons.map((p) => [p.id, p]));
+      // episodesもMapに変換
+      const episodeMap = new Map(episodes.map((e) => [e.id, e]));
 
       // 既存のノード位置を保持しながら更新（選択状態は既存ノードから引き継ぐ）
       const updatedNodes = newNodes.map((newNode) => {
@@ -102,14 +111,14 @@ export function useGraphDataSync() {
             selected: existingNode.selected,
           };
         }
-        // 新規ノードの場合
-        // person.positionが未設定（undefined）の場合のみランダムな位置に配置
-        // person.positionが設定されている場合は、(0,0)であってもその座標を使用
+        // 新規ノードの場合: positionが設定されていなければランダム配置
+        // Personノードとエピソードノードで同じ方針
         const person = personMap.get(newNode.id);
-        const shouldUseRandomPosition = !person?.position;
+        const episode = episodeMap.get(newNode.id);
+        const hasStoredPosition = person?.position ?? episode?.position;
         return {
           ...newNode,
-          position: shouldUseRandomPosition
+          position: !hasStoredPosition
             ? {
                 x: Math.random() * 500 + 100,
                 y: Math.random() * 500 + 100,
@@ -136,8 +145,8 @@ export function useGraphDataSync() {
           // resolveCollisionsは変更がない場合に元の配列を返すため、参照等価性でチェック
           if (resolvedNodes !== currentNodes) {
             // 位置が変更された場合のみ更新
-            setNodes(resolvedNodes as GraphNode[]);
-            syncNodePositionsToStore(resolvedNodes, updatePersonPositions);
+            setNodes(resolvedNodes as AnyGraphNode[]);
+            syncNodePositionsToStore(resolvedNodes, updatePersonPositions, updateEpisodePosition);
           }
           collisionResolutionRafIdRef.current = null;
         });
@@ -174,7 +183,7 @@ export function useGraphDataSync() {
       const prevEdgeMap = new Map(prevEdges.map((edge) => [edge.id, edge]));
       const updatedEdges = newEdges.map((newEdge) => {
         const existingEdge = prevEdgeMap.get(newEdge.id);
-        // タイムラインモードのdiff表示: diffStatusMapに存在するIDのみハイライト
+        // タイムラインモードのdiff表示: diffStatusMapに存在するIDのみハイライト（participationエッジは対象外）
         const diffStatus = diffStatusMap.size > 0
           ? (diffStatusMap.get(newEdge.id) ?? null)
           : undefined;
@@ -184,7 +193,7 @@ export function useGraphDataSync() {
           // newEdge.data が存在する場合は diffStatus を付与する。
           // data が undefined の場合（通常は発生しない）はそのまま渡す
           ...(newEdge.data ? { data: { ...newEdge.data, diffStatus } } : {}),
-        } as RelationshipEdge;
+        } as AnyGraphEdge;
       });
       return updatedEdges;
     });
@@ -196,7 +205,7 @@ export function useGraphDataSync() {
         collisionResolutionRafIdRef.current = null;
       }
     };
-  }, [persons, relationships, setNodes, setEdges, forceEnabled, updatePersonPositions, edgeFilter, timelineMode, activeSnapshotIndex, previousSnapshotIndex, snapshots]);
+  }, [persons, relationships, episodes, episodeParticipations, setNodes, setEdges, forceEnabled, updatePersonPositions, updateEpisodePosition, edgeFilter, timelineMode, activeSnapshotIndex, previousSnapshotIndex, snapshots]);
 
   // 選択状態の変更時に既存ノード/エッジのselectedプロパティのみ更新
   // 配列参照を変更しないようにhasChangedフラグで最適化

--- a/src/components/graph/useGraphInteractions.ts
+++ b/src/components/graph/useGraphInteractions.ts
@@ -9,7 +9,7 @@ import { useGraphStore } from '@/stores/useGraphStore';
 import { useDialogStore } from '@/stores/useDialogStore';
 import { readFileAsDataUrl } from '@/lib/image-utils';
 import { findClosestTargetNode } from '@/lib/connection-target-detection';
-import type { GraphNode, RelationshipEdge } from '@/types/graph';
+import type { GraphNode, RelationshipEdge, AnyGraphEdge } from '@/types/graph';
 import type { ContextMenuState } from './useContextMenu';
 
 /**
@@ -67,6 +67,7 @@ export function useGraphInteractions({
   const updateRelationship = useGraphStore((state) => state.updateRelationship);
   const removePerson = useGraphStore((state) => state.removePerson);
   const removeRelationship = useGraphStore((state) => state.removeRelationship);
+  const removeParticipation = useGraphStore((state) => state.removeParticipation);
   const setSelectedPersonIds = useGraphStore((state) => state.setSelectedPersonIds);
   const clearSelection = useGraphStore((state) => state.clearSelection);
   const selectPersonPairForEdit = useGraphStore((state) => state.selectPersonPairForEdit);
@@ -441,10 +442,13 @@ export function useGraphInteractions({
       }
       if (edgesToDelete.length > 0) {
         const count = edgesToDelete.length;
-        const firstEdge = edgesToDelete[0] as RelationshipEdge;
+        const firstEdge = edgesToDelete[0] as AnyGraphEdge;
+        const edgeLabel = firstEdge.type === 'participation'
+          ? '参加関係'
+          : ((firstEdge as RelationshipEdge).data?.label ?? (firstEdge as RelationshipEdge).data?.edgeType ?? '不明な関係');
         messages.push(
-          count === 1 && firstEdge
-            ? `「${firstEdge.data?.label ?? firstEdge.data?.edgeType ?? '不明な関係'}」を削除してもよろしいですか？`
+          count === 1
+            ? `「${edgeLabel}」を削除してもよろしいですか？`
             : `${count}個の関係を削除してもよろしいですか？`
         );
       }
@@ -471,13 +475,18 @@ export function useGraphInteractions({
   );
 
   // エッジ削除ハンドラ（確認はonBeforeDeleteで実行済み）
+  // participation エッジと relationship エッジを type で判別して適切なアクションを呼ぶ
   const handleEdgesDelete = useCallback(
-    (edgesToDelete: RelationshipEdge[]) => {
+    (edgesToDelete: AnyGraphEdge[]) => {
       edgesToDelete.forEach((edge) => {
-        removeRelationship(edge.id);
+        if (edge.type === 'participation') {
+          removeParticipation(edge.id);
+        } else {
+          removeRelationship(edge.id);
+        }
       });
     },
-    [removeRelationship]
+    [removeRelationship, removeParticipation]
   );
 
   // モーダルからの登録ハンドラ

--- a/src/components/panel/DefaultPanel.tsx
+++ b/src/components/panel/DefaultPanel.tsx
@@ -8,6 +8,7 @@
 import { PersonList } from './PersonList';
 import { ActiveChartHeader } from './ActiveChartHeader';
 import { SnapshotList } from './SnapshotList';
+import { EpisodeList } from './EpisodeList';
 
 /**
  * デフォルトパネルコンポーネント
@@ -23,6 +24,11 @@ export function DefaultPanel() {
       {/* タイムラインセクション */}
       <div>
         <SnapshotList />
+      </div>
+
+      {/* エピソードセクション */}
+      <div>
+        <EpisodeList />
       </div>
 
       {/* 人物管理セクション */}

--- a/src/components/panel/EpisodeList.test.tsx
+++ b/src/components/panel/EpisodeList.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * EpisodeListコンポーネントのテスト
+ * エピソード一覧の表示・追加ボタン・削除確認・インライン編集を検証する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EpisodeList } from './EpisodeList';
+import type { Episode } from '@/types/episode';
+
+// dnd-kitをモック（テスト環境ではPointerSensorが動作しないため）
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual('@dnd-kit/core');
+  return {
+    ...actual,
+    DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+vi.mock('@dnd-kit/sortable', async () => {
+  const actual = await vi.importActual('@dnd-kit/sortable');
+  return {
+    ...actual,
+    SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useSortable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: null,
+      isDragging: false,
+    }),
+  };
+});
+
+// useDialogStoreをモック
+vi.mock('@/stores/useDialogStore', () => ({
+  useDialogStore: vi.fn((selector: (state: { openConfirm: ReturnType<typeof vi.fn> }) => unknown) =>
+    selector({ openConfirm: mockOpenConfirm })
+  ),
+}));
+
+const mockOpenConfirm = vi.fn().mockResolvedValue(true);
+
+// useGraphStoreをモック
+const mockDeleteEpisode = vi.fn();
+const mockUpdateEpisode = vi.fn();
+const mockReorderEpisodes = vi.fn();
+const mockCreateEpisode = vi.fn().mockReturnValue('ep-new');
+const mockAddParticipation = vi.fn();
+
+vi.mock('@/stores/useGraphStore', () => ({
+  useGraphStore: vi.fn((selector: (state: typeof mockState) => unknown) =>
+    selector(mockState)
+  ),
+}));
+
+const episodeSample: Episode = {
+  id: 'ep-001',
+  title: '初めての出会い',
+  relatedRelationshipIds: [],
+  properties: {},
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockState = {
+  episodes: [episodeSample],
+  episodeParticipations: [],
+  persons: [],
+  deleteEpisode: mockDeleteEpisode,
+  updateEpisode: mockUpdateEpisode,
+  reorderEpisodes: mockReorderEpisodes,
+  createEpisode: mockCreateEpisode,
+  addParticipation: mockAddParticipation,
+};
+
+describe('EpisodeList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOpenConfirm.mockResolvedValue(true);
+    mockState.episodes = [episodeSample];
+  });
+
+  describe('一覧表示', () => {
+    it('エピソードのタイトルが表示される', () => {
+      render(<EpisodeList />);
+      expect(screen.getByText('初めての出会い')).toBeInTheDocument();
+    });
+
+    it('エピソードが0件のとき空状態メッセージが表示される', () => {
+      mockState.episodes = [];
+      render(<EpisodeList />);
+      expect(screen.getByText(/エピソードがありません/)).toBeInTheDocument();
+    });
+  });
+
+  describe('追加ボタン', () => {
+    it('「+ エピソードを追加」ボタンが表示される', () => {
+      render(<EpisodeList />);
+      expect(screen.getByRole('button', { name: /エピソードを追加/ })).toBeInTheDocument();
+    });
+
+    it('追加ボタンをクリックするとダイアログが開く', async () => {
+      const user = userEvent.setup();
+      render(<EpisodeList />);
+      await user.click(screen.getByRole('button', { name: /エピソードを追加/ }));
+      // ダイアログが表示される
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('削除確認', () => {
+    it('削除ボタンをクリックすると確認ダイアログが表示される', async () => {
+      const user = userEvent.setup();
+      render(<EpisodeList />);
+      await user.click(screen.getByRole('button', { name: /削除/ }));
+      expect(mockOpenConfirm).toHaveBeenCalledOnce();
+    });
+
+    it('確認後にdeleteEpisodeが呼ばれる', async () => {
+      const user = userEvent.setup();
+      mockOpenConfirm.mockResolvedValueOnce(true);
+      render(<EpisodeList />);
+      await user.click(screen.getByRole('button', { name: /削除/ }));
+      expect(mockDeleteEpisode).toHaveBeenCalledWith('ep-001');
+    });
+
+    it('キャンセル時はdeleteEpisodeが呼ばれない', async () => {
+      const user = userEvent.setup();
+      mockOpenConfirm.mockResolvedValueOnce(false);
+      render(<EpisodeList />);
+      await user.click(screen.getByRole('button', { name: /削除/ }));
+      expect(mockDeleteEpisode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('インライン編集', () => {
+    it('タイトルをクリックすると編集モードになる', async () => {
+      const user = userEvent.setup();
+      render(<EpisodeList />);
+      await user.click(screen.getByText('初めての出会い'));
+      // 入力フィールドが表示される
+      expect(screen.getByRole('textbox', { name: /タイトルを編集/ })).toBeInTheDocument();
+    });
+
+    it('Enterキーでタイトルを保存する', async () => {
+      const user = userEvent.setup();
+      render(<EpisodeList />);
+      await user.click(screen.getByText('初めての出会い'));
+      const input = screen.getByRole('textbox', { name: /タイトルを編集/ });
+      await user.clear(input);
+      await user.type(input, '再会の場面');
+      await user.keyboard('{Enter}');
+      expect(mockUpdateEpisode).toHaveBeenCalledWith('ep-001', expect.objectContaining({ title: '再会の場面' }));
+    });
+
+    it('IME変換中のEnterキーでは保存されない', () => {
+      render(<EpisodeList />);
+      fireEvent.click(screen.getByText('初めての出会い'));
+      const input = screen.getByRole('textbox', { name: /タイトルを編集/ });
+      fireEvent.change(input, { target: { value: '別の題名' } });
+      // IME変換中
+      fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+      expect(mockUpdateEpisode).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/panel/EpisodeList.tsx
+++ b/src/components/panel/EpisodeList.tsx
@@ -1,0 +1,252 @@
+/**
+ * EpisodeListコンポーネント
+ * サイドパネルのエピソード一覧
+ *
+ * 機能:
+ * - エピソード一覧の表示
+ * - タイトルのインライン編集
+ * - エピソードの削除（確認ダイアログ付き）
+ * - 「+ エピソードを追加」ボタンでEpisodeCaptureDialogを開く
+ * - ドラッグ&ドロップによる並び替え
+ */
+
+'use client';
+
+import { useState, useRef } from 'react';
+import { Plus, Trash2, GripVertical } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useGraphStore } from '@/stores/useGraphStore';
+import { useDialogStore } from '@/stores/useDialogStore';
+import { EpisodeCaptureDialog, type EpisodeCaptureValues } from '@/components/ui/EpisodeCaptureDialog';
+import type { Episode } from '@/types/episode';
+
+/**
+ * ソート可能なエピソード行コンポーネント
+ */
+function SortableEpisodeItem({
+  episode,
+  onDelete,
+  onTitleSave,
+}: {
+  episode: Episode;
+  onDelete: (id: string) => void;
+  onTitleSave: (id: string, title: string) => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(episode.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: episode.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const handleTitleClick = () => {
+    setIsEditing(true);
+    setEditValue(episode.title);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const handleSave = () => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== episode.title) {
+      onTitleSave(episode.id, trimmed);
+    }
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === 'Escape') {
+      setIsEditing(false);
+    }
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-1 px-2 py-1.5 rounded hover:bg-gray-50 group"
+    >
+      {/* ドラッグハンドル */}
+      <button
+        {...attributes}
+        {...listeners}
+        className="cursor-grab text-gray-300 hover:text-gray-500 shrink-0"
+        aria-label="ドラッグして並び替え"
+        tabIndex={-1}
+      >
+        <GripVertical className="w-3.5 h-3.5" />
+      </button>
+
+      {/* タイトル（インライン編集） */}
+      <div className="flex-1 min-w-0">
+        {isEditing ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleSave}
+            className="w-full px-1 py-0.5 text-xs border border-amber-400 rounded focus:outline-none focus:ring-1 focus:ring-amber-500"
+            aria-label="タイトルを編集"
+          />
+        ) : (
+          <button
+            type="button"
+            className="w-full text-left text-xs text-gray-800 truncate hover:text-amber-700"
+            onClick={handleTitleClick}
+          >
+            {episode.title}
+          </button>
+        )}
+        {episode.occurredAt && (
+          <span className="text-[10px] text-gray-400">{episode.occurredAt}</span>
+        )}
+      </div>
+
+      {/* 削除ボタン */}
+      <button
+        type="button"
+        onClick={() => onDelete(episode.id)}
+        className="opacity-0 group-hover:opacity-100 shrink-0 text-gray-400 hover:text-red-500 transition-opacity"
+        aria-label={`「${episode.title}」を削除`}
+      >
+        <Trash2 className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * エピソード一覧コンポーネント
+ */
+export function EpisodeList() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const episodes = useGraphStore((state) => state.episodes);
+  const createEpisode = useGraphStore((state) => state.createEpisode);
+  const deleteEpisode = useGraphStore((state) => state.deleteEpisode);
+  const updateEpisode = useGraphStore((state) => state.updateEpisode);
+  const reorderEpisodes = useGraphStore((state) => state.reorderEpisodes);
+  const addParticipation = useGraphStore((state) => state.addParticipation);
+  const openConfirm = useDialogStore((state) => state.openConfirm);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = episodes.findIndex((e) => e.id === active.id);
+    const newIndex = episodes.findIndex((e) => e.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = arrayMove(episodes, oldIndex, newIndex);
+    reorderEpisodes(reordered.map((e) => e.id));
+  };
+
+  const handleDelete = async (id: string) => {
+    const episode = episodes.find((e) => e.id === id);
+    const confirmed = await openConfirm({
+      message: `「${episode?.title ?? 'このエピソード'}」を削除してもよろしいですか？`,
+      isDanger: true,
+    });
+    if (confirmed) {
+      deleteEpisode(id);
+    }
+  };
+
+  const handleTitleSave = (id: string, title: string) => {
+    updateEpisode(id, { title });
+  };
+
+  const handleSave = (values: EpisodeCaptureValues) => {
+    const episodeId = createEpisode({
+      title: values.title,
+      description: values.description,
+      occurredAt: values.occurredAt,
+      relatedRelationshipIds: values.relatedRelationshipIds,
+    });
+    // 参加人物のエッジを作成
+    for (const personId of values.participantPersonIds) {
+      addParticipation({ episodeId, personId });
+    }
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <>
+      {/* セクションヘッダー */}
+      <div className="flex items-center justify-between px-3 py-2">
+        <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">エピソード</h3>
+        <button
+          type="button"
+          onClick={() => setIsDialogOpen(true)}
+          className="flex items-center gap-0.5 text-xs text-amber-600 hover:text-amber-700 font-medium"
+          aria-label="エピソードを追加"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          エピソードを追加
+        </button>
+      </div>
+
+      {/* 一覧 */}
+      {episodes.length === 0 ? (
+        <p className="px-3 py-4 text-xs text-gray-400 text-center">
+          エピソードがありません
+        </p>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={episodes.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+            <div className="space-y-0.5">
+              {episodes.map((episode) => (
+                <SortableEpisodeItem
+                  key={episode.id}
+                  episode={episode}
+                  onDelete={handleDelete}
+                  onTitleSave={handleTitleSave}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      {/* エピソード追加ダイアログ */}
+      <EpisodeCaptureDialog
+        isOpen={isDialogOpen}
+        onSave={handleSave}
+        onCancel={() => setIsDialogOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/components/panel/EpisodeList.tsx
+++ b/src/components/panel/EpisodeList.tsx
@@ -51,6 +51,8 @@ function SortableEpisodeItem({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(episode.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Enter→blur の二重発火を防ぐフラグ（SortableSnapshotItemと同パターン）
+  const isSavingRef = useRef(false);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: episode.id,
@@ -69,11 +71,14 @@ function SortableEpisodeItem({
   };
 
   const handleSave = () => {
+    if (isSavingRef.current) return;
+    isSavingRef.current = true;
     const trimmed = editValue.trim();
     if (trimmed && trimmed !== episode.title) {
       onTitleSave(episode.id, trimmed);
     }
     setIsEditing(false);
+    isSavingRef.current = false;
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -82,7 +87,9 @@ function SortableEpisodeItem({
       e.preventDefault();
       handleSave();
     } else if (e.key === 'Escape') {
+      isSavingRef.current = true;
       setIsEditing(false);
+      isSavingRef.current = false;
     }
   };
 
@@ -98,7 +105,6 @@ function SortableEpisodeItem({
         {...listeners}
         className="cursor-grab text-gray-300 hover:text-gray-500 shrink-0"
         aria-label="ドラッグして並び替え"
-        tabIndex={-1}
       >
         <GripVertical className="w-3.5 h-3.5" />
       </button>

--- a/src/components/ui/EpisodeCaptureDialog.test.tsx
+++ b/src/components/ui/EpisodeCaptureDialog.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * EpisodeCaptureDialogのテスト
+ * エピソード作成/編集ダイアログの入力・バリデーション・IMEガードを検証する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EpisodeCaptureDialog } from './EpisodeCaptureDialog';
+import type { Person } from '@/types/person';
+
+// useGraphStoreをモック（persons一覧の取得に使用）
+vi.mock('@/stores/useGraphStore', () => ({
+  useGraphStore: vi.fn((selector: (state: { persons: Person[] }) => unknown) =>
+    selector({ persons: mockPersons })
+  ),
+}));
+
+const mockPersons: Person[] = [
+  {
+    id: 'p-001',
+    name: '佐藤 花子',
+    labels: [],
+    properties: {},
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'p-002',
+    name: '田中 一郎',
+    labels: [],
+    properties: {},
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+];
+
+function makeProps(overrides: Partial<Parameters<typeof EpisodeCaptureDialog>[0]> = {}) {
+  return {
+    isOpen: true,
+    onSave: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('EpisodeCaptureDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('タイトル必須バリデーション', () => {
+    it('タイトルが空のとき保存ボタンが無効化されている', () => {
+      render(<EpisodeCaptureDialog {...makeProps()} />);
+
+      const saveButton = screen.getByRole('button', { name: '保存' });
+      expect(saveButton).toBeDisabled();
+    });
+
+    it('タイトルを入力すると保存ボタンが有効になる', async () => {
+      const user = userEvent.setup();
+      render(<EpisodeCaptureDialog {...makeProps()} />);
+
+      const titleInput = screen.getByLabelText(/タイトル/);
+      await user.type(titleInput, '初めての出会い');
+
+      expect(screen.getByRole('button', { name: '保存' })).toBeEnabled();
+    });
+
+    it('タイトルが空白のみのとき保存ボタンが無効化されている', async () => {
+      const user = userEvent.setup();
+      render(<EpisodeCaptureDialog {...makeProps()} />);
+
+      const titleInput = screen.getByLabelText(/タイトル/);
+      await user.type(titleInput, '   ');
+
+      expect(screen.getByRole('button', { name: '保存' })).toBeDisabled();
+    });
+  });
+
+  describe('保存処理', () => {
+    it('タイトルだけ入力して保存するとonSaveが呼ばれる', async () => {
+      const user = userEvent.setup();
+      const onSave = vi.fn();
+      render(<EpisodeCaptureDialog {...makeProps({ onSave })} />);
+
+      await user.type(screen.getByLabelText(/タイトル/), '再会の場面');
+      await user.click(screen.getByRole('button', { name: '保存' }));
+
+      expect(onSave).toHaveBeenCalledWith({
+        title: '再会の場面',
+        description: undefined,
+        occurredAt: undefined,
+        participantPersonIds: [],
+        relatedRelationshipIds: [],
+      });
+    });
+
+    it('全フィールドを入力して保存するとonSaveが呼ばれる', async () => {
+      const user = userEvent.setup();
+      const onSave = vi.fn();
+      render(<EpisodeCaptureDialog {...makeProps({ onSave })} />);
+
+      await user.type(screen.getByLabelText(/タイトル/), '決別の夜');
+      await user.type(screen.getByLabelText(/説明/), '二人が永遠の別れを告げた');
+      await user.type(screen.getByLabelText(/発生日時/), '第12話');
+
+      await user.click(screen.getByRole('button', { name: '保存' }));
+
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: '決別の夜',
+          description: '二人が永遠の別れを告げた',
+          occurredAt: '第12話',
+        })
+      );
+    });
+  });
+
+  describe('キャンセル処理', () => {
+    it('キャンセルボタンでonCancelが呼ばれる', async () => {
+      const user = userEvent.setup();
+      const onCancel = vi.fn();
+      render(<EpisodeCaptureDialog {...makeProps({ onCancel })} />);
+
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('IMEガード', () => {
+    it('IME変換中（isComposing=true）のEnterキーでは保存されない', async () => {
+      const onSave = vi.fn();
+      render(<EpisodeCaptureDialog {...makeProps({ onSave })} />);
+
+      const titleInput = screen.getByLabelText(/タイトル/);
+      fireEvent.change(titleInput, { target: { value: '初恋' } });
+      // IME変換中のEnterイベント（isComposing=true）
+      // fireEvent.keyDown の isComposing オプションが nativeEvent.isComposing に反映される
+      fireEvent.keyDown(titleInput, { key: 'Enter', isComposing: true });
+
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('IME確定後のEnterキーで保存される', () => {
+      const onSave = vi.fn();
+      render(<EpisodeCaptureDialog {...makeProps({ onSave })} />);
+
+      const titleInput = screen.getByLabelText(/タイトル/);
+      fireEvent.change(titleInput, { target: { value: '初恋の季節' } });
+      // 通常のEnterキー（isComposing=false）
+      fireEvent.keyDown(titleInput, { key: 'Enter' });
+
+      expect(onSave).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('初期値（編集モード）', () => {
+    it('initialValuesが渡された場合、フォームに初期値が設定される', () => {
+      render(
+        <EpisodeCaptureDialog
+          {...makeProps({
+            initialValues: {
+              title: '邂逅',
+              description: '最初の出会いの場面',
+              occurredAt: '第1話',
+              participantPersonIds: [],
+              relatedRelationshipIds: [],
+            },
+          })}
+        />
+      );
+
+      expect(screen.getByLabelText(/タイトル/)).toHaveValue('邂逅');
+      expect(screen.getByLabelText(/説明/)).toHaveValue('最初の出会いの場面');
+      expect(screen.getByLabelText(/発生日時/)).toHaveValue('第1話');
+    });
+  });
+
+  describe('表示制御', () => {
+    it('isOpen=falseのときダイアログが表示されない', () => {
+      render(<EpisodeCaptureDialog {...makeProps({ isOpen: false })} />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/EpisodeCaptureDialog.tsx
+++ b/src/components/ui/EpisodeCaptureDialog.tsx
@@ -1,0 +1,260 @@
+/**
+ * EpisodeCaptureDialogコンポーネント
+ * エピソードの作成・編集ダイアログ
+ *
+ * 入力項目:
+ * - タイトル（必須）
+ * - 説明（任意、複数行）
+ * - 発生日時（任意、自由文字列）
+ * - 参加人物（任意、複数選択）
+ * - 関連関係（任意、ID参照）
+ *
+ * 特徴:
+ * - タイトルが空の場合は保存ボタンを無効化
+ * - Enterキーで保存（IME変換中は無視）
+ * - Escapeキーでキャンセル
+ * - 背景クリックでキャンセル
+ */
+
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { useGraphStore } from '@/stores/useGraphStore';
+
+/**
+ * EpisodeCaptureDialogの保存データ
+ */
+export type EpisodeCaptureValues = {
+  title: string;
+  description?: string;
+  occurredAt?: string;
+  participantPersonIds: string[];
+  relatedRelationshipIds: string[];
+};
+
+/**
+ * EpisodeCaptureDialogのプロパティ
+ */
+type EpisodeCaptureDialogProps = {
+  /** ダイアログを表示するかどうか */
+  isOpen: boolean;
+  /** 保存ボタン押下時のコールバック */
+  onSave: (values: EpisodeCaptureValues) => void;
+  /** キャンセル時のコールバック */
+  onCancel: () => void;
+  /** 編集モード時の初期値 */
+  initialValues?: EpisodeCaptureValues;
+};
+
+/**
+ * エピソード作成・編集ダイアログ
+ */
+export function EpisodeCaptureDialog({
+  isOpen,
+  onSave,
+  onCancel,
+  initialValues,
+}: EpisodeCaptureDialogProps) {
+  const [title, setTitle] = useState(initialValues?.title ?? '');
+  const [description, setDescription] = useState(initialValues?.description ?? '');
+  const [occurredAt, setOccurredAt] = useState(initialValues?.occurredAt ?? '');
+  const [participantPersonIds, setParticipantPersonIds] = useState<string[]>(
+    initialValues?.participantPersonIds ?? []
+  );
+
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const persons = useGraphStore((state) => state.persons);
+
+  // ダイアログが開くたびに入力値をリセット（または初期値を反映）してフォーカス
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(initialValues?.title ?? '');
+      setDescription(initialValues?.description ?? '');
+      setOccurredAt(initialValues?.occurredAt ?? '');
+      setParticipantPersonIds(initialValues?.participantPersonIds ?? []);
+      const timer = setTimeout(() => {
+        titleInputRef.current?.focus();
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+    // isOpen の変化時のみリセットする（initialValues の参照変化では再初期化しない）
+  }, [isOpen]);
+
+  // Escapeキーでキャンセル
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onCancel();
+      }
+    };
+    if (isOpen) {
+      window.addEventListener('keydown', handleKeyDown);
+    }
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  const isValid = title.trim().length > 0;
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({
+      title: title.trim(),
+      description: description.trim() || undefined,
+      occurredAt: occurredAt.trim() || undefined,
+      participantPersonIds,
+      relatedRelationshipIds: initialValues?.relatedRelationshipIds ?? [],
+    });
+  };
+
+  /**
+   * タイトル入力のEnterキー処理（IME変換中は無視）
+   */
+  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
+  /**
+   * 参加人物トグル
+   */
+  const toggleParticipant = (personId: string) => {
+    setParticipantPersonIds((prev) =>
+      prev.includes(personId) ? prev.filter((id) => id !== personId) : [...prev, personId]
+    );
+  };
+
+  /**
+   * 背景クリックでキャンセル
+   */
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleOverlayClick}
+      role="presentation"
+    >
+      <div
+        className="bg-white rounded-lg shadow-lg p-6 max-w-md w-full mx-4 max-h-[90vh] overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="episode-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <h2 id="episode-dialog-title" className="text-lg font-bold mb-4">
+          {initialValues ? 'エピソードを編集' : 'エピソードを追加'}
+        </h2>
+
+        {/* タイトル（必須） */}
+        <div className="mb-4">
+          <label htmlFor="episode-title" className="block text-sm font-medium text-gray-700 mb-1">
+            タイトル
+            <span className="text-red-500 ml-1" aria-hidden="true">*</span>
+          </label>
+          <input
+            ref={titleInputRef}
+            id="episode-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={handleTitleKeyDown}
+            placeholder="例: 初めての出会い、決別の夜"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500 text-sm"
+            aria-required="true"
+          />
+        </div>
+
+        {/* 発生日時（任意） */}
+        <div className="mb-4">
+          <label htmlFor="episode-occurred-at" className="block text-sm font-medium text-gray-700 mb-1">
+            発生日時
+            <span className="text-gray-400 ml-1 text-xs font-normal">（任意）</span>
+          </label>
+          <input
+            id="episode-occurred-at"
+            type="text"
+            value={occurredAt}
+            onChange={(e) => setOccurredAt(e.target.value)}
+            placeholder="例: 第5話、2024年春"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500 text-sm"
+          />
+        </div>
+
+        {/* 説明（任意） */}
+        <div className="mb-4">
+          <label htmlFor="episode-description" className="block text-sm font-medium text-gray-700 mb-1">
+            説明
+            <span className="text-gray-400 ml-1 text-xs font-normal">（任意）</span>
+          </label>
+          <textarea
+            id="episode-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="このエピソードの概要や背景メモを入力"
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500 text-sm resize-none"
+          />
+        </div>
+
+        {/* 参加人物（任意） */}
+        {persons.length > 0 && (
+          <div className="mb-6">
+            <span className="block text-sm font-medium text-gray-700 mb-2">
+              参加人物
+              <span className="text-gray-400 ml-1 text-xs font-normal">（任意）</span>
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {persons.map((person) => {
+                const isSelected = participantPersonIds.includes(person.id);
+                return (
+                  <button
+                    key={person.id}
+                    type="button"
+                    onClick={() => toggleParticipant(person.id)}
+                    className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                      isSelected
+                        ? 'bg-amber-500 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    {person.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* ボタン */}
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-800 font-medium transition-colors text-sm"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!isValid}
+            className="px-4 py-2 rounded bg-amber-500 hover:bg-amber-600 disabled:bg-amber-300 disabled:cursor-not-allowed text-white font-medium transition-colors text-sm"
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/chart-io.test.ts
+++ b/src/lib/chart-io.test.ts
@@ -513,12 +513,12 @@ describe('prepareChartForImport', () => {
     expect(prepared.name).toBe('源氏物語 人物相関図');
   });
 
-  it('normalizeChart経由でschemaVersion 12に正規化される', () => {
+  it('normalizeChart経由でschemaVersion 13に正規化される', () => {
     // schemaVersionが古い（または欠落した）データでもインポートできることを確認
     const chart = makeTestChart({ schemaVersion: undefined });
     const prepared = prepareChartForImport(chart);
 
-    expect(prepared.schemaVersion).toBe(12);
+    expect(prepared.schemaVersion).toBe(13);
   });
 
   it('スナップショットなしのChartも正常にインポートできる', () => {

--- a/src/lib/graph-utils.test.ts
+++ b/src/lib/graph-utils.test.ts
@@ -4,10 +4,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { personsToNodes, relationshipsToEdges, matchesEdgeFilter, syncNodePositionsToStore, calculateParallelEdgeOffset } from './graph-utils';
+import { personsToNodes, relationshipsToEdges, matchesEdgeFilter, syncNodePositionsToStore, calculateParallelEdgeOffset, episodesToNodes, participationsToEdges } from './graph-utils';
 import type { Person } from '@/types/person';
 import type { Relationship, EdgeFilter } from '@/types/relationship';
 import type { GraphNode } from '@/types/graph';
+import type { Episode, EpisodeParticipation } from '@/types/episode';
 
 // ─── テストデータ ヘルパー ─────────────────────────────────────────────────────
 
@@ -807,5 +808,118 @@ describe('graph-utils', () => {
       // 合計間隔が正の値であること
       expect(offset1 - offset0).toBeGreaterThan(0);
     });
+  });
+});
+
+// ─── episodesToNodes / participationsToEdges ──────────────────────────────────
+
+/** テスト用エピソードのヘルパー */
+function makeEpisode(overrides: Partial<Episode> & { id: string; title: string }): Episode {
+  return {
+    relatedRelationshipIds: [],
+    properties: {},
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('episodesToNodes', () => {
+  it('Episode配列をEpisodeNodeの配列に変換する', () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 'ep-001', title: '初めての出会い' }),
+    ];
+
+    const nodes = episodesToNodes(episodes);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].id).toBe('ep-001');
+    expect(nodes[0].type).toBe('episode');
+    expect(nodes[0].data.title).toBe('初めての出会い');
+  });
+
+  it('説明・日時・関連関係IDがdataに含まれる', () => {
+    const episodes: Episode[] = [
+      makeEpisode({
+        id: 'ep-002',
+        title: '決別の朝',
+        description: '二人の関係が壊れた',
+        occurredAt: '第5話',
+        relatedRelationshipIds: ['rel-001'],
+      }),
+    ];
+
+    const nodes = episodesToNodes(episodes);
+
+    expect(nodes[0].data.description).toBe('二人の関係が壊れた');
+    expect(nodes[0].data.occurredAt).toBe('第5話');
+    expect(nodes[0].data.relatedRelationshipIds).toEqual(['rel-001']);
+  });
+
+  it('position が設定されている場合はそれを使用する', () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 'ep-003', title: '再会', position: { x: 200, y: 300 } }),
+    ];
+
+    const nodes = episodesToNodes(episodes);
+
+    expect(nodes[0].position).toEqual({ x: 200, y: 300 });
+  });
+
+  it('position がない場合は (0, 0) をデフォルトにする', () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 'ep-004', title: '別れ' }),
+    ];
+
+    const nodes = episodesToNodes(episodes);
+
+    expect(nodes[0].position).toEqual({ x: 0, y: 0 });
+  });
+
+  it('空配列を渡すと空配列が返る', () => {
+    const nodes = episodesToNodes([]);
+    expect(nodes).toEqual([]);
+  });
+});
+
+describe('participationsToEdges', () => {
+  it('EpisodeParticipation配列をParticipationEdgeの配列に変換する', () => {
+    const participations: EpisodeParticipation[] = [
+      {
+        id: 'part-001',
+        episodeId: 'ep-001',
+        personId: 'person-001',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const edges = participationsToEdges(participations);
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].id).toBe('part-001');
+    expect(edges[0].type).toBe('participation');
+    expect(edges[0].source).toBe('ep-001');
+    expect(edges[0].target).toBe('person-001');
+  });
+
+  it('roleがある場合はdataに含まれる', () => {
+    const participations: EpisodeParticipation[] = [
+      {
+        id: 'part-002',
+        episodeId: 'ep-002',
+        personId: 'person-002',
+        role: '主人公',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const edges = participationsToEdges(participations);
+
+    expect(edges[0].data?.role).toBe('主人公');
+  });
+
+  it('空配列を渡すと空配列が返る', () => {
+    const edges = participationsToEdges([]);
+    expect(edges).toEqual([]);
   });
 });

--- a/src/lib/graph-utils.ts
+++ b/src/lib/graph-utils.ts
@@ -216,25 +216,29 @@ export function participationsToEdges(participations: EpisodeParticipation[]): P
  * React Flowのノード配列からMapを構築してストアの位置更新関数を呼ぶヘルパー
  *
  * @param nodes - id と position を持つノード配列
- * @param updatePersonPositions - Personストアの位置更新関数
- * @param updateEpisodePosition - Episodeストアの位置更新関数（省略可）
+ * @param updatePersonPositions - Personストアの位置一括更新関数
+ * @param updateEpisodePositions - Episodeストアの位置一括更新関数（省略可）
  *
  * @description
  * EpisodeNodeはtype='episode'で判定し、それ以外はPersonノードとして扱う。
- * updateEpisodePosition が渡された場合のみEpisodeの位置を更新する。
+ * Episode位置をMapにまとめてから一括更新することでZustand setの連続発火を防ぐ。
  */
 export function syncNodePositionsToStore(
   nodes: Array<{ id: string; type?: string; position: { x: number; y: number } }>,
   updatePersonPositions: (positions: Map<string, { x: number; y: number }>) => void,
-  updateEpisodePosition?: (id: string, position: { x: number; y: number }) => void
+  updateEpisodePositions?: (positions: Map<string, { x: number; y: number }>) => void
 ): void {
   const personPositions = new Map<string, { x: number; y: number }>();
+  const episodePositions = new Map<string, { x: number; y: number }>();
   for (const node of nodes) {
     if (node.type === 'episode') {
-      updateEpisodePosition?.(node.id, node.position);
+      episodePositions.set(node.id, node.position);
     } else {
       personPositions.set(node.id, node.position);
     }
   }
   updatePersonPositions(personPositions);
+  if (episodePositions.size > 0) {
+    updateEpisodePositions?.(episodePositions);
+  }
 }

--- a/src/lib/graph-utils.ts
+++ b/src/lib/graph-utils.ts
@@ -1,11 +1,12 @@
 /**
  * グラフ変換ユーティリティ
- * Person/RelationshipをReact FlowのNode/Edgeに変換する
+ * Person/Relationship/Episode/EpisodeParticipationをReact FlowのNode/Edgeに変換する
  */
 
 import type { Person } from '@/types/person';
 import type { Relationship, EdgeFilter } from '@/types/relationship';
-import type { GraphNode, RelationshipEdge } from '@/types/graph';
+import type { GraphNode, RelationshipEdge, EpisodeNode, ParticipationEdge } from '@/types/graph';
+import type { Episode, EpisodeParticipation } from '@/types/episode';
 import { deriveEdgeVisual } from './relationship-visual';
 
 /**
@@ -176,17 +177,64 @@ export function calculateParallelEdgeOffset(
 }
 
 /**
+ * Episode配列をEpisodeNode配列に変換する
+ * @param episodes - 変換対象のEpisode配列
+ * @returns EpisodeNode配列。episode.positionがある場合はそれを使用し、ない場合は(0, 0)に設定される
+ */
+export function episodesToNodes(episodes: Episode[]): EpisodeNode[] {
+  return episodes.map((episode) => ({
+    id: episode.id,
+    type: 'episode' as const,
+    data: {
+      title: episode.title,
+      description: episode.description,
+      occurredAt: episode.occurredAt,
+      relatedRelationshipIds: episode.relatedRelationshipIds,
+    },
+    position: episode.position ?? { x: 0, y: 0 },
+  }));
+}
+
+/**
+ * EpisodeParticipation配列をParticipationEdge配列に変換する
+ * @param participations - 変換対象のEpisodeParticipation配列
+ * @returns ParticipationEdge配列。エピソードから人物への破線エッジを生成する
+ */
+export function participationsToEdges(participations: EpisodeParticipation[]): ParticipationEdge[] {
+  return participations.map((participation) => ({
+    id: participation.id,
+    type: 'participation' as const,
+    source: participation.episodeId,
+    target: participation.personId,
+    data: {
+      role: participation.role,
+    },
+  }));
+}
+
+/**
  * React Flowのノード配列からMapを構築してストアの位置更新関数を呼ぶヘルパー
+ *
  * @param nodes - id と position を持つノード配列
- * @param updatePositions - ストアの位置更新関数
+ * @param updatePersonPositions - Personストアの位置更新関数
+ * @param updateEpisodePosition - Episodeストアの位置更新関数（省略可）
+ *
+ * @description
+ * EpisodeNodeはtype='episode'で判定し、それ以外はPersonノードとして扱う。
+ * updateEpisodePosition が渡された場合のみEpisodeの位置を更新する。
  */
 export function syncNodePositionsToStore(
-  nodes: Array<{ id: string; position: { x: number; y: number } }>,
-  updatePositions: (positions: Map<string, { x: number; y: number }>) => void
+  nodes: Array<{ id: string; type?: string; position: { x: number; y: number } }>,
+  updatePersonPositions: (positions: Map<string, { x: number; y: number }>) => void,
+  updateEpisodePosition?: (id: string, position: { x: number; y: number }) => void
 ): void {
-  const positions = new Map<string, { x: number; y: number }>();
+  const personPositions = new Map<string, { x: number; y: number }>();
   for (const node of nodes) {
-    positions.set(node.id, node.position);
+    if (node.type === 'episode') {
+      updateEpisodePosition?.(node.id, node.position);
+    } else {
+      personPositions.set(node.id, node.position);
+    }
   }
-  updatePositions(positions);
+  updatePersonPositions(personPositions);
 }

--- a/src/lib/migration.test.ts
+++ b/src/lib/migration.test.ts
@@ -1534,7 +1534,7 @@ describe('migrateV9ToV10', () => {
 });
 
 describe('normalizeChart', () => {
-  // v12マイグレーションのテスト
+  // v12/v13マイグレーションのテスト
 
   // v11チャートのベースデータ（スナップショットなし）
   const baseV11Chart = {
@@ -1558,12 +1558,14 @@ describe('normalizeChart', () => {
     updatedAt: '2024-01-01T00:00:00.000Z',
   };
 
-  describe('v11チャートのv12への正規化', () => {
-    it('schemaVersion: 11 のチャートに snapshots: [] を補完する', () => {
+  describe('v11チャートのv13への正規化', () => {
+    it('schemaVersion: 11 のチャートに snapshots/episodes/episodeParticipations を補完する', () => {
       const result = normalizeChart({ ...baseV11Chart });
 
-      expect(result.schemaVersion).toBe(12);
+      expect(result.schemaVersion).toBe(13);
       expect(result.snapshots).toEqual([]);
+      expect(result.episodes).toEqual([]);
+      expect(result.episodeParticipations).toEqual([]);
     });
 
     it('既に snapshots が設定されている場合はそのまま保持する', () => {
@@ -1582,24 +1584,113 @@ describe('normalizeChart', () => {
 
       const result = normalizeChart(chartWithSnapshots);
 
-      expect(result.schemaVersion).toBe(12);
+      expect(result.schemaVersion).toBe(13);
       expect(result.snapshots).toHaveLength(1);
       expect(result.snapshots?.[0].label).toBe('第1話');
     });
   });
 
-  describe('v12チャートはそのまま返す', () => {
-    it('schemaVersion: 12 のチャートはデータ変更なしで返す', () => {
+  describe('v12チャートのv13への正規化', () => {
+    it('schemaVersion: 12 のチャートに episodes: [] と episodeParticipations: [] を補完する', () => {
+      // NOTE: v12 → v13 のマイグレーション。schemaVersion: 12 はもはや早期リターンしない
       const v12Chart = {
         ...baseV11Chart,
         snapshots: [],
         schemaVersion: 12,
       };
 
-      const result = normalizeChart(v12Chart);
+      const result = normalizeChart(v12Chart as Parameters<typeof normalizeChart>[0]);
 
-      // 同一オブジェクトが返ること（変換処理なし）
-      expect(result).toBe(v12Chart);
+      expect(result.schemaVersion).toBe(13);
+      expect(result.episodes).toEqual([]);
+      expect(result.episodeParticipations).toEqual([]);
+    });
+
+    it('既に episodes が設定されている v12 チャートはその値を保持する', () => {
+      const v12ChartWithEpisodes = {
+        ...baseV11Chart,
+        snapshots: [],
+        episodes: [
+          {
+            id: 'ep-001',
+            title: '運命の出会い',
+            relatedRelationshipIds: [],
+            properties: {},
+            createdAt: '2024-06-01T00:00:00.000Z',
+            updatedAt: '2024-06-01T00:00:00.000Z',
+          },
+        ],
+        episodeParticipations: [],
+        schemaVersion: 12,
+      };
+
+      const result = normalizeChart(v12ChartWithEpisodes as Parameters<typeof normalizeChart>[0]);
+
+      expect(result.schemaVersion).toBe(13);
+      expect(result.episodes).toHaveLength(1);
+      expect(result.episodes?.[0].title).toBe('運命の出会い');
+    });
+
+    it('既存スナップショットに episodes: [] と episodeParticipations: [] を補完する', () => {
+      const v12ChartWithSnapshot = {
+        ...baseV11Chart,
+        snapshots: [
+          {
+            id: 'snap-001',
+            label: '第1話',
+            persons: [],
+            relationships: [],
+            createdAt: '2024-06-01T00:00:00.000Z',
+            // episodes/episodeParticipationsは未設定（古いスナップショット）
+          },
+        ],
+        schemaVersion: 12,
+      };
+
+      const result = normalizeChart(v12ChartWithSnapshot as Parameters<typeof normalizeChart>[0]);
+
+      expect(result.schemaVersion).toBe(13);
+      expect(result.snapshots?.[0].episodes).toEqual([]);
+      expect(result.snapshots?.[0].episodeParticipations).toEqual([]);
+    });
+
+    it('既存スナップショットに episodes が設定済みの場合はそのまま保持する', () => {
+      const v12ChartWithEpisodeSnapshot = {
+        ...baseV11Chart,
+        snapshots: [
+          {
+            id: 'snap-001',
+            label: '第2話',
+            persons: [],
+            relationships: [],
+            episodes: [{ episodeId: 'ep-001', title: '再会', relatedRelationshipIds: [], properties: {} }],
+            episodeParticipations: [],
+            createdAt: '2024-06-01T00:00:00.000Z',
+          },
+        ],
+        schemaVersion: 12,
+      };
+
+      const result = normalizeChart(v12ChartWithEpisodeSnapshot as Parameters<typeof normalizeChart>[0]);
+
+      expect(result.snapshots?.[0].episodes).toHaveLength(1);
+      expect(result.snapshots?.[0].episodes?.[0].title).toBe('再会');
+    });
+  });
+
+  describe('v13チャートはそのまま返す', () => {
+    it('schemaVersion: 13 のチャートはデータ変更なしで返す', () => {
+      const v13Chart = {
+        ...baseV11Chart,
+        snapshots: [],
+        episodes: [],
+        episodeParticipations: [],
+        schemaVersion: 13,
+      };
+
+      const result = normalizeChart(v13Chart as Parameters<typeof normalizeChart>[0]);
+
+      expect(result).toBe(v13Chart);
     });
   });
 });

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -711,24 +711,25 @@ export function migrateGraphState(persistedState: unknown, version: number): unk
   return state;
 }
 
-// ─── IndexedDB Chart の正規化（v12 形式への変換） ──────────────────────────────
+// ─── IndexedDB Chart の正規化（v13 形式への変換） ──────────────────────────────
 
 /**
- * IndexedDB からロードした Chart を v12 形式に正規化する
+ * IndexedDB からロードした Chart を v13 形式に正規化する
  *
  * スキーマ変換の段階:
- *   v8以前  → v9: レイヤーベース → プロパティグラフ（forward/reverse構造）
+ *   v8以前  → v9:  レイヤーベース → プロパティグラフ（forward/reverse構造）
  *   v9/v10  → v11: Person.kind → labels、RelationshipV9 → Relationship
  *   v11     → v12: snapshots フィールドの追加（タイムライン機能対応）
+ *   v12     → v13: episodes/episodeParticipations フィールドの追加（エピソードノード対応）
  *
  * @param chart - ロードした Chart オブジェクト（古い schemaVersion の可能性あり）
- * @returns v12 形式に正規化された Chart
+ * @returns v13 形式に正規化された Chart
  */
 export function normalizeChart(chart: Chart): Chart {
   const schemaVersion = chart.schemaVersion ?? 0;
 
-  // v12以降はすでに最新形式
-  if (schemaVersion >= 12) return chart;
+  // v13以降はすでに最新形式
+  if (schemaVersion >= 13) return chart;
 
   let persons = chart.persons as unknown as LegacyPersonV10[];
   let relationships = chart.relationships as unknown[];
@@ -761,12 +762,21 @@ export function normalizeChart(chart: Chart): Chart {
   // persons に properties フィールドを追加
   const normalizedPersons = migratePersonsV10ToV11(persons);
 
-  // v11形式に正規化したチャートをv12に変換（snapshotsフィールドを補完）
+  // 既存スナップショットに episodes/episodeParticipations フィールドを補完（v13対応）
+  const normalizedSnapshots = (chart.snapshots ?? []).map((snapshot) => ({
+    ...snapshot,
+    episodes: snapshot.episodes ?? [],
+    episodeParticipations: snapshot.episodeParticipations ?? [],
+  }));
+
+  // v13に変換（episodes/episodeParticipationsフィールドを補完）
   return {
     ...chart,
     persons: normalizedPersons,
     relationships: normalizedRelationships,
-    snapshots: chart.snapshots ?? [],
-    schemaVersion: 12,
+    snapshots: normalizedSnapshots,
+    episodes: chart.episodes ?? [],
+    episodeParticipations: chart.episodeParticipations ?? [],
+    schemaVersion: 13,
   };
 }

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -4023,4 +4023,304 @@ describe('useGraphStore', () => {
       });
     });
   });
+
+  describe('エピソード機能', () => {
+    beforeEach(() => {
+      // エピソード関連の状態を初期化
+      useGraphStore.setState({
+        episodes: [],
+        episodeParticipations: [],
+      });
+    });
+
+    describe('createEpisode', () => {
+      it('新しいエピソードを作成できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          episodeId = result.current.createEpisode({
+            title: '初めての出会い',
+          });
+        });
+
+        expect(result.current.episodes).toHaveLength(1);
+        expect(result.current.episodes[0].id).toBe(episodeId!);
+        expect(result.current.episodes[0].title).toBe('初めての出会い');
+        expect(result.current.episodes[0].relatedRelationshipIds).toEqual([]);
+        expect(result.current.episodes[0].properties).toEqual({});
+        expect(result.current.episodes[0].createdAt).toBeTruthy();
+        expect(result.current.episodes[0].updatedAt).toBeTruthy();
+      });
+
+      it('説明・日時・関連関係IDを指定してエピソードを作成できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.createEpisode({
+            title: '決別の朝',
+            description: '二人の関係が決定的に壊れた朝の場面',
+            occurredAt: '第5話',
+            relatedRelationshipIds: ['rel-001'],
+          });
+        });
+
+        expect(result.current.episodes[0].description).toBe('二人の関係が決定的に壊れた朝の場面');
+        expect(result.current.episodes[0].occurredAt).toBe('第5話');
+        expect(result.current.episodes[0].relatedRelationshipIds).toEqual(['rel-001']);
+      });
+
+      it('複数のエピソードを作成できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        act(() => {
+          result.current.createEpisode({ title: 'エピソード1' });
+          result.current.createEpisode({ title: 'エピソード2' });
+        });
+
+        expect(result.current.episodes).toHaveLength(2);
+      });
+    });
+
+    describe('updateEpisode', () => {
+      it('エピソードのタイトルを更新できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          episodeId = result.current.createEpisode({ title: '旧タイトル' });
+        });
+
+        act(() => {
+          result.current.updateEpisode(episodeId!, { title: '再会の瞬間' });
+        });
+
+        expect(result.current.episodes[0].title).toBe('再会の瞬間');
+        expect(result.current.episodes[0].updatedAt).toBeTruthy();
+      });
+
+      it('複数フィールドを同時に更新できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          episodeId = result.current.createEpisode({ title: '最初の邂逅' });
+        });
+
+        act(() => {
+          result.current.updateEpisode(episodeId!, {
+            description: '二人が運命的に出会った場面',
+            occurredAt: '第1話 冒頭',
+          });
+        });
+
+        expect(result.current.episodes[0].description).toBe('二人が運命的に出会った場面');
+        expect(result.current.episodes[0].occurredAt).toBe('第1話 冒頭');
+        // タイトルは変更されていないこと
+        expect(result.current.episodes[0].title).toBe('最初の邂逅');
+      });
+    });
+
+    describe('deleteEpisode', () => {
+      it('エピソードを削除できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          episodeId = result.current.createEpisode({ title: '幻の再会' });
+        });
+
+        act(() => {
+          result.current.deleteEpisode(episodeId!);
+        });
+
+        expect(result.current.episodes).toHaveLength(0);
+      });
+
+      it('エピソード削除時に紐づく参加エッジも削除される', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        // 人物とエピソードを作成
+        act(() => {
+          result.current.addPerson({ name: '桐島 遥', labels: ['人物'], properties: {} });
+        });
+        let episodeId!: string;
+        act(() => {
+          episodeId = result.current.createEpisode({ title: '対峙' });
+        });
+        const personId = result.current.persons[0].id;
+
+        // 参加エッジを追加
+        act(() => {
+          result.current.addParticipation({ episodeId, personId });
+        });
+        expect(result.current.episodeParticipations).toHaveLength(1);
+
+        // エピソードを削除すると参加エッジも消える
+        act(() => {
+          result.current.deleteEpisode(episodeId);
+        });
+
+        expect(result.current.episodes).toHaveLength(0);
+        expect(result.current.episodeParticipations).toHaveLength(0);
+      });
+    });
+
+    describe('reorderEpisodes', () => {
+      it('エピソードをID配列の順序で並び替えられる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let id1!: string, id2!: string, id3!: string;
+        act(() => {
+          id1 = result.current.createEpisode({ title: '第1エピソード' });
+          id2 = result.current.createEpisode({ title: '第2エピソード' });
+          id3 = result.current.createEpisode({ title: '第3エピソード' });
+        });
+
+        // 逆順に並び替え
+        act(() => {
+          result.current.reorderEpisodes([id3!, id2!, id1!]);
+        });
+
+        expect(result.current.episodes[0].title).toBe('第3エピソード');
+        expect(result.current.episodes[1].title).toBe('第2エピソード');
+        expect(result.current.episodes[2].title).toBe('第1エピソード');
+      });
+    });
+
+    describe('updateEpisodePosition', () => {
+      it('エピソードのキャンバス座標を更新できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          episodeId = result.current.createEpisode({ title: '運命の分岐点' });
+        });
+
+        act(() => {
+          result.current.updateEpisodePosition(episodeId!, { x: 150, y: 300 });
+        });
+
+        expect(result.current.episodes[0].position).toEqual({ x: 150, y: 300 });
+      });
+    });
+
+    describe('addParticipation', () => {
+      it('エピソードに人物を参加者として追加できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          result.current.addPerson({ name: '水城 葵', labels: ['人物'], properties: {} });
+          episodeId = result.current.createEpisode({ title: '静寂の告白' });
+        });
+        const personId = result.current.persons[0].id;
+
+        let participationId!: string;
+        act(() => {
+          participationId = result.current.addParticipation({ episodeId, personId });
+        });
+
+        expect(result.current.episodeParticipations).toHaveLength(1);
+        expect(result.current.episodeParticipations[0].id).toBe(participationId);
+        expect(result.current.episodeParticipations[0].episodeId).toBe(episodeId);
+        expect(result.current.episodeParticipations[0].personId).toBe(personId);
+        expect(result.current.episodeParticipations[0].createdAt).toBeTruthy();
+      });
+    });
+
+    describe('removeParticipation', () => {
+      it('参加エッジを削除できる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        let episodeId!: string;
+        act(() => {
+          result.current.addPerson({ name: '黒瀬 律', labels: ['人物'], properties: {} });
+          episodeId = result.current.createEpisode({ title: '因縁の対決' });
+        });
+        const personId = result.current.persons[0].id;
+
+        let participationId!: string;
+        act(() => {
+          participationId = result.current.addParticipation({ episodeId, personId });
+        });
+
+        act(() => {
+          result.current.removeParticipation(participationId);
+        });
+
+        expect(result.current.episodeParticipations).toHaveLength(0);
+      });
+    });
+
+    describe('captureSnapshot でエピソードが取り込まれる', () => {
+      it('スナップショット保存時にエピソードと参加エッジが含まれる', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        useGraphStore.setState({ snapshots: [], timelineMode: false, activeSnapshotIndex: null });
+
+        let episodeId!: string;
+        act(() => {
+          result.current.addPerson({ name: '橘 咲良', labels: ['人物'], properties: {} });
+          episodeId = result.current.createEpisode({
+            title: '出発の朝',
+            description: '長い旅の始まり',
+            occurredAt: '第1話',
+          });
+        });
+        const personId = result.current.persons[0].id;
+        act(() => {
+          result.current.addParticipation({ episodeId, personId });
+        });
+
+        act(() => {
+          result.current.captureSnapshot('第1話スナップショット');
+        });
+
+        const snapshot = result.current.snapshots[0];
+        expect(snapshot.episodes).toHaveLength(1);
+        expect(snapshot.episodes![0].title).toBe('出発の朝');
+        expect(snapshot.episodes![0].episodeId).toBe(episodeId);
+        expect(snapshot.episodeParticipations).toHaveLength(1);
+        expect(snapshot.episodeParticipations![0].episodeId).toBe(episodeId);
+        expect(snapshot.episodeParticipations![0].personId).toBe(personId);
+      });
+    });
+
+    describe('goToSnapshot でエピソードが復元される', () => {
+      it('スナップショットに戻ると保存時のエピソードが復元される', () => {
+        const { result } = renderHook(() => useGraphStore());
+
+        useGraphStore.setState({ snapshots: [], timelineMode: false, activeSnapshotIndex: null });
+
+        let episodeId!: string;
+        act(() => {
+          result.current.addPerson({ name: '霧島 蒼', labels: ['人物'], properties: {} });
+          episodeId = result.current.createEpisode({ title: '雨の日の記憶' });
+        });
+        const personId = result.current.persons[0].id;
+        act(() => {
+          result.current.addParticipation({ episodeId, personId });
+          result.current.captureSnapshot('第2話');
+        });
+
+        // スナップショット保存後にエピソードを削除
+        act(() => {
+          result.current.deleteEpisode(episodeId);
+        });
+        expect(result.current.episodes).toHaveLength(0);
+
+        // タイムラインモードでスナップショットに戻る
+        act(() => {
+          result.current.setTimelineMode(true);
+          result.current.goToSnapshot(0);
+        });
+
+        // エピソードが復元されていること
+        expect(result.current.episodes).toHaveLength(1);
+        expect(result.current.episodes[0].title).toBe('雨の日の記憶');
+        expect(result.current.episodeParticipations).toHaveLength(1);
+      });
+    });
+  });
 });

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -518,6 +518,12 @@ type GraphActions = {
   updateEpisodePosition: (id: string, position: { x: number; y: number }) => void;
 
   /**
+   * 複数エピソードの位置を一括更新する（ドラッグ終了時の効率的バッチ更新用）
+   * @param positions - エピソードID → 座標 のMap
+   */
+  updateEpisodePositions: (positions: Map<string, { x: number; y: number }>) => void;
+
+  /**
    * エピソードに参加者（人物）を追加する
    * @param input - エピソードIDと人物ID
    * @returns 作成した参加エッジのID
@@ -1577,6 +1583,19 @@ export const useGraphStore = create<GraphStore>()(
         },
 
         reorderEpisodes: (orderedIds) => {
+          const { episodes } = get();
+
+          if (orderedIds.length !== episodes.length) {
+            throw new Error('並び順のエピソード数が一致しません');
+          }
+          if (new Set(orderedIds).size !== orderedIds.length) {
+            throw new Error('並び順に重複したエピソードIDが含まれています');
+          }
+          const currentIds = new Set(episodes.map((e) => e.id));
+          if (orderedIds.some((id) => !currentIds.has(id))) {
+            throw new Error('並び順に存在しないエピソードIDが含まれています');
+          }
+
           set((s) => {
             const episodeMap = new Map(s.episodes.map((e) => [e.id, e]));
             const sortedEpisodes = orderedIds
@@ -1588,11 +1607,39 @@ export const useGraphStore = create<GraphStore>()(
 
         updateEpisodePosition: (id, position) => {
           const now = new Date().toISOString();
-          set((s) => ({
-            episodes: s.episodes.map((e) =>
-              e.id === id ? { ...e, position, updatedAt: now } : e
-            ),
-          }));
+          set((s) => {
+            const target = s.episodes.find((e) => e.id === id);
+            // 位置が変わっていない場合は更新しない（updatedAt汚染を防ぐ）
+            if (
+              target &&
+              target.position?.x === position.x &&
+              target.position?.y === position.y
+            ) {
+              return {};
+            }
+            return {
+              episodes: s.episodes.map((e) =>
+                e.id === id ? { ...e, position, updatedAt: now } : e
+              ),
+            };
+          });
+        },
+
+        updateEpisodePositions: (positions) => {
+          if (positions.size === 0) return;
+          const now = new Date().toISOString();
+          set((s) => {
+            let hasChanged = false;
+            const updated = s.episodes.map((e) => {
+              const newPos = positions.get(e.id);
+              if (!newPos) return e;
+              // 位置が変わっていない場合はスキップ（updatedAt汚染を防ぐ）
+              if (e.position?.x === newPos.x && e.position?.y === newPos.y) return e;
+              hasChanged = true;
+              return { ...e, position: newPos, updatedAt: now };
+            });
+            return hasChanged ? { episodes: updated } : {};
+          });
         },
 
         addParticipation: ({ episodeId, personId }) => {

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -21,7 +21,8 @@ import { INITIAL_EDGE_FILTER } from '@/types/relationship';
 import type { EgoLayoutParams } from '@/lib/ego-layout';
 import { DEFAULT_EGO_LAYOUT_PARAMS } from '@/lib/ego-layout';
 import type { ChartMeta, Chart } from '@/types/chart';
-import type { Snapshot, SnapshotPerson, SnapshotRelationship } from '@/types/snapshot';
+import type { Snapshot, SnapshotPerson, SnapshotRelationship, SnapshotEpisode, SnapshotEpisodeParticipation } from '@/types/snapshot';
+import type { Episode, EpisodeParticipation } from '@/types/episode';
 import {
   initDB,
   saveChart,
@@ -96,6 +97,10 @@ type GraphState = {
   editingRelationshipId: string | null;
   /** エッジフィルタ（タグ・述語による絞り込み、セッション内のみ保持） */
   edgeFilter: EdgeFilter;
+  /** エピソードノード一覧（チャートに永続化される） */
+  episodes: Episode[];
+  /** エピソード参加エッジ一覧（チャートに永続化される） */
+  episodeParticipations: EpisodeParticipation[];
   /** タイムラインスナップショット一覧（チャートに永続化される） */
   snapshots: Snapshot[];
   /** タイムライン再生モード（true のとき編集操作を無効化、pauseAutoSave=true） */
@@ -106,6 +111,10 @@ type GraphState = {
   _livePersons: Person[] | null;
   /** タイムラインモード中のライブRelationshipsデータ退避（モード終了時に復元する） */
   _liveRelationships: Relationship[] | null;
+  /** タイムラインモード中のライブEpisodesデータ退避（モード終了時に復元する） */
+  _liveEpisodes: Episode[] | null;
+  /** タイムラインモード中のライブEpisodeParticipationsデータ退避（モード終了時に復元する） */
+  _liveEpisodeParticipations: EpisodeParticipation[] | null;
   /** アニメーション自動再生中かどうか */
   isPlaying: boolean;
   /** 自動再生の再生間隔（ミリ秒）。PLAYBACK_SPEEDS で定義された3段階のみ有効 */
@@ -135,11 +144,15 @@ const INITIAL_STATE: GraphState = {
   pauseAutoSave: false,
   editingRelationshipId: null,
   edgeFilter: INITIAL_EDGE_FILTER,
+  episodes: [],
+  episodeParticipations: [],
   snapshots: [],
   timelineMode: false,
   activeSnapshotIndex: null,
   _livePersons: null,
   _liveRelationships: null,
+  _liveEpisodes: null,
+  _liveEpisodeParticipations: null,
   isPlaying: false,
   playbackSpeed: 2000,
   previousSnapshotIndex: null,
@@ -172,12 +185,14 @@ function buildChartFromState(state: GraphState): Chart | null {
     // タイムラインモード中は退避したライブデータを保存（スナップショット表示状態を上書きしない）
     persons: state._livePersons ?? state.persons,
     relationships: state._liveRelationships ?? state.relationships,
+    episodes: state._liveEpisodes ?? state.episodes,
+    episodeParticipations: state._liveEpisodeParticipations ?? state.episodeParticipations,
     forceEnabled: state.forceEnabled,
     forceParams: state.forceParams,
     egoLayoutParams: state.egoLayoutParams,
     snapshots: state.snapshots,
-    // v12 形式であることを明示する（ロード時の再マイグレーションを防ぐ）
-    schemaVersion: 12,
+    // v13 形式であることを明示する（ロード時の再マイグレーションを防ぐ）
+    schemaVersion: 13,
     createdAt: meta.createdAt,
     updatedAt: new Date().toISOString(),
   };
@@ -468,6 +483,52 @@ type GraphActions = {
    * 退避していたライブデータを復元する
    */
   goToLive: () => void;
+
+  /**
+   * 新しいエピソードを作成する
+   * @param input - タイトル・説明・日時・関連関係IDなどの入力値
+   * @returns 作成したエピソードのID
+   */
+  createEpisode: (input: { title: string; description?: string; occurredAt?: string; relatedRelationshipIds?: string[]; position?: { x: number; y: number } }) => string;
+
+  /**
+   * エピソードを更新する
+   * @param id - 更新するエピソードのID
+   * @param patch - 更新する内容
+   */
+  updateEpisode: (id: string, patch: Partial<Omit<Episode, 'id' | 'createdAt'>>) => void;
+
+  /**
+   * エピソードを削除する（紐づく参加エッジも連動削除）
+   * @param id - 削除するエピソードのID
+   */
+  deleteEpisode: (id: string) => void;
+
+  /**
+   * エピソードの並び順を変更する
+   * @param orderedIds - 並び替え後のエピソードIDの配列
+   */
+  reorderEpisodes: (orderedIds: string[]) => void;
+
+  /**
+   * エピソードのキャンバス座標を更新する
+   * @param id - 更新するエピソードのID
+   * @param position - 新しいキャンバス座標
+   */
+  updateEpisodePosition: (id: string, position: { x: number; y: number }) => void;
+
+  /**
+   * エピソードに参加者（人物）を追加する
+   * @param input - エピソードIDと人物ID
+   * @returns 作成した参加エッジのID
+   */
+  addParticipation: (input: { episodeId: string; personId: string }) => string;
+
+  /**
+   * エピソード参加エッジを削除する
+   * @param participationId - 削除する参加エッジのID
+   */
+  removeParticipation: (participationId: string) => void;
 };
 
 /**
@@ -778,6 +839,8 @@ export const useGraphStore = create<GraphStore>()(
             chartMetas,
             persons: chart.persons,
             relationships: chart.relationships,
+            episodes: chart.episodes ?? [],
+            episodeParticipations: chart.episodeParticipations ?? [],
             forceEnabled: chart.forceEnabled,
             forceParams: chart.forceParams,
             egoLayoutParams: chart.egoLayoutParams,
@@ -897,6 +960,8 @@ export const useGraphStore = create<GraphStore>()(
             activeChartId: chart.id,
             persons: chart.persons,
             relationships: chart.relationships,
+            episodes: chart.episodes ?? [],
+            episodeParticipations: chart.episodeParticipations ?? [],
             forceEnabled: chart.forceEnabled,
             forceParams: chart.forceParams,
             egoLayoutParams: chart.egoLayoutParams,
@@ -907,6 +972,8 @@ export const useGraphStore = create<GraphStore>()(
             activeSnapshotIndex: null,
             _livePersons: null,
             _liveRelationships: null,
+            _liveEpisodes: null,
+            _liveEpisodeParticipations: null,
             pauseAutoSave: false,
             // 再生状態もリセット（前チャートの再生状態が残らないように）
             isPlaying: false,
@@ -1216,12 +1283,33 @@ export const useGraphStore = create<GraphStore>()(
             },
           }));
 
+          // SnapshotEpisode: エピソードの軽量表現
+          const snapshotEpisodes: SnapshotEpisode[] = state.episodes.map((e) => ({
+            episodeId: e.id,
+            title: e.title,
+            ...(e.description !== undefined ? { description: e.description } : {}),
+            ...(e.occurredAt !== undefined ? { occurredAt: e.occurredAt } : {}),
+            relatedRelationshipIds: [...e.relatedRelationshipIds],
+            position: e.position ? { ...e.position } : undefined,
+            properties: { ...e.properties },
+          }));
+
+          // SnapshotEpisodeParticipation: 参加エッジの軽量表現
+          const snapshotParticipations: SnapshotEpisodeParticipation[] = state.episodeParticipations.map((p) => ({
+            participationId: p.id,
+            episodeId: p.episodeId,
+            personId: p.personId,
+            ...(p.role !== undefined ? { role: p.role } : {}),
+          }));
+
           const snapshot: Snapshot = {
             id: nanoid(),
             label,
             ...(description !== undefined ? { description } : {}),
             persons: snapshotPersons,
             relationships: snapshotRelationships,
+            episodes: snapshotEpisodes,
+            episodeParticipations: snapshotParticipations,
             createdAt: new Date().toISOString(),
           };
 
@@ -1320,6 +1408,8 @@ export const useGraphStore = create<GraphStore>()(
               activeSnapshotIndex: null,
               _livePersons: state.persons,
               _liveRelationships: state.relationships,
+              _liveEpisodes: state.episodes,
+              _liveEpisodeParticipations: state.episodeParticipations,
             }));
           } else {
             // タイムラインモードを終了: ライブデータを復元してpauseAutoSave=false
@@ -1333,8 +1423,12 @@ export const useGraphStore = create<GraphStore>()(
               isPlaying: false,
               persons: s._livePersons ?? s.persons,
               relationships: s._liveRelationships ?? s.relationships,
+              episodes: s._liveEpisodes ?? s.episodes,
+              episodeParticipations: s._liveEpisodeParticipations ?? s.episodeParticipations,
               _livePersons: null,
               _liveRelationships: null,
+              _liveEpisodes: null,
+              _liveEpisodeParticipations: null,
             }));
           }
         },
@@ -1398,6 +1492,28 @@ export const useGraphStore = create<GraphStore>()(
             updatedAt: snapshot.createdAt,
           }));
 
+          // スナップショット時点のEpisodeを復元する
+          const restoredEpisodes: Episode[] = (snapshot.episodes ?? []).map((se) => ({
+            id: se.episodeId,
+            title: se.title,
+            description: se.description,
+            occurredAt: se.occurredAt,
+            relatedRelationshipIds: [...se.relatedRelationshipIds],
+            position: se.position ? { ...se.position } : undefined,
+            properties: { ...se.properties },
+            createdAt: snapshot.createdAt,
+            updatedAt: snapshot.createdAt,
+          }));
+
+          // スナップショット時点のEpisodeParticipationを復元する
+          const restoredParticipations: EpisodeParticipation[] = (snapshot.episodeParticipations ?? []).map((sep) => ({
+            id: sep.participationId,
+            episodeId: sep.episodeId,
+            personId: sep.personId,
+            role: sep.role,
+            createdAt: snapshot.createdAt,
+          }));
+
           // 直前のスナップショットインデックスを保存してdiffハイライト計算に使用する
           const previousIndex = state.activeSnapshotIndex;
           set(() => ({
@@ -1405,6 +1521,8 @@ export const useGraphStore = create<GraphStore>()(
             previousSnapshotIndex: previousIndex,
             persons: restoredPersons,
             relationships: restoredRelationships,
+            episodes: restoredEpisodes,
+            episodeParticipations: restoredParticipations,
           }));
         },
 
@@ -1418,6 +1536,80 @@ export const useGraphStore = create<GraphStore>()(
             previousSnapshotIndex: null,
             persons: s._livePersons ?? s.persons,
             relationships: s._liveRelationships ?? s.relationships,
+            episodes: s._liveEpisodes ?? s.episodes,
+            episodeParticipations: s._liveEpisodeParticipations ?? s.episodeParticipations,
+          }));
+        },
+
+        createEpisode: (input) => {
+          const id = nanoid();
+          const now = new Date().toISOString();
+          const episode: Episode = {
+            id,
+            title: input.title,
+            ...(input.description !== undefined ? { description: input.description } : {}),
+            ...(input.occurredAt !== undefined ? { occurredAt: input.occurredAt } : {}),
+            relatedRelationshipIds: input.relatedRelationshipIds ?? [],
+            position: input.position,
+            properties: {},
+            createdAt: now,
+            updatedAt: now,
+          };
+          set((s) => ({ episodes: [...s.episodes, episode] }));
+          return id;
+        },
+
+        updateEpisode: (id, patch) => {
+          const now = new Date().toISOString();
+          set((s) => ({
+            episodes: s.episodes.map((e) =>
+              e.id === id ? { ...e, ...patch, updatedAt: now } : e
+            ),
+          }));
+        },
+
+        deleteEpisode: (id) => {
+          set((s) => ({
+            episodes: s.episodes.filter((e) => e.id !== id),
+            // 紐づく参加エッジも連動削除
+            episodeParticipations: s.episodeParticipations.filter((p) => p.episodeId !== id),
+          }));
+        },
+
+        reorderEpisodes: (orderedIds) => {
+          set((s) => {
+            const episodeMap = new Map(s.episodes.map((e) => [e.id, e]));
+            const sortedEpisodes = orderedIds
+              .map((id) => episodeMap.get(id))
+              .filter((e): e is Episode => e !== undefined);
+            return { episodes: sortedEpisodes };
+          });
+        },
+
+        updateEpisodePosition: (id, position) => {
+          const now = new Date().toISOString();
+          set((s) => ({
+            episodes: s.episodes.map((e) =>
+              e.id === id ? { ...e, position, updatedAt: now } : e
+            ),
+          }));
+        },
+
+        addParticipation: ({ episodeId, personId }) => {
+          const id = nanoid();
+          const participation: EpisodeParticipation = {
+            id,
+            episodeId,
+            personId,
+            createdAt: new Date().toISOString(),
+          };
+          set((s) => ({ episodeParticipations: [...s.episodeParticipations, participation] }));
+          return id;
+        },
+
+        removeParticipation: (participationId) => {
+          set((s) => ({
+            episodeParticipations: s.episodeParticipations.filter((p) => p.id !== participationId),
           }));
         },
 

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -1,11 +1,12 @@
 /**
  * 相関図（Chart）の型定義
- * 複数の相関図を管理するためのデータモデル（v12 タイムラインスナップショット対応）
+ * 複数の相関図を管理するためのデータモデル（v13 エピソードノード対応）
  */
 
 import type { Person } from './person';
 import type { Relationship } from './relationship';
 import type { Snapshot } from './snapshot';
+import type { Episode, EpisodeParticipation } from './episode';
 import type { ForceParams } from '@/stores/useGraphStore';
 import type { EgoLayoutParams } from '@/lib/ego-layout';
 
@@ -15,6 +16,8 @@ import type { EgoLayoutParams } from '@/lib/ego-layout';
  * @property name - 相関図の名前（最大50文字）
  * @property persons - この相関図に含まれる人物のリスト
  * @property relationships - この相関図に含まれる関係のリスト
+ * @property episodes - この相関図に含まれるエピソードのリスト（v13以降）
+ * @property episodeParticipations - エピソード参加エッジのリスト（v13以降）
  * @property forceEnabled - force-directedレイアウトが有効かどうか
  * @property forceParams - force-directedレイアウトのパラメータ
  * @property egoLayoutParams - EGO Layoutのパラメータ
@@ -28,6 +31,10 @@ export type Chart = {
   name: string;
   persons: Person[];
   relationships: Relationship[];
+  /** エピソードノード一覧（v13以降、省略時は空配列として扱う） */
+  episodes?: Episode[];
+  /** エピソード参加エッジ一覧（v13以降、省略時は空配列として扱う） */
+  episodeParticipations?: EpisodeParticipation[];
   forceEnabled: boolean;
   forceParams: ForceParams;
   egoLayoutParams: EgoLayoutParams;

--- a/src/types/episode.ts
+++ b/src/types/episode.ts
@@ -1,0 +1,59 @@
+/**
+ * エピソード関連の型定義
+ *
+ * エピソードはプロパティグラフ上の第一級ノードとして扱う。
+ * Person ノードと並んでキャンバスに表示され、
+ * EpisodeParticipation エッジで参加者との関係を表現する。
+ *
+ * 設計方針:
+ * - Episode はノードとしてグラフに組み込み、キャンバス上で可視化する
+ * - Episode ↔ Person の参加関係は EpisodeParticipation エッジで表現する
+ * - Relationship（Edge）への紐づけはID参照に留め、エッジtoエッジを避ける
+ */
+
+/**
+ * エピソード
+ *
+ * 登場人物や関係にまつわる「時系列上の出来事」を表すグラフノード。
+ *
+ * @property id - 一意な識別子（nanoidで生成）
+ * @property title - 必須のタイトル（例: "初めての出会い"）
+ * @property description - 任意の複数行説明文
+ * @property occurredAt - 任意のユーザー指定日時（自由文字列。例: "第3話", "2024年春"）
+ * @property relatedRelationshipIds - 関連する関係のID参照配列（エッジtoエッジを避けプロパティとして保持）
+ * @property position - キャンバス上の座標（Personノードと同様）
+ * @property properties - 将来の拡張用カスタムプロパティ
+ * @property createdAt - 作成日時（ISO 8601形式）
+ * @property updatedAt - 最終更新日時（ISO 8601形式）
+ */
+export type Episode = {
+  id: string;
+  title: string;
+  description?: string;
+  occurredAt?: string;
+  relatedRelationshipIds: string[];
+  position?: { x: number; y: number };
+  properties: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * Episode ↔ Person の参加エッジ
+ *
+ * 「このエピソードにこの人物が関わる」を表すグラフエッジ。
+ * 向きを持たない軽量な注釈として扱い、キャンバスでは破線で可視化する。
+ *
+ * @property id - 一意な識別子（nanoidで生成）
+ * @property episodeId - 参加するエピソードのID
+ * @property personId - 参加する人物のID
+ * @property role - 将来拡張用のロール（例: "主人公", "言及"）。初版では未使用
+ * @property createdAt - 作成日時（ISO 8601形式）
+ */
+export type EpisodeParticipation = {
+  id: string;
+  episodeId: string;
+  personId: string;
+  role?: string;
+  createdAt: string;
+};

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -1,6 +1,6 @@
 /**
  * グラフ描画に関連する型定義
- * React Flowで使用するノードとエッジの型を定義（v11 プロパティグラフ方式）
+ * React Flowで使用するノードとエッジの型を定義（v13 エピソードノード対応）
  */
 
 import type { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
@@ -60,3 +60,50 @@ export type GraphNode = ReactFlowNode<PersonNodeData, 'graph'>;
  * React Flowで使用する関係エッジ型
  */
 export type RelationshipEdge = ReactFlowEdge<RelationshipEdgeData>;
+
+/**
+ * エピソードノードのデータ型
+ * EpisodeNodeComponentで使用される
+ *
+ * @property title - エピソードのタイトル
+ * @property description - 任意の説明文（複数行）
+ * @property occurredAt - 任意のユーザー指定日時（自由文字列）
+ * @property relatedRelationshipIds - 関連する関係のID参照配列
+ */
+export type EpisodeNodeData = {
+  title: string;
+  description?: string;
+  occurredAt?: string;
+  relatedRelationshipIds: string[];
+};
+
+/**
+ * React Flowで使用するエピソードノード型
+ */
+export type EpisodeNode = ReactFlowNode<EpisodeNodeData, 'episode'>;
+
+/**
+ * エピソード参加エッジのデータ型
+ * ParticipationEdgeコンポーネントで使用される
+ *
+ * @property role - 将来拡張用のロール（初版では未使用）
+ */
+export type ParticipationEdgeData = {
+  role?: string;
+};
+
+/**
+ * React Flowで使用するエピソード参加エッジ型
+ * EpisodeノードとPersonノードを破線で繋ぐ向きなしエッジ
+ */
+export type ParticipationEdge = ReactFlowEdge<ParticipationEdgeData>;
+
+/**
+ * グラフ上のノード全種別のユニオン型
+ */
+export type AnyGraphNode = GraphNode | EpisodeNode;
+
+/**
+ * グラフ上のエッジ全種別のユニオン型
+ */
+export type AnyGraphEdge = RelationshipEdge | ParticipationEdge;

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -57,6 +57,42 @@ export type SnapshotRelationship = {
 };
 
 /**
+ * スナップショット時点のエピソードの軽量表現
+ *
+ * @property episodeId - Episode.id への参照
+ * @property title - スナップショット時点のタイトル
+ * @property description - スナップショット時点の説明文
+ * @property occurredAt - スナップショット時点のユーザー指定日時
+ * @property relatedRelationshipIds - 関連関係のID参照配列
+ * @property position - スナップショット時点のキャンバス座標
+ * @property properties - カスタムプロパティ
+ */
+export type SnapshotEpisode = {
+  episodeId: string;
+  title: string;
+  description?: string;
+  occurredAt?: string;
+  relatedRelationshipIds: string[];
+  position?: { x: number; y: number };
+  properties: Record<string, unknown>;
+};
+
+/**
+ * スナップショット時点のエピソード参加エッジの軽量表現
+ *
+ * @property participationId - EpisodeParticipation.id への参照
+ * @property episodeId - 参加するエピソードのID
+ * @property personId - 参加する人物のID
+ * @property role - 将来拡張用のロール
+ */
+export type SnapshotEpisodeParticipation = {
+  participationId: string;
+  episodeId: string;
+  personId: string;
+  role?: string;
+};
+
+/**
  * タイムラインスナップショット
  *
  * ユーザーが保存したある時点のグラフ全体の状態を表す。
@@ -67,6 +103,8 @@ export type SnapshotRelationship = {
  * @property description - 任意の説明文
  * @property persons - スナップショット時点の人物リスト（imageDataUrl を除く軽量表現）
  * @property relationships - スナップショット時点の関係リスト
+ * @property episodes - スナップショット時点のエピソードリスト（v13以降）
+ * @property episodeParticipations - スナップショット時点の参加エッジリスト（v13以降）
  * @property createdAt - 保存日時（ISO 8601形式）
  */
 export type Snapshot = {
@@ -75,5 +113,9 @@ export type Snapshot = {
   description?: string;
   persons: SnapshotPerson[];
   relationships: SnapshotRelationship[];
+  /** エピソードリスト（v13以降、省略時は空配列として扱う） */
+  episodes?: SnapshotEpisode[];
+  /** エピソード参加エッジリスト（v13以降、省略時は空配列として扱う） */
+  episodeParticipations?: SnapshotEpisodeParticipation[];
   createdAt: string;
 };


### PR DESCRIPTION
## Summary

- **Episodeをプロパティグラフのノード**としてキャンバスに表示（付箋風amberカード）
- **EpisodeParticipation エッジ**（破線グレー）でEpisode↔Personを接続
- **EpisodeCaptureDialog**: タイトル・説明・発生日時・参加人物を入力（IMEガード対応）
- **EpisodeList** をサイドパネルに追加（dnd-kit並び替え・インライン編集・削除確認）
- **pane右クリック**から「エピソードをここに追加」導線
- スキーマ v12→v13 マイグレーション（既存データへの `episodes[]`/`episodeParticipations[]` 補填）
- Snapshot capture/restore にEpisode/Participation を統合

## Test plan

- [x] `npm run lint` — 警告ゼロ
- [x] `npm run type-check` — 型エラーゼロ
- [x] `npm test` — 1209テスト通過（EpisodeNode・ParticipationEdge・store CRUD・migration・graph-utils・EpisodeCaptureDialog・EpisodeList）

## Manual verification checklist

- [ ] サイドパネル「+ エピソードを追加」→ダイアログ→保存→キャンバスにEpisodeNode出現
- [ ] Episodeと人物の間に破線エッジが描画される
- [ ] EpisodeNodeをドラッグして位置が保存される
- [ ] pane右クリック→「エピソードをここに追加」でダイアログが開く
- [ ] EpisodeList でタイトルインライン編集・削除確認が動作する
- [ ] Snapshot保存→ライブ編集→Snapshot復元でEpisodeが保持される
- [ ] v12のLocalStorageデータを読み込むとepisodesが補填される

Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)