### PR TITLE
feat: EpisodeノードをAIチャット抽出対象に統合する（Phase A）

### DIFF
--- a/src/app/api/extract-relationships/route.test.ts
+++ b/src/app/api/extract-relationships/route.test.ts
@@ -47,6 +47,7 @@ const validExtractionResult = {
       properties: { closeness: 0.8, affection: 0.9, awareness: 'known' },
     },
   ],
+  episodes: [],
 };
 
 function makeRequest(body: unknown): Request {
@@ -138,7 +139,7 @@ describe('POST /api/extract-relationships', () => {
   });
 
   it('existingPersonNames が指定された場合はプロンプトに含まれること', async () => {
-    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [] } } as GenerateObjectResult);
+    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [], episodes: [] } } as GenerateObjectResult);
 
     const req = makeRequest({
       ...baseRequestBody,
@@ -155,5 +156,40 @@ describe('POST /api/extract-relationships', () => {
     const prompt = (callArgs as { prompt?: string }).prompt ?? '';
     expect(prompt).toContain('田中太郎');
     expect(prompt).toContain('山田花子');
+  });
+
+  it('プロンプトにエピソード抽出指示が含まれること', async () => {
+    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [], episodes: [] } } as GenerateObjectResult);
+
+    const req = makeRequest(baseRequestBody);
+    await POST(req);
+
+    const callArgs = mockGenerateObject.mock.calls[0][0] as { prompt?: string };
+    const prompt = callArgs.prompt ?? '';
+    // episodes 抽出の指示が含まれていること
+    expect(prompt).toContain('episodes');
+  });
+
+  it('existingEpisodeTitles が指定された場合はプロンプトに含まれること', async () => {
+    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [], episodes: [] } } as GenerateObjectResult);
+
+    const req = makeRequest({
+      ...baseRequestBody,
+      existingEpisodeTitles: ['初めての出会い', '卒業式の告白'],
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+
+    const callArgs = mockGenerateObject.mock.calls[0][0] as { prompt?: string };
+    const prompt = callArgs.prompt ?? '';
+    expect(prompt).toContain('初めての出会い');
+    expect(prompt).toContain('卒業式の告白');
+  });
+
+  it('existingEpisodeTitles が配列でない場合は 400 を返すこと', async () => {
+    const req = makeRequest({ ...baseRequestBody, existingEpisodeTitles: '無効な値' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/extract-relationships/route.ts
+++ b/src/app/api/extract-relationships/route.ts
@@ -35,12 +35,17 @@ const MAX_TEXT_LENGTH = 10000;
 /** existingPersonNames の最大件数（プロンプト長制限のため） */
 const MAX_EXISTING_PERSON_NAMES = 200;
 
+/** existingEpisodeTitles の最大件数 */
+const MAX_EXISTING_EPISODE_TITLES = 200;
+
 /** リクエストボディのバリデーションスキーマ */
 const RequestBodySchema = z.object({
   /** 関係を抽出するテキスト（1〜10000文字） */
   text: z.string().min(1).max(MAX_TEXT_LENGTH),
   /** 既存の人物名リスト（LLM に渡してマッチングを促す。最大 200 件） */
   existingPersonNames: z.array(z.string()).max(MAX_EXISTING_PERSON_NAMES),
+  /** 既存のエピソードタイトルリスト（重複探索抑制のためプロンプトに注入する） */
+  existingEpisodeTitles: z.array(z.string()).max(MAX_EXISTING_EPISODE_TITLES).optional().default([]),
   /** OpenRouter APIキー（クライアントの設定から渡す） */
   apiKey: z.string().min(1),
   /** 使用するモデル（OpenRouter モデル ID 形式: "provider/model-name"） */
@@ -64,20 +69,30 @@ function sanitizePersonName(name: string): string {
  * LLM に渡すプロンプトを構築する
  * @param text - ユーザーが入力したテキスト
  * @param existingPersonNames - 既存の人物名リスト（サニタイズ済み）
+ * @param existingEpisodeTitles - 既存のエピソードタイトルリスト（サニタイズ済み）
  */
-function buildPrompt(text: string, existingPersonNames: string[]): string {
+function buildPrompt(text: string, existingPersonNames: string[], existingEpisodeTitles: string[]): string {
   const sanitizedNames = existingPersonNames
     .map(sanitizePersonName)
     .filter((n) => n.length > 0);
+
+  const sanitizedEpisodeTitles = existingEpisodeTitles
+    .map(sanitizePersonName)
+    .filter((t) => t.length > 0);
 
   const existingNamesSection =
     sanitizedNames.length > 0
       ? `\n\n## 既存の人物（相関図に登録済み）\n以下の人物はすでに相関図に登録されています。テキスト中にこれらの人物が登場する場合は、必ず同じ名前を使用してください：\n${sanitizedNames.map((n) => `- ${n}`).join('\n')}`
       : '';
 
+  const existingEpisodesSection =
+    sanitizedEpisodeTitles.length > 0
+      ? `\n\n## 既存のエピソード（相関図に登録済み）\n以下のエピソードはすでに相関図に登録されています。重複するエピソードは追加しないでください：\n${sanitizedEpisodeTitles.map((t) => `- ${t}`).join('\n')}`
+      : '';
+
   return `あなたはテキストから人物（またはアイテム）間の関係を抽出するアシスタントです。
 
-与えられたテキストを分析し、登場する人物・物とそれらの間の関係を構造化されたJSONとして出力してください。${existingNamesSection}
+与えられたテキストを分析し、登場する人物・物とそれらの間の関係、および複数人物が関与する出来事（エピソード）を構造化されたJSONとして出力してください。${existingNamesSection}${existingEpisodesSection}
 
 ## 注意事項
 - テキストに明示的に記述されている関係のみを抽出してください。推測や補完は行わないでください。
@@ -88,7 +103,10 @@ function buildPrompt(text: string, existingPersonNames: string[]): string {
 - label は type より具体的な表現が必要な場合のみ設定してください（1〜3語の短いラベル。人物名は含めない）。例: type="親子" の場合に label="実の親子" のように限定したいとき。type と同じ内容になる場合は null を設定してください。
 - tags には関係を端的に表すラベルを含めてください（例: "親友", "ライバル", "上司部下"）。
 - symmetric は、関係が対称・無向の場合（例: 友人、同僚、家族）に true にしてください。片想い・上司→部下など非対称・有向の関係では false にしてください。
-- turningPoints は配列で返してください。ない場合は空配列 [] にしてください。
+- turningPoints は常に空配列 [] を設定してください（出来事は episodes に抽出してください）。
+- episodes には、テキスト中で複数人物が関与する「出来事・場面・イベント」を抽出してください（例: "初めての出会い", "卒業式", "決戦"）。出来事がない場合は空配列 [] にしてください。
+- episodes の participantNames は、その出来事に関わった人物の名前配列で、必ず persons に列挙した人物名と一致させてください。
+- episodes.occurredAt は発生時点の自由文字列（"第3話", "2024年春", "2020-04-01" など）。テキストに記述がない場合は null にしてください。
 
 ## 解析対象テキスト
 ${text}`;
@@ -116,12 +134,12 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const { text, existingPersonNames, apiKey, model } = parsed.data;
+  const { text, existingPersonNames, existingEpisodeTitles, apiKey, model } = parsed.data;
 
   try {
     // OpenRouter プロバイダを初期化（クライアントから受け取った APIキーを使用）
     const openrouter = createOpenRouter({ apiKey });
-    const prompt = buildPrompt(text, existingPersonNames);
+    const prompt = buildPrompt(text, existingPersonNames, existingEpisodeTitles);
 
     // zod v4 は generateObject に直接渡せないため、
     // JSON Schema に変換してから jsonSchema ヘルパーで包む

--- a/src/app/api/extract-relationships/route.ts
+++ b/src/app/api/extract-relationships/route.ts
@@ -35,17 +35,27 @@ const MAX_TEXT_LENGTH = 10000;
 /** existingPersonNames の最大件数（プロンプト長制限のため） */
 const MAX_EXISTING_PERSON_NAMES = 200;
 
+/** existingPersonNames の各要素の最大文字数（プロンプト肥大化防止のため） */
+const MAX_EXISTING_PERSON_NAME_LENGTH = 200;
+
 /** existingEpisodeTitles の最大件数 */
 const MAX_EXISTING_EPISODE_TITLES = 200;
+
+/** existingEpisodeTitles の各要素の最大文字数（プロンプト肥大化防止のため） */
+const MAX_EXISTING_EPISODE_TITLE_LENGTH = 200;
 
 /** リクエストボディのバリデーションスキーマ */
 const RequestBodySchema = z.object({
   /** 関係を抽出するテキスト（1〜10000文字） */
   text: z.string().min(1).max(MAX_TEXT_LENGTH),
   /** 既存の人物名リスト（LLM に渡してマッチングを促す。最大 200 件） */
-  existingPersonNames: z.array(z.string()).max(MAX_EXISTING_PERSON_NAMES),
+  existingPersonNames: z.array(z.string().max(MAX_EXISTING_PERSON_NAME_LENGTH)).max(MAX_EXISTING_PERSON_NAMES),
   /** 既存のエピソードタイトルリスト（重複探索抑制のためプロンプトに注入する） */
-  existingEpisodeTitles: z.array(z.string()).max(MAX_EXISTING_EPISODE_TITLES).optional().default([]),
+  existingEpisodeTitles: z
+    .array(z.string().max(MAX_EXISTING_EPISODE_TITLE_LENGTH))
+    .max(MAX_EXISTING_EPISODE_TITLES)
+    .optional()
+    .default([]),
   /** OpenRouter APIキー（クライアントの設定から渡す） */
   apiKey: z.string().min(1),
   /** 使用するモデル（OpenRouter モデル ID 形式: "provider/model-name"） */
@@ -66,6 +76,20 @@ function sanitizePersonName(name: string): string {
 }
 
 /**
+ * エピソードタイトルをサニタイズする
+ *
+ * 人物名とは異なり、日付（2024-04-01）やスラッシュを含むタイトルを変形しないよう
+ * 改行・制御文字のみ除去し、それ以外の記号はそのまま保持する。
+ * @param title - サニタイズ対象のエピソードタイトル
+ */
+function sanitizeEpisodeTitle(title: string): string {
+  return title
+    .replace(/[\r\n\t]/g, ' ') // 改行・タブを空白に
+    .replace(/\p{C}/gu, '') // Unicode 制御文字を除去
+    .trim();
+}
+
+/**
  * LLM に渡すプロンプトを構築する
  * @param text - ユーザーが入力したテキスト
  * @param existingPersonNames - 既存の人物名リスト（サニタイズ済み）
@@ -77,7 +101,7 @@ function buildPrompt(text: string, existingPersonNames: string[], existingEpisod
     .filter((n) => n.length > 0);
 
   const sanitizedEpisodeTitles = existingEpisodeTitles
-    .map(sanitizePersonName)
+    .map(sanitizeEpisodeTitle)
     .filter((t) => t.length > 0);
 
   const existingNamesSection =

--- a/src/app/api/interview-chat/route.test.ts
+++ b/src/app/api/interview-chat/route.test.ts
@@ -139,4 +139,22 @@ describe('POST /api/interview-chat', () => {
     expect(callArgs.system).toContain('田中太郎と佐藤花子は親友');
     expect(callArgs.system).toContain('佐藤花子と鈴木一郎は同僚');
   });
+
+  it('既存エピソードタイトルがシステムプロンプトに含まれること', async () => {
+    const req = makeRequest({
+      ...baseRequestBody,
+      existingEpisodeTitles: ['田中と佐藤の初対面', '部活の合宿での出来事'],
+    });
+    await POST(req);
+
+    const callArgs = mockStreamText.mock.calls[0][0] as { system?: string };
+    expect(callArgs.system).toContain('田中と佐藤の初対面');
+    expect(callArgs.system).toContain('部活の合宿での出来事');
+  });
+
+  it('existingEpisodeTitles が配列でない場合は 400 を返すこと', async () => {
+    const req = makeRequest({ ...baseRequestBody, existingEpisodeTitles: '無効な値' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
 });

--- a/src/app/api/interview-chat/route.ts
+++ b/src/app/api/interview-chat/route.ts
@@ -37,10 +37,13 @@ const MAX_EXISTING_PERSON_NAMES = 200;
 /** existingRelationshipSummaries の最大件数 */
 const MAX_EXISTING_RELATIONSHIP_SUMMARIES = 200;
 
+/** existingEpisodeTitles の最大件数 */
+const MAX_EXISTING_EPISODE_TITLES = 200;
+
 /** メッセージ本文の最大文字数 */
 const MAX_CONTENT_LENGTH = 10000;
 
-/** 人物名・関係サマリの要素ごとの最大文字数 */
+/** 人物名・関係サマリ・エピソードタイトルの要素ごとの最大文字数 */
 const MAX_NAME_LENGTH = 200;
 
 /** チャットメッセージのスキーマ */
@@ -57,6 +60,8 @@ const RequestBodySchema = z.object({
   existingPersonNames: z.array(z.string().max(MAX_NAME_LENGTH)).max(MAX_EXISTING_PERSON_NAMES),
   /** 既存の関係サマリリスト（システムプロンプトに注入する） */
   existingRelationshipSummaries: z.array(z.string().max(MAX_NAME_LENGTH)).max(MAX_EXISTING_RELATIONSHIP_SUMMARIES),
+  /** 既存のエピソードタイトルリスト（重複探索抑制のためシステムプロンプトに注入する） */
+  existingEpisodeTitles: z.array(z.string().max(MAX_NAME_LENGTH)).max(MAX_EXISTING_EPISODE_TITLES).optional().default([]),
   /** OpenRouter APIキー（クライアントの設定から渡す） */
   apiKey: z.string().min(1),
   /** 使用するモデル（OpenRouter モデル ID 形式） */
@@ -88,7 +93,7 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  const { messages, existingPersonNames, existingRelationshipSummaries, apiKey, model } = parsed.data;
+  const { messages, existingPersonNames, existingRelationshipSummaries, existingEpisodeTitles, apiKey, model } = parsed.data;
 
   try {
     // OpenRouter プロバイダを初期化（クライアントから受け取った APIキーを使用）
@@ -98,6 +103,7 @@ export async function POST(request: Request): Promise<Response> {
     const systemPrompt = buildInterviewSystemPrompt(
       existingPersonNames,
       existingRelationshipSummaries,
+      existingEpisodeTitles,
     );
 
     const result = streamText({

--- a/src/app/api/interview-extract/route.test.ts
+++ b/src/app/api/interview-extract/route.test.ts
@@ -49,6 +49,7 @@ const validExtractionResult = {
       properties: { closeness: 0.7, affection: 0.8, awareness: 'known' },
     },
   ],
+  episodes: [],
 };
 
 function makeRequest(body: unknown): Request {
@@ -136,7 +137,7 @@ describe('POST /api/interview-extract', () => {
   });
 
   it('generateObject に渡されるプロンプトにチャット履歴が含まれること', async () => {
-    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [] } } as GenerateObjectResult);
+    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [], episodes: [] } } as GenerateObjectResult);
 
     const req = makeRequest(baseRequestBody);
     await POST(req);
@@ -145,5 +146,39 @@ describe('POST /api/interview-extract', () => {
     const prompt = callArgs.prompt ?? '';
     // チャット履歴のテキストが含まれていること
     expect(prompt).toContain('太宰治と芥川龍之介が登場します');
+  });
+
+  it('プロンプトにエピソード抽出指示が含まれること', async () => {
+    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [], episodes: [] } } as GenerateObjectResult);
+
+    const req = makeRequest(baseRequestBody);
+    await POST(req);
+
+    const callArgs = mockGenerateObject.mock.calls[0][0] as { prompt?: string };
+    const prompt = callArgs.prompt ?? '';
+    expect(prompt).toContain('episodes');
+  });
+
+  it('existingEpisodeTitles が指定された場合はプロンプトに含まれること', async () => {
+    mockGenerateObject.mockResolvedValueOnce({ object: { persons: [], relationships: [], episodes: [] } } as GenerateObjectResult);
+
+    const req = makeRequest({
+      ...baseRequestBody,
+      existingEpisodeTitles: ['太宰と芥川の初対面', '文学サロンでの再会'],
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+
+    const callArgs = mockGenerateObject.mock.calls[0][0] as { prompt?: string };
+    const prompt = callArgs.prompt ?? '';
+    expect(prompt).toContain('太宰と芥川の初対面');
+    expect(prompt).toContain('文学サロンでの再会');
+  });
+
+  it('existingEpisodeTitles が配列でない場合は 400 を返すこと', async () => {
+    const req = makeRequest({ ...baseRequestBody, existingEpisodeTitles: '無効な値' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/interview-extract/route.ts
+++ b/src/app/api/interview-extract/route.ts
@@ -83,6 +83,21 @@ function sanitizePersonName(name: string): string {
 }
 
 /**
+ * エピソードタイトルをサニタイズする
+ *
+ * 人物名とは異なり、日付（2024-04-01）やスラッシュを含むタイトルを変形しないよう
+ * 改行・制御文字のみ除去し、それ以外の記号はそのまま保持する。
+ * @param title - サニタイズ対象のエピソードタイトル
+ * @returns サニタイズ後のエピソードタイトル
+ */
+function sanitizeEpisodeTitle(title: string): string {
+  return title
+    .replace(/[\r\n\t]/g, ' ') // 改行・タブを空白に
+    .replace(/\p{C}/gu, '') // Unicode 制御文字を除去
+    .trim();
+}
+
+/**
  * チャット履歴と既存人物名から LLM に渡すプロンプトを構築する
  *
  * @param chatHistory - インタビューのチャット履歴
@@ -100,7 +115,7 @@ function buildPrompt(
     .filter((n) => n.length > 0);
 
   const sanitizedEpisodeTitles = existingEpisodeTitles
-    .map(sanitizePersonName)
+    .map(sanitizeEpisodeTitle)
     .filter((t) => t.length > 0);
 
   const existingNamesSection =

--- a/src/app/api/interview-extract/route.ts
+++ b/src/app/api/interview-extract/route.ts
@@ -36,10 +36,13 @@ const MAX_CHAT_HISTORY = 200;
 /** existingPersonNames の最大件数 */
 const MAX_EXISTING_PERSON_NAMES = 200;
 
+/** existingEpisodeTitles の最大件数 */
+const MAX_EXISTING_EPISODE_TITLES = 200;
+
 /** メッセージ本文の最大文字数 */
 const MAX_MESSAGE_LENGTH = 10000;
 
-/** 人物名要素ごとの最大文字数 */
+/** 人物名・エピソードタイトル要素ごとの最大文字数 */
 const MAX_PERSON_NAME_LENGTH = 200;
 
 /** generateObject のタイムアウト（ミリ秒） */
@@ -57,6 +60,8 @@ const RequestBodySchema = z.object({
   chatHistory: z.array(ChatMessageSchema).min(1).max(MAX_CHAT_HISTORY),
   /** 既存の人物名リスト（重複登録防止のためにプロンプトに渡す） */
   existingPersonNames: z.array(z.string().max(MAX_PERSON_NAME_LENGTH)).max(MAX_EXISTING_PERSON_NAMES),
+  /** 既存のエピソードタイトルリスト（重複探索抑制のためプロンプトに渡す） */
+  existingEpisodeTitles: z.array(z.string().max(MAX_PERSON_NAME_LENGTH)).max(MAX_EXISTING_EPISODE_TITLES).optional().default([]),
   /** OpenRouter APIキー */
   apiKey: z.string().min(1),
   /** 使用するモデル（OpenRouter モデル ID 形式） */
@@ -82,19 +87,30 @@ function sanitizePersonName(name: string): string {
  *
  * @param chatHistory - インタビューのチャット履歴
  * @param existingPersonNames - 既存の人物名リスト（サニタイズ前）
+ * @param existingEpisodeTitles - 既存のエピソードタイトルリスト（サニタイズ前）
  * @returns プロンプト文字列
  */
 function buildPrompt(
   chatHistory: Array<{ role: 'user' | 'assistant'; content: string }>,
   existingPersonNames: string[],
+  existingEpisodeTitles: string[],
 ): string {
   const sanitizedNames = existingPersonNames
     .map(sanitizePersonName)
     .filter((n) => n.length > 0);
 
+  const sanitizedEpisodeTitles = existingEpisodeTitles
+    .map(sanitizePersonName)
+    .filter((t) => t.length > 0);
+
   const existingNamesSection =
     sanitizedNames.length > 0
       ? `\n\n## 既存の人物（相関図に登録済み）\n以下の人物はすでに相関図に登録されています。インタビュー記録にこれらの人物が登場する場合は、必ず同じ名前を使用してください：\n${sanitizedNames.map((n) => `- ${n}`).join('\n')}`
+      : '';
+
+  const existingEpisodesSection =
+    sanitizedEpisodeTitles.length > 0
+      ? `\n\n## 既存のエピソード（相関図に登録済み）\n以下のエピソードはすでに相関図に登録されています。重複するエピソードは追加しないでください：\n${sanitizedEpisodeTitles.map((t) => `- ${t}`).join('\n')}`
       : '';
 
   // チャット履歴を読みやすい形式に変換
@@ -107,7 +123,7 @@ function buildPrompt(
 
   return `あなたはテキストから人物（またはアイテム）間の関係を抽出するアシスタントです。
 
-以下はインタビューの記録です。この会話から登場する人物・物とそれらの間の関係を構造化されたJSONとして抽出してください。${existingNamesSection}
+以下はインタビューの記録です。この会話から登場する人物・物とそれらの間の関係、および複数人物が関与する出来事（エピソード）を構造化されたJSONとして抽出してください。${existingNamesSection}${existingEpisodesSection}
 
 ## 注意事項
 - インタビュー記録に明示的に記述されている情報のみを抽出してください。推測や補完は行わないでください。
@@ -118,7 +134,10 @@ function buildPrompt(
 - label は type より具体的な表現が必要な場合のみ設定してください（1〜3語の短いラベル）。type と同じ内容になる場合は null を設定してください。
 - tags には関係を端的に表すラベルを含めてください（例: "親友", "ライバル", "上司部下"）。
 - symmetric は、関係が対称・無向の場合（例: 友人、同僚、家族）に true にしてください。
-- turningPoints は配列で返してください。ない場合は空配列 [] にしてください。
+- turningPoints は常に空配列 [] を設定してください（出来事は episodes に抽出してください）。
+- episodes には、インタビュー中でユーザーが語った複数人物が関与する「出来事・場面・イベント」を抽出してください（例: "初めての出会い", "卒業式", "告白"）。出来事がない場合は空配列 [] にしてください。
+- episodes の participantNames は、その出来事に関わった人物の名前配列で、必ず persons に列挙した人物名と一致させてください。
+- episodes.occurredAt は発生時点の自由文字列（"第3話", "2024年春", "2020-04-01" など）。不明な場合は null にしてください。
 
 ## インタビューの記録
 ${historyText}`;
@@ -149,11 +168,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const { chatHistory, existingPersonNames, apiKey, model } = parsed.data;
+  const { chatHistory, existingPersonNames, existingEpisodeTitles, apiKey, model } = parsed.data;
 
   try {
     const openrouter = createOpenRouter({ apiKey });
-    const prompt = buildPrompt(chatHistory, existingPersonNames);
+    const prompt = buildPrompt(chatHistory, existingPersonNames, existingEpisodeTitles);
 
     const rawSchema = getLlmExtractionJsonSchema();
     const schema = jsonSchema<ReturnType<typeof LlmExtractionResultSchema.parse>>(rawSchema, {

--- a/src/components/graph/ChatInputBar.test.tsx
+++ b/src/components/graph/ChatInputBar.test.tsx
@@ -25,12 +25,16 @@ vi.mock('@/hooks/useExtractRelationships', () => ({
 // useGraphStore をモック
 const mockAddPerson = vi.fn();
 const mockAddRelationship = vi.fn();
+const mockCreateEpisode = vi.fn(() => 'episode-new-id');
+const mockAddParticipation = vi.fn();
 
 function getMockStore() {
   return {
     persons: [] as { id: string; name: string; createdAt: string }[],
     addPerson: mockAddPerson,
     addRelationship: mockAddRelationship,
+    createEpisode: mockCreateEpisode,
+    addParticipation: mockAddParticipation,
   };
 }
 
@@ -133,6 +137,7 @@ describe('ChatInputBar', () => {
             properties: {},
           },
         ],
+        episodes: [],
       },
       reset: mockReset,
     });
@@ -148,7 +153,7 @@ describe('ChatInputBar', () => {
       extract: mockExtract,
       isLoading: false,
       error: null,
-      extractionResult: { persons: [], relationships: [] },
+      extractionResult: { persons: [], relationships: [], episodes: [] },
       reset: mockReset,
     });
 
@@ -179,6 +184,7 @@ describe('ChatInputBar', () => {
             properties: {},
           },
         ],
+        episodes: [],
       },
       reset: mockReset,
     });
@@ -189,6 +195,58 @@ describe('ChatInputBar', () => {
     await waitFor(() => {
       expect(mockAddPerson).toHaveBeenCalled();
       expect(mockAddRelationship).toHaveBeenCalled();
+      expect(mockReset).toHaveBeenCalled();
+    });
+  });
+
+  it('抽出結果にエピソードがある場合 createEpisode と addParticipation が呼ばれること', async () => {
+    // persons を空にして、エピソード参加者の解決が正常に動作するかをテスト
+    // 参加者名 '田中太郎'・'山田花子' が persons に存在する状態でエピソードを解決する
+    const mockGetState = vi.fn().mockReturnValue({
+      persons: [
+        { id: 'p1', name: '田中太郎', createdAt: '2024-01-01T00:00:00.000Z' },
+        { id: 'p2', name: '山田花子', createdAt: '2024-01-01T00:00:00.000Z' },
+      ],
+      addPerson: mockAddPerson,
+      addRelationship: mockAddRelationship,
+      createEpisode: mockCreateEpisode,
+      addParticipation: mockAddParticipation,
+    });
+    const { useGraphStore } = await import('@/stores/useGraphStore');
+    vi.mocked(useGraphStore).getState = mockGetState;
+
+    mockUseExtractRelationships.mockReturnValue({
+      extract: mockExtract,
+      isLoading: false,
+      error: null,
+      extractionResult: {
+        persons: [
+          { name: '田中太郎', labels: ['人物'] },
+          { name: '山田花子', labels: ['人物'] },
+        ],
+        relationships: [],
+        episodes: [
+          {
+            title: '初めての出会い',
+            description: null,
+            occurredAt: null,
+            participantNames: ['田中太郎', '山田花子'],
+          },
+        ],
+      },
+      reset: mockReset,
+    });
+
+    render(<ChatInputBar />);
+    fireEvent.click(screen.getByRole('button', { name: /追加/ }));
+
+    await waitFor(() => {
+      // エピソード作成が呼ばれること
+      expect(mockCreateEpisode).toHaveBeenCalledWith(
+        expect.objectContaining({ title: '初めての出会い' })
+      );
+      // 参加エッジが追加されること（2人分）
+      expect(mockAddParticipation).toHaveBeenCalledTimes(2);
       expect(mockReset).toHaveBeenCalled();
     });
   });

--- a/src/components/graph/ChatInputBar.tsx
+++ b/src/components/graph/ChatInputBar.tsx
@@ -102,6 +102,8 @@ export function ChatInputBar() {
   const persons = useGraphStore((s) => s.persons);
   const addPerson = useGraphStore((s) => s.addPerson);
   const addRelationship = useGraphStore((s) => s.addRelationship);
+  const createEpisode = useGraphStore((s) => s.createEpisode);
+  const addParticipation = useGraphStore((s) => s.addParticipation);
 
   /**
    * ハイライト計算用: 人物を名前の長さ降順にソートしてキャッシュする
@@ -347,9 +349,10 @@ export function ChatInputBar() {
   /**
    * 「相関図に追加」ボタンを押したときの処理
    *
-   * 2 パスで人物と関係をストアに追加する（ExtractionModal と同じロジック）:
+   * 3 パスで人物・関係・エピソードをストアに追加する:
    *   1. resolveExtractionResult で新規人物を特定し addPerson で追加
-   *   2. 追加後のストア状態で再度 resolveExtractionResult を呼び出し関係を解決
+   *   2. 追加後のストア状態で関係とエピソードを解決
+   *   3. エピソードを createEpisode で追加し、参加エッジを addParticipation で追加
    */
   const handleConfirm = useCallback(() => {
     if (!extractionResult) return;
@@ -360,18 +363,30 @@ export function ChatInputBar() {
       addPerson({ name: person.name, labels: person.labels, properties: {} });
     }
 
-    // 2 パス目: 追加後のストア状態で関係を解決
+    // 2 パス目: 追加後のストア状態で関係とエピソードを解決
     const currentPersons = useGraphStore.getState().persons;
-    const { relationships } = resolveExtractionResult(extractionResult, currentPersons, new Map());
+    const { relationships, episodes } = resolveExtractionResult(extractionResult, currentPersons, new Map());
     for (const rel of relationships) {
       addRelationship(rel);
+    }
+
+    // 3 パス目: エピソード作成＋参加エッジ追加
+    for (const ep of episodes) {
+      const episodeId = createEpisode({
+        title: ep.title,
+        description: ep.description,
+        occurredAt: ep.occurredAt,
+      });
+      for (const personId of ep.participantPersonIds) {
+        addParticipation({ episodeId, personId });
+      }
     }
 
     // 入力とプレビューをリセット
     setText('');
     reset();
     setTimeout(() => adjustHeight(), 0);
-  }, [extractionResult, persons, addPerson, addRelationship, reset, adjustHeight]);
+  }, [extractionResult, persons, addPerson, addRelationship, createEpisode, addParticipation, reset, adjustHeight]);
 
   /**
    * キャンセルボタンを押したときの処理

--- a/src/components/graph/EpisodePreviewSection.test.tsx
+++ b/src/components/graph/EpisodePreviewSection.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * EpisodePreviewSection コンポーネントのテスト
+ *
+ * エピソードプレビューセクションのUI表示を検証する。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EpisodePreviewSection } from './EpisodePreviewSection';
+import type { LlmEpisode } from '@/lib/llm-extraction-schema';
+
+describe('EpisodePreviewSection', () => {
+  it('エピソードが空のとき「なし」と表示されること', () => {
+    render(<EpisodePreviewSection episodes={[]} />);
+    expect(screen.getByText(/なし/)).toBeInTheDocument();
+    expect(screen.getByText(/エピソード.*0.*件/)).toBeInTheDocument();
+  });
+
+  it('エピソードタイトルが表示されること', () => {
+    const episodes: LlmEpisode[] = [
+      { title: '初めての出会い', description: null, occurredAt: null, participantNames: ['田中太郎', '山田花子'] },
+    ];
+    render(<EpisodePreviewSection episodes={episodes} />);
+    expect(screen.getByText('初めての出会い')).toBeInTheDocument();
+  });
+
+  it('occurredAt が表示されること', () => {
+    const episodes: LlmEpisode[] = [
+      { title: '卒業式', description: null, occurredAt: '2023年春', participantNames: ['田中太郎'] },
+    ];
+    render(<EpisodePreviewSection episodes={episodes} />);
+    expect(screen.getByText('2023年春')).toBeInTheDocument();
+  });
+
+  it('参加者名が表示されること', () => {
+    const episodes: LlmEpisode[] = [
+      { title: '告白', description: null, occurredAt: null, participantNames: ['田中太郎', '山田花子'] },
+    ];
+    render(<EpisodePreviewSection episodes={episodes} />);
+    expect(screen.getByText(/田中太郎/)).toBeInTheDocument();
+    expect(screen.getByText(/山田花子/)).toBeInTheDocument();
+  });
+
+  it('複数エピソードの件数が表示されること', () => {
+    const episodes: LlmEpisode[] = [
+      { title: 'A', description: null, occurredAt: null, participantNames: [] },
+      { title: 'B', description: null, occurredAt: null, participantNames: [] },
+      { title: 'C', description: null, occurredAt: null, participantNames: [] },
+    ];
+    render(<EpisodePreviewSection episodes={episodes} />);
+    expect(screen.getByText(/エピソード.*3.*件/)).toBeInTheDocument();
+  });
+});

--- a/src/components/graph/EpisodePreviewSection.tsx
+++ b/src/components/graph/EpisodePreviewSection.tsx
@@ -1,0 +1,49 @@
+/**
+ * エピソードプレビューセクションコンポーネント
+ *
+ * LLM 抽出結果のエピソード一覧を表示する共通コンポーネント。
+ * ExtractionPreviewPanel と InterviewModal のプレビューから参照する。
+ */
+
+import { CalendarClock } from 'lucide-react';
+import type { LlmEpisode } from '@/lib/llm-extraction-schema';
+
+type Props = {
+  /** 表示するエピソード一覧 */
+  episodes: LlmEpisode[];
+};
+
+/**
+ * エピソード一覧をプレビュー表示するセクション
+ */
+export function EpisodePreviewSection({ episodes }: Props) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <CalendarClock size={14} className="text-amber-600" aria-hidden />
+        <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
+          エピソード ({episodes.length} 件)
+        </span>
+      </div>
+      {episodes.length === 0 ? (
+        <p className="text-sm text-gray-400 ml-5">なし</p>
+      ) : (
+        <ul className="space-y-1">
+          {episodes.map((ep, i) => (
+            <li key={i} className="text-sm text-gray-700 ml-1">
+              <div className="font-medium">{ep.title}</div>
+              {ep.occurredAt && (
+                <div className="text-xs text-gray-400">{ep.occurredAt}</div>
+              )}
+              {ep.participantNames.length > 0 && (
+                <div className="text-xs text-amber-600">
+                  参加者: {ep.participantNames.join(', ')}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/graph/ExtractionPreviewPanel.tsx
+++ b/src/components/graph/ExtractionPreviewPanel.tsx
@@ -13,6 +13,7 @@
 
 import { Users, Link } from 'lucide-react';
 import type { LlmExtractionResult } from '@/lib/llm-extraction-schema';
+import { EpisodePreviewSection } from './EpisodePreviewSection';
 
 /**
  * ExtractionPreviewPanel の Props
@@ -115,6 +116,8 @@ export function ExtractionPreviewPanel({
             </ul>
           )}
         </div>
+        {/* エピソードセクション */}
+        <EpisodePreviewSection episodes={result.episodes} />
       </div>
 
       {/* アクションボタン */}

--- a/src/components/interview/InterviewModal.test.tsx
+++ b/src/components/interview/InterviewModal.test.tsx
@@ -9,6 +9,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { InterviewModal } from './InterviewModal';
 import { useInterviewStore } from '@/stores/useInterviewStore';
+import type { ExtractionResolutionResult } from '@/lib/person-matching';
 
 // useInterviewChat をモック
 vi.mock('@/hooks/useInterviewChat', () => ({
@@ -24,11 +25,34 @@ vi.mock('@/hooks/useInterviewChat', () => ({
 }));
 
 // useGraphStore をモック
-vi.mock('@/stores/useGraphStore', () => ({
-  useGraphStore: vi.fn((selector: (s: { persons: unknown[] }) => unknown) => {
-    return selector({ persons: [] });
-  }),
-}));
+const mockAddPerson = vi.fn();
+const mockAddRelationship = vi.fn();
+const mockCreateEpisode = vi.fn(() => 'episode-new-id');
+const mockAddParticipation = vi.fn();
+
+function getMockGraphStore() {
+  return {
+    persons: [] as { id: string; name: string; createdAt: string }[],
+    addPerson: mockAddPerson,
+    addRelationship: mockAddRelationship,
+    createEpisode: mockCreateEpisode,
+    addParticipation: mockAddParticipation,
+    activeChartId: 'chart-001',
+  };
+}
+
+vi.mock('@/stores/useGraphStore', () => {
+  const mockUseGraphStore = vi.fn(
+    (selector: (s: ReturnType<typeof getMockGraphStore>) => unknown) => {
+      return selector(getMockGraphStore());
+    }
+  );
+  Object.defineProperty(mockUseGraphStore, 'getState', {
+    value: () => getMockGraphStore(),
+    writable: true,
+  });
+  return { useGraphStore: mockUseGraphStore };
+});
 
 // useAiSettingsStore をモック
 vi.mock('@/stores/useAiSettingsStore', () => ({
@@ -38,8 +62,13 @@ vi.mock('@/stores/useAiSettingsStore', () => ({
 }));
 
 // person-matching をモック
+const mockResolveExtractionResult = vi.fn((): ExtractionResolutionResult => ({
+  newPersons: [],
+  relationships: [],
+  episodes: [],
+}));
 vi.mock('@/lib/person-matching', () => ({
-  resolveExtractionResult: vi.fn(() => ({ newPersons: [], relationships: [] })),
+  resolveExtractionResult: () => mockResolveExtractionResult(),
 }));
 
 /** ストア状態をリセットするヘルパー */
@@ -113,5 +142,40 @@ describe('InterviewModal', () => {
     useInterviewStore.setState({ isModalOpen: true, session: null });
     render(<InterviewModal />);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('プレビューで「相関図に反映」をクリックするとエピソードが追加されること', async () => {
+    // エピソードを含む抽出結果をセット
+    mockResolveExtractionResult.mockReturnValue({
+      newPersons: [],
+      relationships: [],
+      episodes: [
+        {
+          title: '卒業式での再会',
+          description: '久しぶりの再会を果たした',
+          occurredAt: '2023年春',
+          participantPersonIds: ['p1', 'p2'],
+        },
+      ],
+    });
+
+    useInterviewStore.setState({ isModalOpen: true });
+    useInterviewStore.getState().startSession('chart-001');
+    useInterviewStore.getState().setExtractionResult({
+      persons: [],
+      relationships: [],
+      episodes: [],
+    });
+    useInterviewStore.getState().setSessionStatus('preview');
+
+    render(<InterviewModal />);
+    fireEvent.click(screen.getByRole('button', { name: /相関図に追加/ }));
+
+    // エピソード作成が呼ばれること
+    expect(mockCreateEpisode).toHaveBeenCalledWith(
+      expect.objectContaining({ title: '卒業式での再会' })
+    );
+    // 参加エッジが2人分追加されること
+    expect(mockAddParticipation).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/interview/InterviewModal.tsx
+++ b/src/components/interview/InterviewModal.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useCallback, useRef } from 'react';
 import { Loader2, Users, Link } from 'lucide-react';
+import { EpisodePreviewSection } from '@/components/graph/EpisodePreviewSection';
 import { useShallow } from 'zustand/react/shallow';
 import { useInterviewStore } from '@/stores/useInterviewStore';
 import { useInterviewChat } from '@/hooks/useInterviewChat';
@@ -112,6 +113,9 @@ function InterviewExtractionPreview({
             </ul>
           )}
         </div>
+
+        {/* エピソードセクション */}
+        <EpisodePreviewSection episodes={result.episodes} />
       </div>
 
       {/* アクションボタン */}
@@ -164,10 +168,12 @@ export function InterviewModal() {
   );
 
   const { messages, append, setMessages, isLoading, endSession, abort } = useInterviewChat();
-  const { addPerson, addRelationship, persons, activeChartId } = useGraphStore(
+  const { addPerson, addRelationship, createEpisode, addParticipation, persons, activeChartId } = useGraphStore(
     useShallow((s) => ({
       addPerson: s.addPerson,
       addRelationship: s.addRelationship,
+      createEpisode: s.createEpisode,
+      addParticipation: s.addParticipation,
       persons: s.persons,
       activeChartId: s.activeChartId,
     }))
@@ -266,6 +272,11 @@ export function InterviewModal() {
 
   /**
    * 抽出結果を相関図に反映する
+   *
+   * 3 パスで人物・関係・エピソードをストアに追加する:
+   *   1. resolveExtractionResult で新規人物を特定し addPerson で追加
+   *   2. 追加後のストア状態で関係とエピソードを解決
+   *   3. エピソードを createEpisode で追加し、参加エッジを addParticipation で追加
    */
   const handleConfirm = useCallback(() => {
     if (!extractionResult) return;
@@ -274,17 +285,29 @@ export function InterviewModal() {
     const { newPersons } = resolveExtractionResult(extractionResult, persons, new Map());
     newPersons.forEach((person) => addPerson({ name: person.name, labels: person.labels, properties: {} }));
 
-    // 2パス目: 人物追加後のストア状態で関係を解決
+    // 2パス目: 人物追加後のストア状態で関係とエピソードを解決
     const updatedPersons = useGraphStore.getState().persons;
-    const { relationships: resolvedRelationships } = resolveExtractionResult(
+    const { relationships: resolvedRelationships, episodes } = resolveExtractionResult(
       extractionResult,
       updatedPersons,
       new Map(),
     );
     resolvedRelationships.forEach((rel) => addRelationship(rel));
 
+    // 3パス目: エピソード作成＋参加エッジ追加
+    for (const ep of episodes) {
+      const episodeId = createEpisode({
+        title: ep.title,
+        description: ep.description,
+        occurredAt: ep.occurredAt,
+      });
+      for (const personId of ep.participantPersonIds) {
+        addParticipation({ episodeId, personId });
+      }
+    }
+
     setSessionStatus('completed');
-  }, [extractionResult, persons, addPerson, addRelationship, setSessionStatus]);
+  }, [extractionResult, persons, addPerson, addRelationship, createEpisode, addParticipation, setSessionStatus]);
 
   /**
    * 抽出結果をキャンセルしてインタビューに戻る

--- a/src/hooks/useExtractRelationships.test.ts
+++ b/src/hooks/useExtractRelationships.test.ts
@@ -7,11 +7,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useExtractRelationships } from './useExtractRelationships';
 
-// useGraphStore をモック（既存人物名の取得のため）
+// useGraphStore をモック（既存人物名・エピソードタイトルの取得のため）
 const mockPersons = [{ id: 'p1', name: '田中太郎', createdAt: '2024-01-01T00:00:00.000Z' }];
+const mockEpisodes = [{ id: 'e1', title: '初めての出会い', relatedRelationshipIds: [], properties: {}, createdAt: '2024-01-01T00:00:00.000Z', updatedAt: '2024-01-01T00:00:00.000Z' }];
 vi.mock('@/stores/useGraphStore', () => ({
-  useGraphStore: vi.fn((selector: (s: { persons: typeof mockPersons }) => unknown) => {
-    const store = { persons: mockPersons };
+  useGraphStore: vi.fn((selector: (s: { persons: typeof mockPersons; episodes: typeof mockEpisodes }) => unknown) => {
+    const store = { persons: mockPersons, episodes: mockEpisodes };
     return selector ? selector(store) : store;
   }),
 }));
@@ -34,6 +35,7 @@ vi.mock('@/stores/useAiSettingsStore', () => ({
 const validResult = {
   persons: [{ name: '田中太郎', labels: ['人物'] }],
   relationships: [],
+  episodes: [],
 };
 
 describe('useExtractRelationships', () => {
@@ -191,5 +193,25 @@ describe('useExtractRelationships', () => {
     expect(body.existingPersonNames).toContain('田中太郎');
     expect(body.apiKey).toBe('sk-or-test-key');
     expect(body.model).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it('既存エピソードタイトルがリクエストに含まれること', async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(validResult), { status: 200 }))
+    );
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useExtractRelationships());
+
+    await act(async () => {
+      await result.current.extract('テスト');
+    });
+
+    // fetch の第2引数（RequestInit）から body を取り出して検証
+    const calls = mockFetch.mock.calls as unknown as [string, RequestInit][];
+    const requestInit = calls[0][1];
+    const body = JSON.parse(requestInit.body as string);
+    // mockEpisodes に含まれる '初めての出会い' がリクエストに含まれていること
+    expect(body.existingEpisodeTitles).toContain('初めての出会い');
   });
 });

--- a/src/hooks/useExtractRelationships.ts
+++ b/src/hooks/useExtractRelationships.ts
@@ -46,6 +46,7 @@ export function useExtractRelationships(): UseExtractRelationshipsReturn {
   const [extractionResult, setExtractionResult] = useState<LlmExtractionResult | null>(null);
 
   const persons = useGraphStore((s) => s.persons);
+  const episodes = useGraphStore((s) => s.episodes);
   const openRouterApiKey = useAiSettingsStore((s) => s.openRouterApiKey);
   const openRouterModel = useAiSettingsStore((s) => s.openRouterModel);
   const isConfigured = useAiSettingsStore((s) => s.isConfigured);
@@ -65,6 +66,7 @@ export function useExtractRelationships(): UseExtractRelationshipsReturn {
       setExtractionResult(null);
 
       const existingPersonNames = persons.map((p) => p.name);
+      const existingEpisodeTitles = episodes.map((e) => e.title);
 
       try {
         const response = await fetch('/api/extract-relationships', {
@@ -73,6 +75,7 @@ export function useExtractRelationships(): UseExtractRelationshipsReturn {
           body: JSON.stringify({
             text,
             existingPersonNames,
+            existingEpisodeTitles,
             apiKey: openRouterApiKey,
             model: openRouterModel,
           }),
@@ -101,7 +104,7 @@ export function useExtractRelationships(): UseExtractRelationshipsReturn {
         setIsLoading(false);
       }
     },
-    [persons, openRouterApiKey, openRouterModel, isConfigured]
+    [persons, episodes, openRouterApiKey, openRouterModel, isConfigured]
   );
 
   const reset = useCallback(() => {

--- a/src/hooks/useInterviewChat.test.ts
+++ b/src/hooks/useInterviewChat.test.ts
@@ -26,9 +26,12 @@ vi.mock('@/stores/useAiSettingsStore', () => ({
 }));
 
 // useGraphStore をモック
+const mockEpisodes = [
+  { id: 'ep1', title: '部活での初対面', relatedRelationshipIds: [], properties: {}, createdAt: '2024-01-01T00:00:00.000Z', updatedAt: '2024-01-01T00:00:00.000Z' },
+];
 vi.mock('@/stores/useGraphStore', () => ({
-  useGraphStore: vi.fn((selector: (s: { persons: unknown[]; relationships: unknown[] }) => unknown) => {
-    const store = { persons: [], relationships: [] };
+  useGraphStore: vi.fn((selector: (s: { persons: unknown[]; relationships: unknown[]; episodes: typeof mockEpisodes }) => unknown) => {
+    const store = { persons: [], relationships: [], episodes: mockEpisodes };
     return selector ? selector(store) : store;
   }),
 }));
@@ -108,7 +111,7 @@ describe('useInterviewChat', () => {
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: vi.fn().mockResolvedValueOnce({ persons: [], relationships: [] }),
+      json: vi.fn().mockResolvedValueOnce({ persons: [], relationships: [], episodes: [] }),
     }));
 
     const { result } = renderHook(() => useInterviewChat());
@@ -146,6 +149,45 @@ describe('useInterviewChat', () => {
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('append で既存エピソードタイトルがリクエストに含まれること', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(
+      createStreamResponse('テスト応答')
+    ));
+
+    const { result } = renderHook(() => useInterviewChat());
+
+    await act(async () => {
+      await result.current.append({ role: 'user', content: 'テスト' });
+    });
+
+    const fetchMock = vi.mocked(global.fetch);
+    const calls = fetchMock.mock.calls as unknown as [string, RequestInit][];
+    const body = JSON.parse(calls[0][1].body as string);
+    // mockEpisodes に含まれる '部活での初対面' が interview-chat リクエストに含まれていること
+    expect(body.existingEpisodeTitles).toContain('部活での初対面');
+  });
+
+  it('endSession で既存エピソードタイトルが抽出APIリクエストに含まれること', async () => {
+    useInterviewStore.getState().startSession('chart-001');
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({ persons: [], relationships: [], episodes: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useInterviewChat());
+
+    await act(async () => {
+      await result.current.endSession();
+    });
+
+    const calls = fetchMock.mock.calls as unknown as [string, RequestInit][];
+    const body = JSON.parse(calls[0][1].body as string);
+    // mockEpisodes に含まれる '部活での初対面' が interview-extract リクエストに含まれていること
+    expect(body.existingEpisodeTitles).toContain('部活での初対面');
   });
 
   it('endSession で抽出API失敗時にエラーがセットされること', async () => {

--- a/src/hooks/useInterviewChat.ts
+++ b/src/hooks/useInterviewChat.ts
@@ -85,21 +85,22 @@ export function useInterviewChat() {
     }))
   );
 
-  // persons と relationships を一つのセレクタで取得してサブスクリプションを減らす
-  const { persons, relationships } = useGraphStore(
-    useShallow((s) => ({ persons: s.persons, relationships: s.relationships }))
+  // persons・relationships・episodes を一つのセレクタで取得してサブスクリプションを減らす
+  const { persons, relationships, episodes } = useGraphStore(
+    useShallow((s) => ({ persons: s.persons, relationships: s.relationships, episodes: s.episodes }))
   );
 
-  // 既存人物名・関係サマリを persons/relationships が変化したときのみ再計算する
-  const { existingPersonNames, existingRelationshipSummaries } = useMemo(() => {
+  // 既存人物名・関係サマリ・エピソードタイトルを persons/relationships/episodes が変化したときのみ再計算する
+  const { existingPersonNames, existingRelationshipSummaries, existingEpisodeTitles } = useMemo(() => {
     const personNames = new Map(persons.map((p) => [p.id, p.name]));
     return {
       existingPersonNames: persons.map((p) => p.name),
       existingRelationshipSummaries: relationships.map((rel) =>
         buildRelationshipSummary(rel, personNames)
       ),
+      existingEpisodeTitles: episodes.map((e) => e.title),
     };
-  }, [persons, relationships]);
+  }, [persons, relationships, episodes]);
 
   /**
    * 進行中のストリーミング fetch を中断する
@@ -160,6 +161,7 @@ export function useInterviewChat() {
             messages: updatedMessages.map((m) => ({ role: m.role, content: m.content })),
             existingPersonNames,
             existingRelationshipSummaries,
+            existingEpisodeTitles,
             apiKey: openRouterApiKey,
             model: openRouterModel,
           }),
@@ -235,6 +237,7 @@ export function useInterviewChat() {
       isConfigured,
       existingPersonNames,
       existingRelationshipSummaries,
+      existingEpisodeTitles,
       openRouterApiKey,
       openRouterModel,
       setError,
@@ -275,6 +278,7 @@ export function useInterviewChat() {
         body: JSON.stringify({
           chatHistory,
           existingPersonNames,
+          existingEpisodeTitles,
           apiKey: openRouterApiKey,
           model: openRouterModel,
         }),
@@ -312,6 +316,7 @@ export function useInterviewChat() {
     openRouterApiKey,
     openRouterModel,
     existingPersonNames,
+    existingEpisodeTitles,
     setSessionStatus,
     setExtractionResult,
     setError,

--- a/src/lib/interview-prompt.test.ts
+++ b/src/lib/interview-prompt.test.ts
@@ -51,6 +51,34 @@ describe('buildInterviewSystemPrompt', () => {
     expect(prompt.length).toBeGreaterThan(0);
   });
 
+  it('既存エピソードタイトルを含む場合にコンテキストとして注入される', () => {
+    const prompt = buildInterviewSystemPrompt([], [], ['初めての出会い', '卒業式の告白']);
+    expect(prompt).toContain('初めての出会い');
+    expect(prompt).toContain('卒業式の告白');
+  });
+
+  it('既存エピソードが空の場合はエピソードセクションを挿入しない', () => {
+    const promptWithEpisodes = buildInterviewSystemPrompt([], [], ['エピソードA']);
+    const promptWithoutEpisodes = buildInterviewSystemPrompt([], [], []);
+    // エピソードあり → セクション有り
+    expect(promptWithEpisodes).toContain('エピソードA');
+    // エピソードなし → エピソードセクション無し
+    expect(promptWithoutEpisodes).not.toContain('登録済みのエピソード');
+  });
+
+  it('エピソードタイトルにMarkdown特殊記号が含まれていてもサニタイズされる', () => {
+    const prompt = buildInterviewSystemPrompt([], [], ['重要な出来事 # 秘密']);
+    expect(prompt).not.toContain('重要な出来事 # 秘密');
+    // # が除去されサニタイズされた形で含まれること
+    expect(prompt).toContain('重要な出来事  秘密');
+  });
+
+  it('第3引数を省略した場合でも正常に生成される（後方互換性）', () => {
+    const prompt = buildInterviewSystemPrompt(['田中太郎'], ['田中太郎と山田花子は友人']);
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
   it('人物名にMarkdown特殊記号が含まれていてもサニタイズされる', () => {
     const prompt = buildInterviewSystemPrompt(['田中 # 太郎'], []);
     // 人物名から #（Markdown特殊記号）が除去され、サニタイズ後の名前が含まれること

--- a/src/lib/interview-prompt.ts
+++ b/src/lib/interview-prompt.ts
@@ -14,6 +14,7 @@
 /** プロンプトインジェクション対策のための最大件数 */
 const MAX_EXISTING_NAMES = 200;
 const MAX_EXISTING_RELATIONSHIPS = 200;
+const MAX_EXISTING_EPISODES = 200;
 
 /**
  * プロンプトインジェクション対策のため人物名をサニタイズする
@@ -33,11 +34,13 @@ function sanitizeName(name: string): string {
  *
  * @param existingPersonNames - 既に相関図に登録されている人物名リスト
  * @param existingRelationshipSummaries - 既に登録されている関係のサマリリスト（例: "AさんとBさんは友人"）
+ * @param existingEpisodeTitles - 既に登録されているエピソードのタイトルリスト（重複探索抑制のため）
  * @returns システムプロンプト文字列
  */
 export function buildInterviewSystemPrompt(
   existingPersonNames: string[],
   existingRelationshipSummaries: string[],
+  existingEpisodeTitles: string[] = [],
 ): string {
   const sanitizedNames = existingPersonNames
     .slice(0, MAX_EXISTING_NAMES)
@@ -49,10 +52,15 @@ export function buildInterviewSystemPrompt(
     .map(sanitizeName)
     .filter((s) => s.length > 0);
 
+  const sanitizedEpisodeTitles = existingEpisodeTitles
+    .slice(0, MAX_EXISTING_EPISODES)
+    .map(sanitizeName)
+    .filter((t) => t.length > 0);
+
   // 既存データのコンテキストセクション
   const existingDataSection =
-    sanitizedNames.length > 0 || sanitizedRelationships.length > 0
-      ? buildExistingDataSection(sanitizedNames, sanitizedRelationships)
+    sanitizedNames.length > 0 || sanitizedRelationships.length > 0 || sanitizedEpisodeTitles.length > 0
+      ? buildExistingDataSection(sanitizedNames, sanitizedRelationships, sanitizedEpisodeTitles)
       : '';
 
   return `あなたは人物相関図を作成するためのインタビュアーです。
@@ -73,7 +81,8 @@ export function buildInterviewSystemPrompt(
 1. **登場人物の列挙**: まず「この物語・出来事・組織などに登場する人物や物をすべて教えてください」と聞く
 2. **個々の属性の深掘り**: 各登場人物について「どのような人ですか？」「どのような役割を持っていますか？」などを聞く
 3. **人物間の関係の探索**: 「〇〇さんと△△さんはどのような関係ですか？」「どのくらい仲が良いですか？」「信頼関係はありますか？」「何か秘密にしていることはありますか？」などを聞く
-4. **確認・補足**: 「他に付け加えることはありますか？」「見落としている関係はありますか？」と聞く
+3.5. **重要な出来事の探索**: 「この人物たちに関わった印象的な出来事や場面はありますか？」「転機となった瞬間を覚えていますか？」「複数の人が関わったエピソードがあれば教えてください」と聞く
+4. **確認・補足**: 「他に付け加えることはありますか？」「見落としている関係や出来事はありますか？」と聞く
 
 ## 質問のコツ
 
@@ -104,9 +113,10 @@ export function buildInterviewSystemPrompt(
  *
  * @param names - サニタイズ済みの既存人物名リスト
  * @param relationships - サニタイズ済みの既存関係サマリリスト
+ * @param episodeTitles - サニタイズ済みの既存エピソードタイトルリスト
  * @returns コンテキストセクション文字列
  */
-function buildExistingDataSection(names: string[], relationships: string[]): string {
+function buildExistingDataSection(names: string[], relationships: string[], episodeTitles: string[]): string {
   let section = '\n\n## 相関図に登録済みの情報\n\n以下の情報はすでに相関図に登録されています。これらを踏まえて、新しい情報や関係を中心に聞き取りを行ってください。';
 
   if (names.length > 0) {
@@ -115,6 +125,10 @@ function buildExistingDataSection(names: string[], relationships: string[]): str
 
   if (relationships.length > 0) {
     section += `\n\n### 登録済みの関係\n${relationships.map((r) => `- ${r}`).join('\n')}`;
+  }
+
+  if (episodeTitles.length > 0) {
+    section += `\n\n### 登録済みのエピソード\n${episodeTitles.map((t) => `- ${t}`).join('\n')}`;
   }
 
   return section;

--- a/src/lib/llm-extraction-schema.test.ts
+++ b/src/lib/llm-extraction-schema.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   LlmPersonSchema,
   LlmRelationshipSchema,
+  LlmEpisodeSchema,
   LlmExtractionResultSchema,
   getLlmExtractionJsonSchema,
   type LlmExtractionResult,
@@ -149,8 +150,75 @@ describe('LlmRelationshipSchema', () => {
   });
 });
 
+describe('LlmEpisodeSchema', () => {
+  it('有効なエピソードデータをパースできること', () => {
+    const valid = {
+      title: '初めての出会い',
+      description: '田中と山田が部活で初めて出会った。',
+      occurredAt: '高校1年の春',
+      participantNames: ['田中太郎', '山田花子'],
+    };
+    const result = LlmEpisodeSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('description が null でも有効であること', () => {
+    const valid = {
+      title: '卒業式',
+      description: null,
+      occurredAt: '2024年3月',
+      participantNames: ['田中太郎'],
+    };
+    const result = LlmEpisodeSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('occurredAt が null でも有効であること', () => {
+    const valid = {
+      title: '初めての喧嘩',
+      description: '些細なことで口論になった。',
+      occurredAt: null,
+      participantNames: ['田中太郎', '山田花子'],
+    };
+    const result = LlmEpisodeSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('participantNames が空配列でも有効であること', () => {
+    const valid = {
+      title: '謎の事件',
+      description: null,
+      occurredAt: null,
+      participantNames: [],
+    };
+    const result = LlmEpisodeSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('title が欠けている場合はパース失敗すること', () => {
+    const invalid = {
+      description: '説明文',
+      occurredAt: null,
+      participantNames: ['田中太郎'],
+    };
+    const result = LlmEpisodeSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it('participantNames が配列でない場合はパース失敗すること', () => {
+    const invalid = {
+      title: 'エピソード',
+      description: null,
+      occurredAt: null,
+      participantNames: '田中太郎',
+    };
+    const result = LlmEpisodeSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('LlmExtractionResultSchema', () => {
-  it('有効な抽出結果をパースできること', () => {
+  it('有効な抽出結果（episodes含む）をパースできること', () => {
     const valid: LlmExtractionResult = {
       persons: [
         { name: '田中太郎', labels: ['人物'] },
@@ -168,15 +236,29 @@ describe('LlmExtractionResultSchema', () => {
           properties: { affection: 0.9, awareness: 'known', role: null },
         },
       ],
+      episodes: [
+        {
+          title: '初めての出会い',
+          description: '部活で出会った。',
+          occurredAt: '高校1年の春',
+          participantNames: ['田中太郎', '山田花子'],
+        },
+      ],
     };
     const result = LlmExtractionResultSchema.safeParse(valid);
     expect(result.success).toBe(true);
   });
 
-  it('persons・relationships が空配列でも有効であること', () => {
-    const valid = { persons: [], relationships: [] };
+  it('persons・relationships・episodes が空配列でも有効であること', () => {
+    const valid = { persons: [], relationships: [], episodes: [] };
     const result = LlmExtractionResultSchema.safeParse(valid);
     expect(result.success).toBe(true);
+  });
+
+  it('episodes が欠けている場合はパース失敗すること', () => {
+    const invalid = { persons: [], relationships: [] };
+    const result = LlmExtractionResultSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
   });
 });
 
@@ -194,7 +276,7 @@ describe('getLlmExtractionJsonSchema', () => {
     expect(schema).toHaveProperty('properties');
   });
 
-  it('persons と relationships プロパティが含まれること', () => {
+  it('persons と relationships と episodes プロパティが含まれること', () => {
     const schema = getLlmExtractionJsonSchema();
     // ランタイム型ガードで properties の存在を確認してからアクセス
     expect(schema !== null && typeof schema === 'object' && 'properties' in schema).toBe(true);
@@ -203,6 +285,29 @@ describe('getLlmExtractionJsonSchema', () => {
     const propsObj = props as Record<string, unknown>;
     expect(propsObj).toHaveProperty('persons');
     expect(propsObj).toHaveProperty('relationships');
+    expect(propsObj).toHaveProperty('episodes');
+  });
+
+  it('episodes が required 配列に含まれること（strict mode 対応）', () => {
+    const schema = getLlmExtractionJsonSchema() as Record<string, unknown>;
+    expect(Array.isArray(schema.required)).toBe(true);
+    expect((schema.required as string[]).includes('episodes')).toBe(true);
+  });
+
+  it('episodes.items に title / participantNames / description / occurredAt が required として含まれること', () => {
+    type JsonSchemaObj = Record<string, unknown>;
+    const schema = getLlmExtractionJsonSchema() as JsonSchemaObj;
+    const schemaProps = schema.properties as JsonSchemaObj;
+    const episodesSchema = schemaProps.episodes as JsonSchemaObj;
+    const episodeItems = episodesSchema.items as JsonSchemaObj;
+
+    expect(Array.isArray(episodeItems.required)).toBe(true);
+    const required = episodeItems.required as string[];
+    expect(required).toContain('title');
+    expect(required).toContain('participantNames');
+    expect(required).toContain('description');
+    expect(required).toContain('occurredAt');
+    expect(episodeItems.additionalProperties).toBe(false);
   });
 
   it('生成されたスキーマが JSON シリアライズ可能であること', () => {

--- a/src/lib/llm-extraction-schema.ts
+++ b/src/lib/llm-extraction-schema.ts
@@ -95,6 +95,31 @@ export const LlmRelationshipSchema = z.object({
 });
 
 /**
+ * LLM が出力するエピソードスキーマ
+ *
+ * Episode は人物相関図上の「出来事・場面・イベント」を表す第一級ノード。
+ * 複数人物が関与する独立した出来事を抽出する用途で使用する。
+ * （関係の当事者2人に閉じた時系列イベントは Relationship.narrative.turningPoints ではなく、
+ *   今後はすべてエピソードとして抽出する）
+ */
+export const LlmEpisodeSchema = z.object({
+  /** 出来事の短いタイトル（例: "初めての出会い", "卒業式の告白"） */
+  title: z.string().describe('出来事の短いタイトル（例: "初めての出会い", "卒業式"）'),
+  /** エピソードの詳細説明（1〜数文）。情報がない場合は null */
+  description: z.string().nullable(),
+  /**
+   * 発生時点の自由記述（"第3話", "2024年春", "2020-04-01" 等）。
+   * テキストに記述がない場合は null
+   */
+  occurredAt: z.string().nullable().describe('発生時点の自由記述（"第3話", "2024年春" など）。不明なら null'),
+  /**
+   * このエピソードに参加した人物名の配列。
+   * persons 配列に列挙した人物名と完全一致させること
+   */
+  participantNames: z.array(z.string()).describe('参加した人物名。persons 配列と一致させる'),
+});
+
+/**
  * LLM が出力する抽出結果全体のスキーマ
  */
 export const LlmExtractionResultSchema = z.object({
@@ -102,6 +127,11 @@ export const LlmExtractionResultSchema = z.object({
   persons: z.array(LlmPersonSchema),
   /** テキストから抽出された関係のリスト */
   relationships: z.array(LlmRelationshipSchema),
+  /**
+   * テキストから抽出されたエピソード（出来事・場面・イベント）のリスト。
+   * 複数人物が関与する独立した出来事を抽出する。ない場合は空配列 []
+   */
+  episodes: z.array(LlmEpisodeSchema),
 });
 
 /** LlmExtractionResult の TypeScript 型（zod スキーマから導出） */
@@ -112,6 +142,9 @@ export type LlmPerson = z.infer<typeof LlmPersonSchema>;
 
 /** LlmRelationship の TypeScript 型 */
 export type LlmRelationship = z.infer<typeof LlmRelationshipSchema>;
+
+/** LlmEpisode の TypeScript 型 */
+export type LlmEpisode = z.infer<typeof LlmEpisodeSchema>;
 
 /**
  * JSON Schema を OpenAI/Azure strict mode 準拠に再帰変換する

--- a/src/lib/person-matching.test.ts
+++ b/src/lib/person-matching.test.ts
@@ -226,6 +226,45 @@ describe('resolveExtractionResult', () => {
       expect(result.episodes).toHaveLength(0);
     });
 
+    it('participantNames に重複がある場合 participantPersonIds が重複排除されること', () => {
+      const resultWithDuplicates: LlmExtractionResult = {
+        // 田中太郎・山田花子は existingPersons に存在するため LLM の persons に含めなくてもよい
+        persons: [{ name: '田中太郎', labels: ['人物'] }, { name: '山田花子', labels: ['人物'] }],
+        relationships: [],
+        episodes: [
+          {
+            title: '重複参加者テスト',
+            description: null,
+            occurredAt: null,
+            // 田中太郎が2回登場（LLMが重複出力した想定）
+            participantNames: ['田中太郎', '田中太郎', '山田花子'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithDuplicates, existingPersons, new Map());
+      expect(result.episodes).toHaveLength(1);
+      // 重複排除後は person-001（田中太郎）・person-002（山田花子）の2件のみ
+      expect(result.episodes[0].participantPersonIds).toHaveLength(2);
+    });
+
+    it('title が前後の空白を持つ場合 trim されること', () => {
+      const resultWithPaddedTitle: LlmExtractionResult = {
+        persons: [{ name: '田中太郎', labels: ['人物'] }],
+        relationships: [],
+        episodes: [
+          {
+            title: '  初めての出会い  ',
+            description: null,
+            occurredAt: null,
+            participantNames: ['田中太郎'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithPaddedTitle, existingPersons, new Map());
+      expect(result.episodes).toHaveLength(1);
+      expect(result.episodes[0].title).toBe('初めての出会い');
+    });
+
     it('description と occurredAt が null の Episode が正しく解決されること', () => {
       const resultWithNulls: LlmExtractionResult = {
         persons: [{ name: '山田花子', labels: ['人物'] }],

--- a/src/lib/person-matching.test.ts
+++ b/src/lib/person-matching.test.ts
@@ -79,6 +79,7 @@ describe('resolveExtractionResult', () => {
         properties: { closeness: 0.5, awareness: 'known', role: '上司' },
       },
     ],
+    episodes: [],
   };
 
   it('既存人物はマッチさせ、新規人物は新規追加リストに含めること', () => {
@@ -127,8 +128,122 @@ describe('resolveExtractionResult', () => {
           properties: {},
         },
       ],
+      episodes: [],
     };
     const result = resolveExtractionResult(badResult, existingPersons, new Map());
     expect(result.relationships).toHaveLength(0);
+  });
+
+  describe('episodes 解決', () => {
+    it('episodes が空の場合は空配列を返すこと', () => {
+      const result = resolveExtractionResult(extractionResult, existingPersons, new Map());
+      expect(result.episodes).toEqual([]);
+    });
+
+    it('既存人物と新規人物の参加者が両方正しく解決されること', () => {
+      // 田中太郎（既存）と新キャラ（新規）が参加するエピソード
+      const resultWithEpisode: LlmExtractionResult = {
+        persons: [
+          { name: '田中太郎', labels: ['人物'] },
+          { name: '新キャラ', labels: ['人物'] },
+        ],
+        relationships: [],
+        episodes: [
+          {
+            title: '初めての出会い',
+            description: '部活で出会った。',
+            occurredAt: '高校1年の春',
+            participantNames: ['田中太郎', '新キャラ'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithEpisode, existingPersons, new Map());
+      expect(result.episodes).toHaveLength(1);
+      const ep = result.episodes[0];
+      expect(ep.title).toBe('初めての出会い');
+      expect(ep.description).toBe('部活で出会った。');
+      expect(ep.occurredAt).toBe('高校1年の春');
+      // 田中太郎は既存なので person-001
+      expect(ep.participantPersonIds).toContain('person-001');
+      // 新キャラは新規追加されるのでnewPersonsにIDがある
+      const newCharId = result.newPersons.find((p) => p.name === '新キャラ')?.id;
+      expect(ep.participantPersonIds).toContain(newCharId);
+    });
+
+    it('解決できない参加者は除外され、Episode 自体は保持されること', () => {
+      const resultWithUnknownParticipant: LlmExtractionResult = {
+        persons: [{ name: '田中太郎', labels: ['人物'] }],
+        relationships: [],
+        episodes: [
+          {
+            title: '謎の事件',
+            description: null,
+            occurredAt: null,
+            participantNames: ['田中太郎', '存在しない人'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithUnknownParticipant, existingPersons, new Map());
+      // Episode は保持される
+      expect(result.episodes).toHaveLength(1);
+      const ep = result.episodes[0];
+      // 解決できた田中太郎のみ参加者として含まれる
+      expect(ep.participantPersonIds).toContain('person-001');
+      expect(ep.participantPersonIds).toHaveLength(1);
+    });
+
+    it('全参加者が解決できない場合は Episode をスキップすること', () => {
+      const resultWithAllUnknown: LlmExtractionResult = {
+        persons: [],
+        relationships: [],
+        episodes: [
+          {
+            title: '参加者不明のエピソード',
+            description: null,
+            occurredAt: null,
+            participantNames: ['存在しない人A', '存在しない人B'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithAllUnknown, existingPersons, new Map());
+      expect(result.episodes).toHaveLength(0);
+    });
+
+    it('title が空文字の Episode はスキップされること', () => {
+      const resultWithEmptyTitle: LlmExtractionResult = {
+        persons: [{ name: '田中太郎', labels: ['人物'] }],
+        relationships: [],
+        episodes: [
+          {
+            title: '',
+            description: null,
+            occurredAt: null,
+            participantNames: ['田中太郎'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithEmptyTitle, existingPersons, new Map());
+      expect(result.episodes).toHaveLength(0);
+    });
+
+    it('description と occurredAt が null の Episode が正しく解決されること', () => {
+      const resultWithNulls: LlmExtractionResult = {
+        persons: [{ name: '山田花子', labels: ['人物'] }],
+        relationships: [],
+        episodes: [
+          {
+            title: '記録のみ',
+            description: null,
+            occurredAt: null,
+            participantNames: ['山田花子'],
+          },
+        ],
+      };
+      const result = resolveExtractionResult(resultWithNulls, existingPersons, new Map());
+      expect(result.episodes).toHaveLength(1);
+      const ep = result.episodes[0];
+      expect(ep.description).toBeUndefined();
+      expect(ep.occurredAt).toBeUndefined();
+    });
   });
 });

--- a/src/lib/person-matching.ts
+++ b/src/lib/person-matching.ts
@@ -52,6 +52,18 @@ type NewPersonData = Omit<Person, 'createdAt'>;
 type NewRelationshipData = Omit<Relationship, 'id' | 'createdAt' | 'updatedAt'>;
 
 /**
+ * ストア投入用の新規エピソードデータの型
+ * createEpisode / addParticipation の引数形式に合わせる（id / createdAt / updatedAt / position / properties は自動生成のため除外）
+ */
+type NewEpisodeData = {
+  title: string;
+  description?: string;
+  occurredAt?: string;
+  /** 解決済みの参加者 Person ID 配列（解決できなかった参加者は除外済み） */
+  participantPersonIds: string[];
+};
+
+/**
  * resolveExtractionResult の戻り値型
  */
 export type ExtractionResolutionResult = {
@@ -59,6 +71,8 @@ export type ExtractionResolutionResult = {
   newPersons: NewPersonData[];
   /** ストアに追加する関係リスト（sourceId / targetId が解決済み） */
   relationships: NewRelationshipData[];
+  /** ストアに追加するエピソードリスト（participantPersonIds が解決済み） */
+  episodes: NewEpisodeData[];
 };
 
 /**
@@ -150,5 +164,35 @@ export function resolveExtractionResult(
     });
   }
 
-  return { newPersons, relationships };
+  // エピソードの解決（relationships と同じ nameToId マップを再利用）
+  const episodes: NewEpisodeData[] = [];
+
+  for (const llmEpisode of result.episodes) {
+    // タイトルが空文字の Episode はスキップ
+    if (!llmEpisode.title.trim()) continue;
+
+    // 参加者名を Person ID に解決（解決できない参加者は除外して Episode は保持）
+    const participantPersonIds: string[] = [];
+    for (const name of llmEpisode.participantNames) {
+      const personId = nameToId.get(normalizeName(name));
+      if (personId !== undefined) {
+        participantPersonIds.push(personId);
+      }
+    }
+
+    // 参加者が 0 人になった Episode はスキップ（ストア上で意味をなさないため）
+    if (participantPersonIds.length === 0) continue;
+
+    const episode: NewEpisodeData = {
+      title: llmEpisode.title,
+      participantPersonIds,
+    };
+    // null を undefined に変換（型の都合で optional フィールドは undefined を使う）
+    if (llmEpisode.description !== null) episode.description = llmEpisode.description;
+    if (llmEpisode.occurredAt !== null) episode.occurredAt = llmEpisode.occurredAt;
+
+    episodes.push(episode);
+  }
+
+  return { newPersons, relationships, episodes };
 }

--- a/src/lib/person-matching.ts
+++ b/src/lib/person-matching.ts
@@ -168,14 +168,18 @@ export function resolveExtractionResult(
   const episodes: NewEpisodeData[] = [];
 
   for (const llmEpisode of result.episodes) {
+    const title = llmEpisode.title.trim();
     // タイトルが空文字の Episode はスキップ
-    if (!llmEpisode.title.trim()) continue;
+    if (!title) continue;
 
     // 参加者名を Person ID に解決（解決できない参加者は除外して Episode は保持）
+    // 同一 Person が重複登録されないよう Set で一意化する
+    const seenParticipantIds = new Set<string>();
     const participantPersonIds: string[] = [];
     for (const name of llmEpisode.participantNames) {
       const personId = nameToId.get(normalizeName(name));
-      if (personId !== undefined) {
+      if (personId !== undefined && !seenParticipantIds.has(personId)) {
+        seenParticipantIds.add(personId);
         participantPersonIds.push(personId);
       }
     }
@@ -184,7 +188,7 @@ export function resolveExtractionResult(
     if (participantPersonIds.length === 0) continue;
 
     const episode: NewEpisodeData = {
-      title: llmEpisode.title,
+      title,
       participantPersonIds,
     };
     // null を undefined に変換（型の都合で optional フィールドは undefined を使う）

--- a/src/stores/useInterviewStore.test.ts
+++ b/src/stores/useInterviewStore.test.ts
@@ -22,6 +22,7 @@ function resetStore() {
 const mockExtractionResult: LlmExtractionResult = {
   persons: [{ name: '山田太郎', labels: ['人物'] }],
   relationships: [],
+  episodes: [],
 };
 
 describe('useInterviewStore', () => {


### PR DESCRIPTION
## Summary

- `LlmExtractionResultSchema` に `episodes` フィールドを追加し、LLM が Episode を抽出できるようにした
- `resolveExtractionResult` でエピソード解決ロジックを追加（参加者名→ID解決、スキップ条件）
- 3つのAPIルート（extract-relationships / interview-chat / interview-extract）に `existingEpisodeTitles` を追加してプロンプトに既存エピソードを注入
- `useExtractRelationships` / `useInterviewChat` で既存エピソードタイトルを fetch body に含める
- `ChatInputBar` / `InterviewModal` の `handleConfirm` を3パス化（Episode作成 + 参加エッジ追加）
- `EpisodePreviewSection` を新規作成し `ExtractionPreviewPanel` / `InterviewModal` に組み込む

## Background

Episodeノード（#94 #102）はデータモデルに追加されたが、AIチャット抽出パイプラインには未統合だった。本PRでその統合を実装する（Phase A）。

Phase B（`turningPoints` の完全削除・マイグレーション）は別PRで実施する。

## Test plan

- [ ] `npm run lint && npm run type-check && npm test` が警告ゼロ・エラーゼロ（CI確認）
- [ ] `npm run dev` で起動後、ChatInputBar から「田中と山田は高校時代に出会い、卒業式で再会した」と入力 → エピソードセクションがプレビューに表示されること
- [ ] 「相関図に追加」クリック後、キャンバス上にエピソードノードが破線で参加者と繋がること
- [ ] インタビューモード起動 → 対話 → セッション終了 → エピソードセクションがプレビューに表示されること
- [ ] Network タブで `existingEpisodeTitles` が各APIリクエストに含まれていること

Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * エピソード（重要な出来事）の抽出・管理機能を追加しました。インタビュー中に複数人が関わる出来事を自動抽出し、参加者と共に記録できるようになりました。エピソードは相関図にプレビュー表示され、確認後に追加できます。

* **Tests**
  * エピソード関連の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->