### PR TITLE
feat: EpisodeノードをPersonと同等の一級ノードに格上げ（選択・編集・接続）

### DIFF
--- a/src/components/graph/EpisodeNodeComponent.test.tsx
+++ b/src/components/graph/EpisodeNodeComponent.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { EpisodeNodeComponent } from './EpisodeNodeComponent';
 
-// React FlowのHandleはzustandプロバイダを必要とするためモック
+// React FlowのHandleとuseConnectionはReactFlowコンテキストを必要とするためモック
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react');
   return {
@@ -17,6 +17,11 @@ vi.mock('@xyflow/react', async () => {
         {children}
       </div>
     ),
+    useConnection: () => ({
+      inProgress: false,
+      fromNode: null,
+      toNode: null,
+    }),
   };
 });
 

--- a/src/components/graph/EpisodeNodeComponent.tsx
+++ b/src/components/graph/EpisodeNodeComponent.tsx
@@ -2,19 +2,30 @@
  * EpisodeNodeComponentコンポーネント
  * エピソードをグラフ上の付箋風カードノードとして表示する
  * Person ノードと並んでキャンバスに配置され、EpisodeParticipation エッジで人物と繋がる
+ *
+ * ハンドルはカード中央1点に集約し、node-intersection.ts の境界交点計算と連携する
  */
 
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { BookOpen } from 'lucide-react';
 import type { EpisodeNodeData } from '@/types/graph';
+import { useHandleHover } from './useHandleHover';
+
+/** エピソードカードの高さ（px）: node-intersection.ts の fallback と一致させる */
+const EPISODE_CARD_HEIGHT = 72;
+/** ハンドル中心の Y 座標（カード高さの中央）*/
+const EPISODE_HANDLE_CENTER_Y = EPISODE_CARD_HEIGHT / 2;
 
 /**
  * エピソードノードコンポーネント
  * @param props - React Flowから渡されるノードプロパティ
  */
-export const EpisodeNodeComponent = memo(({ data, selected }: NodeProps) => {
+export const EpisodeNodeComponent = memo(({ data, selected, id }: NodeProps) => {
   const nodeData = data as EpisodeNodeData;
+
+  const { handleMouseEnter, handleMouseLeave, showSourceHandle, showTargetHandle, isConnectingToThisNode } =
+    useHandleHover(id, selected ?? false);
 
   return (
     <div
@@ -23,24 +34,48 @@ export const EpisodeNodeComponent = memo(({ data, selected }: NodeProps) => {
           ? 'border-blue-500 shadow-blue-200 shadow-xl'
           : 'border-amber-200 hover:border-amber-400'
       }`}
-      style={{ width: 180, minHeight: 72, padding: '10px 12px' }}
+      style={{ width: 180, minHeight: EPISODE_CARD_HEIGHT, padding: '10px 12px' }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
-      {/* 参加エッジ用ハンドル（source） */}
+      {/* 参加エッジ用ハンドル（source）: カード中央に配置 */}
       <Handle
         type="source"
         id="participation-source"
         position={Position.Top}
-        className="!w-3 !h-3 !bg-amber-400 !border-2 !border-white !rounded-full"
-        style={{ top: -6 }}
+        className="!absolute !rounded-xl !border-transparent !bg-transparent transition-opacity duration-200"
+        style={{
+          left: '50%',
+          top: `${EPISODE_HANDLE_CENTER_Y}px`,
+          transform: 'translate(-50%, -50%)',
+          width: '100%',
+          height: `${EPISODE_CARD_HEIGHT}px`,
+          opacity: showSourceHandle ? 1 : 0,
+          pointerEvents: showSourceHandle ? 'auto' : 'none',
+          zIndex: 2,
+        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       />
 
-      {/* 参加エッジ用ハンドル（target） */}
+      {/* 参加エッジ用ハンドル（target）: カード中央に配置 */}
       <Handle
         type="target"
         id="participation-target"
-        position={Position.Bottom}
-        className="!w-3 !h-3 !bg-amber-400 !border-2 !border-white !rounded-full"
-        style={{ bottom: -6 }}
+        position={Position.Top}
+        className="!absolute !rounded-xl !border-transparent !bg-transparent transition-opacity duration-200"
+        style={{
+          left: '50%',
+          top: `${EPISODE_HANDLE_CENTER_Y}px`,
+          transform: 'translate(-50%, -50%)',
+          width: '100%',
+          height: `${EPISODE_CARD_HEIGHT}px`,
+          opacity: 0,
+          pointerEvents: showTargetHandle || isConnectingToThisNode ? 'auto' : 'none',
+          zIndex: isConnectingToThisNode ? 15 : 2,
+        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       />
 
       {/* ヘッダー: アイコン + タイトル */}

--- a/src/components/graph/EpisodeNodeComponent.tsx
+++ b/src/components/graph/EpisodeNodeComponent.tsx
@@ -38,7 +38,7 @@ export const EpisodeNodeComponent = memo(({ data, selected, id }: NodeProps) => 
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {/* 参加エッジ用ハンドル（source）: カード中央に配置 */}
+      {/* 参加エッジ用ハンドル（source）: カード全体を透明ヒット領域として覆う。ホバー時のみ visible */}
       <Handle
         type="source"
         id="participation-source"

--- a/src/components/graph/ParticipationEdge.test.tsx
+++ b/src/components/graph/ParticipationEdge.test.tsx
@@ -8,7 +8,7 @@ import { render } from '@testing-library/react';
 import { ParticipationEdge } from './ParticipationEdge';
 import type { EdgeProps } from '@xyflow/react';
 
-// React FlowのBaseEdgeはzustandプロバイダを必要とするためモック
+// React FlowのBaseEdge・useReactFlow・getStraightPathはコンテキストを必要とするためモック
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react');
   return {
@@ -17,6 +17,18 @@ vi.mock('@xyflow/react', async () => {
       <path data-testid="base-edge" style={style} {...props} />
     ),
     getStraightPath: () => ['M 0 0 L 100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) => ({
+        id,
+        type: id.startsWith('ep') ? 'episode' : undefined,
+        position: { x: 0, y: 0 },
+        measured: {
+          width: id.startsWith('ep') ? 180 : 80,
+          height: id.startsWith('ep') ? 72 : 80,
+        },
+        data: {},
+      }),
+    }),
   };
 });
 

--- a/src/components/graph/ParticipationEdge.test.tsx
+++ b/src/components/graph/ParticipationEdge.test.tsx
@@ -18,16 +18,21 @@ vi.mock('@xyflow/react', async () => {
     ),
     getStraightPath: () => ['M 0 0 L 100 100', 50, 50],
     useReactFlow: () => ({
-      getNode: (id: string) => ({
-        id,
-        type: id.startsWith('ep') ? 'episode' : undefined,
-        position: { x: 0, y: 0 },
-        measured: {
-          width: id.startsWith('ep') ? 180 : 80,
-          height: id.startsWith('ep') ? 72 : 80,
-        },
-        data: {},
-      }),
+      getNode: (id: string) => {
+        // テストに存在するノードIDのみ返す。不明なIDは undefined（実際のuseReactFlowの挙動を再現）
+        const knownIds = ['ep-001', 'person-001'];
+        if (!knownIds.includes(id)) return undefined;
+        return {
+          id,
+          type: id.startsWith('ep') ? 'episode' : undefined,
+          position: { x: 0, y: 0 },
+          measured: {
+            width: id.startsWith('ep') ? 180 : 80,
+            height: id.startsWith('ep') ? 72 : 80,
+          },
+          data: {},
+        };
+      },
     }),
   };
 });

--- a/src/components/graph/ParticipationEdge.tsx
+++ b/src/components/graph/ParticipationEdge.tsx
@@ -32,16 +32,7 @@ export const ParticipationEdge = memo((props: EdgeProps) => {
       return { sourcePoint: { x: 0, y: 0 }, targetPoint: { x: 0, y: 0 } };
     }
     return getEdgeIntersectionPoints(sourceNode, targetNode);
-  }, [
-    sourceNode?.position.x,
-    sourceNode?.position.y,
-    sourceNode?.measured?.width,
-    sourceNode?.measured?.height,
-    targetNode?.position.x,
-    targetNode?.position.y,
-    targetNode?.measured?.width,
-    targetNode?.measured?.height,
-  ]);
+  }, [sourceNode, targetNode]);
 
   if (!sourceNode || !targetNode) return null;
 

--- a/src/components/graph/ParticipationEdge.tsx
+++ b/src/components/graph/ParticipationEdge.tsx
@@ -6,25 +6,50 @@
  * - 破線（strokeDasharray）でRelationshipエッジと視覚的に区別
  * - グレー系の色で主張を抑える
  * - マーカーなし（向きを持たないエッジ）
+ * - ノード境界との交点計算で正確な端点を算出（PersonNode/EpisodeNode両対応）
  */
 
 'use client';
 
-import { memo } from 'react';
-import { BaseEdge, EdgeProps, getStraightPath } from '@xyflow/react';
+import { memo, useMemo } from 'react';
+import { BaseEdge, EdgeProps, getStraightPath, useReactFlow } from '@xyflow/react';
+import { getEdgeIntersectionPoints } from '@/lib/node-intersection';
 
 /**
  * エピソード参加エッジコンポーネント
  * @param props - React Flowから渡されるエッジプロパティ
  */
 export const ParticipationEdge = memo((props: EdgeProps) => {
-  const { sourceX, sourceY, targetX, targetY } = props;
+  const { source, target } = props;
+  const { getNode } = useReactFlow();
+
+  const sourceNode = getNode(source);
+  const targetNode = getNode(target);
+
+  // ノードの境界との交点を計算（キャッシュして再計算を最小化）
+  const { sourcePoint, targetPoint } = useMemo(() => {
+    if (!sourceNode || !targetNode) {
+      return { sourcePoint: { x: 0, y: 0 }, targetPoint: { x: 0, y: 0 } };
+    }
+    return getEdgeIntersectionPoints(sourceNode, targetNode);
+  }, [
+    sourceNode?.position.x,
+    sourceNode?.position.y,
+    sourceNode?.measured?.width,
+    sourceNode?.measured?.height,
+    targetNode?.position.x,
+    targetNode?.position.y,
+    targetNode?.measured?.width,
+    targetNode?.measured?.height,
+  ]);
+
+  if (!sourceNode || !targetNode) return null;
 
   const [edgePath] = getStraightPath({
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
+    sourceX: sourcePoint.x,
+    sourceY: sourcePoint.y,
+    targetX: targetPoint.x,
+    targetY: targetPoint.y,
   });
 
   return (

--- a/src/components/graph/useGraphDataSync.ts
+++ b/src/components/graph/useGraphDataSync.ts
@@ -30,6 +30,7 @@ export function useGraphDataSync() {
   const episodeParticipations = useGraphStore((state) => state.episodeParticipations);
   const forceEnabled = useGraphStore((state) => state.forceEnabled);
   const selectedPersonIds = useGraphStore((state) => state.selectedPersonIds);
+  const selectedEpisodeIds = useGraphStore((state) => state.selectedEpisodeIds);
   const updatePersonPositions = useGraphStore((state) => state.updatePersonPositions);
   const updateEpisodePositions = useGraphStore((state) => state.updateEpisodePositions);
   const edgeFilter = useGraphStore((state) => state.edgeFilter);
@@ -213,7 +214,11 @@ export function useGraphDataSync() {
     setNodes((prevNodes) => {
       let hasChanged = false;
       const updatedNodes = prevNodes.map((node) => {
-        const shouldBeSelected = selectedPersonIds.includes(node.id);
+        // EpisodeノードはselectedEpisodeIds、PersonノードはselectedPersonIdsで判定
+        const shouldBeSelected =
+          node.type === 'episode'
+            ? selectedEpisodeIds.includes(node.id)
+            : selectedPersonIds.includes(node.id);
         if (node.selected !== shouldBeSelected) {
           hasChanged = true;
           return { ...node, selected: shouldBeSelected };
@@ -239,7 +244,7 @@ export function useGraphDataSync() {
       });
       return hasChanged ? updatedEdges : prevEdges;
     });
-  }, [selectedPersonIds, setNodes, setEdges]);
+  }, [selectedPersonIds, selectedEpisodeIds, setNodes, setEdges]);
 
   return {
     nodes,

--- a/src/components/graph/useGraphInteractions.ts
+++ b/src/components/graph/useGraphInteractions.ts
@@ -60,6 +60,7 @@ export function useGraphInteractions({
 }: UseGraphInteractionsParams) {
   // Zustandストアから状態とアクションを取得
   const persons = useGraphStore((state) => state.persons);
+  const episodes = useGraphStore((state) => state.episodes);
   const relationships = useGraphStore((state) => state.relationships);
   const timelineMode = useGraphStore((state) => state.timelineMode);
   const addPerson = useGraphStore((state) => state.addPerson);
@@ -68,9 +69,12 @@ export function useGraphInteractions({
   const removePerson = useGraphStore((state) => state.removePerson);
   const removeRelationship = useGraphStore((state) => state.removeRelationship);
   const removeParticipation = useGraphStore((state) => state.removeParticipation);
+  const addParticipation = useGraphStore((state) => state.addParticipation);
   const setSelectedPersonIds = useGraphStore((state) => state.setSelectedPersonIds);
   const clearSelection = useGraphStore((state) => state.clearSelection);
   const selectPersonPairForEdit = useGraphStore((state) => state.selectPersonPairForEdit);
+  const selectEpisode = useGraphStore((state) => state.selectEpisode);
+  const toggleEpisodeSelection = useGraphStore((state) => state.toggleEpisodeSelection);
 
   // タイムラインモードの状態をrefで保持（useEffect内で最新値を参照するため）
   const timelineModeRef = useRef(timelineMode);
@@ -106,10 +110,34 @@ export function useGraphInteractions({
       // 自己接続を防止
       if (sourceId === targetId) return;
 
-      // 両方のノードが実際に存在することを確認
-      const sourceNode = persons.find((p) => p.id === sourceId);
-      const targetNode = persons.find((p) => p.id === targetId);
-      if (!sourceNode || !targetNode) return;
+      // ノード種別を判定（Person or Episode）
+      const sourcePerson = persons.find((p) => p.id === sourceId);
+      const targetPerson = persons.find((p) => p.id === targetId);
+      const sourceEpisode = episodes.find((e) => e.id === sourceId);
+      const targetEpisode = episodes.find((e) => e.id === targetId);
+
+      // Episode↔Episode の接続は非対応
+      if (sourceEpisode && targetEpisode) return;
+
+      // Person↔Episode の接続: 即座に EpisodeParticipation を作成（モーダル不要）
+      if (sourceEpisode || targetEpisode) {
+        const episodeId = (sourceEpisode ?? targetEpisode)!.id;
+        const personId = (sourcePerson ?? targetPerson)?.id;
+        if (!personId) return;
+        // 既に参加エッジが存在する場合は重複作成しない
+        const alreadyExists = useGraphStore
+          .getState()
+          .episodeParticipations.some(
+            (p) => p.episodeId === episodeId && p.personId === personId
+          );
+        if (!alreadyExists) {
+          addParticipation({ episodeId, personId });
+        }
+        return;
+      }
+
+      // Person↔Person の接続
+      if (!sourcePerson || !targetPerson) return;
 
       // 同じペアの関係が既に存在するかチェック（方向問わず、最初の1件を返す）
       const existingRelationship = relationships.find(
@@ -125,7 +153,7 @@ export function useGraphInteractions({
         ...(existingRelationship ? { existingRelationshipId: existingRelationship.id } : {}),
       });
     },
-    [persons, relationships, timelineMode]
+    [persons, episodes, relationships, addParticipation, timelineMode]
   );
 
   // キャンバスへの画像ドロップハンドラ
@@ -275,23 +303,31 @@ export function useGraphInteractions({
         closeContextMenu();
       }
 
-      // Shiftキーが押されている場合は複数選択（トグル）
-      if (event.shiftKey) {
-        const currentSelectedIds = useGraphStore.getState().selectedPersonIds;
-        const isSelected = currentSelectedIds.includes(node.id);
-        if (isSelected) {
-          // 選択解除
-          setSelectedPersonIds(currentSelectedIds.filter((id) => id !== node.id));
+      // EpisodeノードとPersonノードで選択ロジックを分岐
+      if (node.type === 'episode') {
+        // Episodeはシンプルなトグル選択（Shiftキー非対応）
+        if (event.shiftKey) {
+          toggleEpisodeSelection(node.id);
         } else {
-          // 選択追加
-          setSelectedPersonIds([...currentSelectedIds, node.id]);
+          selectEpisode(node.id);
         }
       } else {
-        // 通常クリック：単一選択
-        setSelectedPersonIds([node.id]);
+        // Personノード: Shiftキーで複数選択トグル
+        if (event.shiftKey) {
+          const currentSelectedIds = useGraphStore.getState().selectedPersonIds;
+          const isSelected = currentSelectedIds.includes(node.id);
+          if (isSelected) {
+            setSelectedPersonIds(currentSelectedIds.filter((id) => id !== node.id));
+          } else {
+            setSelectedPersonIds([...currentSelectedIds, node.id]);
+          }
+        } else {
+          // 通常クリック：単一選択
+          setSelectedPersonIds([node.id]);
+        }
       }
     },
-    [contextMenu, closeContextMenu, setSelectedPersonIds]
+    [contextMenu, closeContextMenu, setSelectedPersonIds, selectEpisode, toggleEpisodeSelection]
   );
 
   // 背景クリックハンドラ

--- a/src/components/graph/useGraphInteractions.ts
+++ b/src/components/graph/useGraphInteractions.ts
@@ -305,7 +305,7 @@ export function useGraphInteractions({
 
       // EpisodeノードとPersonノードで選択ロジックを分岐
       if (node.type === 'episode') {
-        // Episodeはシンプルなトグル選択（Shiftキー非対応）
+        // Episodeの選択: Shiftキーで toggleEpisodeSelection、通常は selectEpisode
         if (event.shiftKey) {
           toggleEpisodeSelection(node.id);
         } else {

--- a/src/components/graph/useGraphInteractions.ts
+++ b/src/components/graph/useGraphInteractions.ts
@@ -71,6 +71,8 @@ export function useGraphInteractions({
   const removeParticipation = useGraphStore((state) => state.removeParticipation);
   const addParticipation = useGraphStore((state) => state.addParticipation);
   const setSelectedPersonIds = useGraphStore((state) => state.setSelectedPersonIds);
+  const selectPerson = useGraphStore((state) => state.selectPerson);
+  const togglePersonSelection = useGraphStore((state) => state.togglePersonSelection);
   const clearSelection = useGraphStore((state) => state.clearSelection);
   const selectPersonPairForEdit = useGraphStore((state) => state.selectPersonPairForEdit);
   const selectEpisode = useGraphStore((state) => state.selectEpisode);
@@ -312,22 +314,16 @@ export function useGraphInteractions({
           selectEpisode(node.id);
         }
       } else {
-        // Personノード: Shiftキーで複数選択トグル
+        // Personノード: Shiftキーで複数選択トグル（selectPerson/togglePersonSelectionがEpisode排他制御を担う）
         if (event.shiftKey) {
-          const currentSelectedIds = useGraphStore.getState().selectedPersonIds;
-          const isSelected = currentSelectedIds.includes(node.id);
-          if (isSelected) {
-            setSelectedPersonIds(currentSelectedIds.filter((id) => id !== node.id));
-          } else {
-            setSelectedPersonIds([...currentSelectedIds, node.id]);
-          }
+          togglePersonSelection(node.id);
         } else {
-          // 通常クリック：単一選択
-          setSelectedPersonIds([node.id]);
+          // 通常クリック：単一選択（selectedEpisodeIds もクリアされる）
+          selectPerson(node.id);
         }
       }
     },
-    [contextMenu, closeContextMenu, setSelectedPersonIds, selectEpisode, toggleEpisodeSelection]
+    [contextMenu, closeContextMenu, setSelectedPersonIds, selectPerson, togglePersonSelection, selectEpisode, toggleEpisodeSelection]
   );
 
   // 背景クリックハンドラ

--- a/src/components/panel/EpisodeEditForm.test.tsx
+++ b/src/components/panel/EpisodeEditForm.test.tsx
@@ -9,6 +9,12 @@ import userEvent from '@testing-library/user-event';
 import { EpisodeEditForm } from './EpisodeEditForm';
 import type { Episode } from '@/types/episode';
 
+// モック関数を vi.hoisted でホイストし、vi.mock より前に初期化する
+const { mockUpdateEpisode, mockDeleteEpisode } = vi.hoisted(() => ({
+  mockUpdateEpisode: vi.fn(),
+  mockDeleteEpisode: vi.fn(),
+}));
+
 // useGraphStore をモック
 vi.mock('@/stores/useGraphStore', () => ({
   useGraphStore: vi.fn((selector: (state: unknown) => unknown) => {
@@ -20,9 +26,6 @@ vi.mock('@/stores/useGraphStore', () => ({
     return selector(state);
   }),
 }));
-
-const mockUpdateEpisode = vi.fn();
-const mockDeleteEpisode = vi.fn();
 
 const baseEpisode: Episode = {
   id: 'ep-001',
@@ -39,6 +42,8 @@ describe('EpisodeEditForm', () => {
   beforeEach(() => {
     mockUpdateEpisode.mockClear();
     mockDeleteEpisode.mockClear();
+    // window.confirm をモック（デフォルトは確認OK）
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
   });
 
   describe('初期表示', () => {
@@ -107,6 +112,19 @@ describe('EpisodeEditForm', () => {
         title: '波乱の展開',
       }));
     });
+
+    it('空のタイトルでblurしても保存されず元の値に戻る', async () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const titleInput = screen.getByRole('textbox', { name: /タイトル/i });
+      await userEvent.clear(titleInput);
+      fireEvent.blur(titleInput);
+
+      // 保存されない
+      expect(mockUpdateEpisode).not.toHaveBeenCalled();
+      // フィールドが元の値に戻る
+      expect(titleInput).toHaveValue('初めての出会い');
+    });
   });
 
   describe('説明・日時保存', () => {
@@ -138,7 +156,16 @@ describe('EpisodeEditForm', () => {
   });
 
   describe('削除', () => {
-    it('削除ボタンをクリックするとdeleteEpisodeが呼ばれる', () => {
+    it('削除ボタンをクリックすると確認ダイアログが表示される', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const deleteButton = screen.getByRole('button', { name: /削除/i });
+      fireEvent.click(deleteButton);
+
+      expect(window.confirm).toHaveBeenCalled();
+    });
+
+    it('確認OKでdeleteEpisodeが呼ばれる', () => {
       render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
 
       const deleteButton = screen.getByRole('button', { name: /削除/i });
@@ -147,7 +174,17 @@ describe('EpisodeEditForm', () => {
       expect(mockDeleteEpisode).toHaveBeenCalledWith('ep-001');
     });
 
-    it('削除後にonCloseが呼ばれる', () => {
+    it('確認キャンセルでdeleteEpisodeが呼ばれない', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const deleteButton = screen.getByRole('button', { name: /削除/i });
+      fireEvent.click(deleteButton);
+
+      expect(mockDeleteEpisode).not.toHaveBeenCalled();
+    });
+
+    it('削除後にonCloseが呼ばれ、deleteEpisodeの後に呼ばれる', () => {
       const onClose = vi.fn();
       render(<EpisodeEditForm episode={baseEpisode} onClose={onClose} />);
 
@@ -155,6 +192,9 @@ describe('EpisodeEditForm', () => {
       fireEvent.click(deleteButton);
 
       expect(onClose).toHaveBeenCalled();
+      // deleteEpisode が onClose より先に呼ばれていること
+      expect(mockDeleteEpisode.mock.invocationCallOrder[0])
+        .toBeLessThan(onClose.mock.invocationCallOrder[0]);
     });
   });
 });

--- a/src/components/panel/EpisodeEditForm.test.tsx
+++ b/src/components/panel/EpisodeEditForm.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * EpisodeEditForm のテスト
+ * エピソードノードの編集フォームの振る舞いを検証する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EpisodeEditForm } from './EpisodeEditForm';
+import type { Episode } from '@/types/episode';
+
+// useGraphStore をモック
+vi.mock('@/stores/useGraphStore', () => ({
+  useGraphStore: vi.fn((selector: (state: unknown) => unknown) => {
+    const state = {
+      updateEpisode: mockUpdateEpisode,
+      deleteEpisode: mockDeleteEpisode,
+      relationships: [],
+    };
+    return selector(state);
+  }),
+}));
+
+const mockUpdateEpisode = vi.fn();
+const mockDeleteEpisode = vi.fn();
+
+const baseEpisode: Episode = {
+  id: 'ep-001',
+  title: '初めての出会い',
+  description: '二人が公園で出会った日',
+  occurredAt: '第1話',
+  relatedRelationshipIds: [],
+  properties: {},
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+describe('EpisodeEditForm', () => {
+  beforeEach(() => {
+    mockUpdateEpisode.mockClear();
+    mockDeleteEpisode.mockClear();
+  });
+
+  describe('初期表示', () => {
+    it('タイトルフィールドに現在のtitleが表示される', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      // タイトル入力フィールドに初期値が表示される
+      const titleInput = screen.getByRole('textbox', { name: /タイトル/i });
+      expect(titleInput).toHaveValue('初めての出会い');
+    });
+
+    it('説明フィールドに現在のdescriptionが表示される', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const descInput = screen.getByRole('textbox', { name: /説明/i });
+      expect(descInput).toHaveValue('二人が公園で出会った日');
+    });
+
+    it('発生日時フィールドに現在のoccurredAtが表示される', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const dateInput = screen.getByRole('textbox', { name: /発生日時/i });
+      expect(dateInput).toHaveValue('第1話');
+    });
+
+    it('削除ボタンが表示される', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      expect(screen.getByRole('button', { name: /削除/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('タイトル保存', () => {
+    it('Enterキーを押すとタイトルが保存される', async () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const titleInput = screen.getByRole('textbox', { name: /タイトル/i });
+      await userEvent.clear(titleInput);
+      await userEvent.type(titleInput, '再会の喜び');
+      fireEvent.keyDown(titleInput, { key: 'Enter' });
+
+      expect(mockUpdateEpisode).toHaveBeenCalledWith('ep-001', expect.objectContaining({
+        title: '再会の喜び',
+      }));
+    });
+
+    it('Enterキー（IME変換確定）では保存されない', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const titleInput = screen.getByRole('textbox', { name: /タイトル/i });
+      // IME変換中（isComposing=true）のEnterキー: KeyboardEventInit で isComposing を指定
+      fireEvent.keyDown(titleInput, { key: 'Enter', isComposing: true });
+
+      expect(mockUpdateEpisode).not.toHaveBeenCalled();
+    });
+
+    it('フォーカスを外すと（blur）タイトルが保存される', async () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const titleInput = screen.getByRole('textbox', { name: /タイトル/i });
+      await userEvent.clear(titleInput);
+      await userEvent.type(titleInput, '波乱の展開');
+      fireEvent.blur(titleInput);
+
+      expect(mockUpdateEpisode).toHaveBeenCalledWith('ep-001', expect.objectContaining({
+        title: '波乱の展開',
+      }));
+    });
+  });
+
+  describe('説明・日時保存', () => {
+    it('説明フィールドをblurすると保存される', async () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const descInput = screen.getByRole('textbox', { name: /説明/i });
+      await userEvent.clear(descInput);
+      await userEvent.type(descInput, '試練の冬が訪れた');
+      fireEvent.blur(descInput);
+
+      expect(mockUpdateEpisode).toHaveBeenCalledWith('ep-001', expect.objectContaining({
+        description: '試練の冬が訪れた',
+      }));
+    });
+
+    it('発生日時フィールドをblurすると保存される', async () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const dateInput = screen.getByRole('textbox', { name: /発生日時/i });
+      await userEvent.clear(dateInput);
+      await userEvent.type(dateInput, '第3話');
+      fireEvent.blur(dateInput);
+
+      expect(mockUpdateEpisode).toHaveBeenCalledWith('ep-001', expect.objectContaining({
+        occurredAt: '第3話',
+      }));
+    });
+  });
+
+  describe('削除', () => {
+    it('削除ボタンをクリックするとdeleteEpisodeが呼ばれる', () => {
+      render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
+
+      const deleteButton = screen.getByRole('button', { name: /削除/i });
+      fireEvent.click(deleteButton);
+
+      expect(mockDeleteEpisode).toHaveBeenCalledWith('ep-001');
+    });
+
+    it('削除後にonCloseが呼ばれる', () => {
+      const onClose = vi.fn();
+      render(<EpisodeEditForm episode={baseEpisode} onClose={onClose} />);
+
+      const deleteButton = screen.getByRole('button', { name: /削除/i });
+      fireEvent.click(deleteButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/panel/EpisodeEditForm.test.tsx
+++ b/src/components/panel/EpisodeEditForm.test.tsx
@@ -3,16 +3,17 @@
  * エピソードノードの編集フォームの振る舞いを検証する
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { EpisodeEditForm } from './EpisodeEditForm';
 import type { Episode } from '@/types/episode';
 
 // モック関数を vi.hoisted でホイストし、vi.mock より前に初期化する
-const { mockUpdateEpisode, mockDeleteEpisode } = vi.hoisted(() => ({
+const { mockUpdateEpisode, mockDeleteEpisode, mockOpenConfirm } = vi.hoisted(() => ({
   mockUpdateEpisode: vi.fn(),
   mockDeleteEpisode: vi.fn(),
+  mockOpenConfirm: vi.fn().mockResolvedValue(true),
 }));
 
 // useGraphStore をモック
@@ -25,6 +26,14 @@ vi.mock('@/stores/useGraphStore', () => ({
     };
     return selector(state);
   }),
+}));
+
+// useDialogStore をモック
+vi.mock('@/stores/useDialogStore', () => ({
+  useDialogStore: vi.fn(
+    (selector: (state: { openConfirm: typeof mockOpenConfirm }) => unknown) =>
+      selector({ openConfirm: mockOpenConfirm })
+  ),
 }));
 
 const baseEpisode: Episode = {
@@ -42,8 +51,12 @@ describe('EpisodeEditForm', () => {
   beforeEach(() => {
     mockUpdateEpisode.mockClear();
     mockDeleteEpisode.mockClear();
-    // window.confirm をモック（デフォルトは確認OK）
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockOpenConfirm.mockClear();
+    mockOpenConfirm.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('初期表示', () => {
@@ -162,36 +175,41 @@ describe('EpisodeEditForm', () => {
       const deleteButton = screen.getByRole('button', { name: /削除/i });
       fireEvent.click(deleteButton);
 
-      expect(window.confirm).toHaveBeenCalled();
+      expect(mockOpenConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ isDanger: true })
+      );
     });
 
-    it('確認OKでdeleteEpisodeが呼ばれる', () => {
+    it('確認OKでdeleteEpisodeが呼ばれる', async () => {
       render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
 
       const deleteButton = screen.getByRole('button', { name: /削除/i });
       fireEvent.click(deleteButton);
+      // openConfirmのPromise解決を待つ
+      await vi.waitFor(() => expect(mockDeleteEpisode).toHaveBeenCalled());
 
       expect(mockDeleteEpisode).toHaveBeenCalledWith('ep-001');
     });
 
-    it('確認キャンセルでdeleteEpisodeが呼ばれない', () => {
-      vi.spyOn(window, 'confirm').mockReturnValue(false);
+    it('確認キャンセルでdeleteEpisodeが呼ばれない', async () => {
+      mockOpenConfirm.mockResolvedValue(false);
       render(<EpisodeEditForm episode={baseEpisode} onClose={vi.fn()} />);
 
       const deleteButton = screen.getByRole('button', { name: /削除/i });
       fireEvent.click(deleteButton);
+      await vi.waitFor(() => expect(mockOpenConfirm).toHaveBeenCalled());
 
       expect(mockDeleteEpisode).not.toHaveBeenCalled();
     });
 
-    it('削除後にonCloseが呼ばれ、deleteEpisodeの後に呼ばれる', () => {
+    it('削除後にonCloseが呼ばれ、deleteEpisodeの後に呼ばれる', async () => {
       const onClose = vi.fn();
       render(<EpisodeEditForm episode={baseEpisode} onClose={onClose} />);
 
       const deleteButton = screen.getByRole('button', { name: /削除/i });
       fireEvent.click(deleteButton);
+      await vi.waitFor(() => expect(onClose).toHaveBeenCalled());
 
-      expect(onClose).toHaveBeenCalled();
       // deleteEpisode が onClose より先に呼ばれていること
       expect(mockDeleteEpisode.mock.invocationCallOrder[0])
         .toBeLessThan(onClose.mock.invocationCallOrder[0]);

--- a/src/components/panel/EpisodeEditForm.tsx
+++ b/src/components/panel/EpisodeEditForm.tsx
@@ -7,6 +7,7 @@
 import { useState, type ChangeEvent } from 'react';
 import { ArrowLeft, Trash2 } from 'lucide-react';
 import { useGraphStore } from '@/stores/useGraphStore';
+import { useDialogStore } from '@/stores/useDialogStore';
 import { PropertiesKvEditor } from '@/components/ui/PropertiesKvEditor';
 import type { Episode } from '@/types/episode';
 
@@ -27,6 +28,7 @@ export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
   const updateEpisode = useGraphStore((state) => state.updateEpisode);
   const deleteEpisode = useGraphStore((state) => state.deleteEpisode);
   const relationships = useGraphStore((state) => state.relationships);
+  const openConfirm = useDialogStore((state) => state.openConfirm);
 
   const [title, setTitle] = useState(episode.title);
   const [description, setDescription] = useState(episode.description ?? '');
@@ -43,6 +45,7 @@ export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
       e.preventDefault();
       const trimmed = title.trim();
       if (trimmed) {
+        setTitle(trimmed);
         updateEpisode(episode.id, { title: trimmed });
       }
     }
@@ -83,11 +86,17 @@ export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
     updateEpisode(episode.id, { properties: next });
   };
 
-  // 削除ハンドラ（確認ダイアログ付き）
-  const handleDelete = () => {
-    if (!window.confirm('このエピソードを削除しますか？')) return;
-    deleteEpisode(episode.id);
-    onClose();
+  // 削除ハンドラ（確認ダイアログ付き）: SingleSelectionPanel と同様に openConfirm を使用
+  const handleDelete = async () => {
+    const confirmed = await openConfirm({
+      message: `「${episode.title}」を削除してもよろしいですか？`,
+      confirmLabel: '削除',
+      isDanger: true,
+    });
+    if (confirmed) {
+      deleteEpisode(episode.id);
+      onClose();
+    }
   };
 
   return (

--- a/src/components/panel/EpisodeEditForm.tsx
+++ b/src/components/panel/EpisodeEditForm.tsx
@@ -1,0 +1,201 @@
+/**
+ * EpisodeEditFormコンポーネント
+ * 選択されたエピソードノードの編集フォーム
+ * title / description / occurredAt / relatedRelationshipIds / properties を編集できる
+ */
+
+import { useState, type ChangeEvent } from 'react';
+import { ArrowLeft, Trash2 } from 'lucide-react';
+import { useGraphStore } from '@/stores/useGraphStore';
+import { PropertiesKvEditor } from '@/components/ui/PropertiesKvEditor';
+import type { Episode } from '@/types/episode';
+
+/**
+ * EpisodeEditFormのProps
+ */
+type EpisodeEditFormProps = {
+  /** 編集対象のエピソード */
+  episode: Episode;
+  /** フォームを閉じるコールバック */
+  onClose: () => void;
+};
+
+/**
+ * エピソード編集フォームコンポーネント
+ */
+export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
+  const updateEpisode = useGraphStore((state) => state.updateEpisode);
+  const deleteEpisode = useGraphStore((state) => state.deleteEpisode);
+  const relationships = useGraphStore((state) => state.relationships);
+
+  const [title, setTitle] = useState(episode.title);
+  const [description, setDescription] = useState(episode.description ?? '');
+  const [occurredAt, setOccurredAt] = useState(episode.occurredAt ?? '');
+  const [relatedRelationshipIds, setRelatedRelationshipIds] = useState<string[]>(
+    episode.relatedRelationshipIds
+  );
+  const [properties, setProperties] = useState<Record<string, unknown>>(episode.properties);
+
+  // タイトル Enterキー保存ハンドラ（IME対応）
+  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      const trimmed = title.trim();
+      if (trimmed) {
+        updateEpisode(episode.id, { title: trimmed });
+      }
+    }
+  };
+
+  // タイトル blur 保存ハンドラ
+  const handleTitleBlur = () => {
+    const trimmed = title.trim();
+    if (trimmed) {
+      updateEpisode(episode.id, { title: trimmed });
+    }
+  };
+
+  // 説明 blur 保存ハンドラ
+  const handleDescriptionBlur = () => {
+    updateEpisode(episode.id, { description: description || undefined });
+  };
+
+  // 発生日時 blur 保存ハンドラ
+  const handleOccurredAtBlur = () => {
+    updateEpisode(episode.id, { occurredAt: occurredAt || undefined });
+  };
+
+  // 関連関係 チェックボックスハンドラ
+  const handleRelationshipToggle = (relId: string, checked: boolean) => {
+    const next = checked
+      ? [...relatedRelationshipIds, relId]
+      : relatedRelationshipIds.filter((id) => id !== relId);
+    setRelatedRelationshipIds(next);
+    updateEpisode(episode.id, { relatedRelationshipIds: next });
+  };
+
+  // プロパティ変更ハンドラ
+  const handlePropertiesChange = (next: Record<string, unknown>) => {
+    setProperties(next);
+    updateEpisode(episode.id, { properties: next });
+  };
+
+  // 削除ハンドラ
+  const handleDelete = () => {
+    deleteEpisode(episode.id);
+    onClose();
+  };
+
+  return (
+    <div className="p-4 bg-white border-b border-gray-200">
+      {/* ヘッダー */}
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-bold text-gray-900">エピソードを編集</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="戻る"
+        >
+          <ArrowLeft className="w-6 h-6" />
+        </button>
+      </div>
+
+      {/* タイトル */}
+      <div className="mb-4">
+        <label htmlFor="episode-title" className="block text-sm font-medium text-gray-700 mb-2">
+          タイトル
+        </label>
+        <input
+          id="episode-title"
+          type="text"
+          value={title}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+          onKeyDown={handleTitleKeyDown}
+          onBlur={handleTitleBlur}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+          placeholder="エピソードのタイトル"
+        />
+      </div>
+
+      {/* 発生日時 */}
+      <div className="mb-4">
+        <label htmlFor="episode-occurred-at" className="block text-sm font-medium text-gray-700 mb-2">
+          発生日時
+        </label>
+        <input
+          id="episode-occurred-at"
+          type="text"
+          value={occurredAt}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setOccurredAt(e.target.value)}
+          onBlur={handleOccurredAtBlur}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+          placeholder="例: 第1話、2024年春"
+        />
+      </div>
+
+      {/* 説明 */}
+      <div className="mb-4">
+        <label htmlFor="episode-description" className="block text-sm font-medium text-gray-700 mb-2">
+          説明
+        </label>
+        <textarea
+          id="episode-description"
+          value={description}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value)}
+          onBlur={handleDescriptionBlur}
+          rows={3}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 resize-none"
+          placeholder="エピソードの説明"
+        />
+      </div>
+
+      {/* 関連関係 */}
+      {relationships.length > 0 && (
+        <div className="mb-4">
+          <span className="block text-sm font-medium text-gray-700 mb-2">関連する関係</span>
+          <div className="space-y-1 max-h-40 overflow-y-auto">
+            {relationships.map((rel) => {
+              const label = rel.label ?? rel.type ?? rel.id;
+              return (
+                <label key={rel.id} className="flex items-center gap-2 text-xs text-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={relatedRelationshipIds.includes(rel.id)}
+                    onChange={(e) => handleRelationshipToggle(rel.id, e.target.checked)}
+                    className="rounded border-gray-300"
+                  />
+                  {label}
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* プロパティ */}
+      <details className="mb-4 border-t border-gray-200 pt-4">
+        <summary className="text-sm font-medium text-gray-700 cursor-pointer select-none">
+          プロパティ
+        </summary>
+        <div className="mt-3">
+          <PropertiesKvEditor value={properties} onChange={handlePropertiesChange} />
+        </div>
+      </details>
+
+      {/* 削除ボタン */}
+      <div className="border-t border-gray-200 pt-4">
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="flex items-center gap-1.5 text-sm text-red-600 hover:text-red-800 transition-colors"
+          aria-label="エピソードを削除"
+        >
+          <Trash2 className="w-4 h-4" />
+          削除
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/panel/EpisodeEditForm.tsx
+++ b/src/components/panel/EpisodeEditForm.tsx
@@ -48,11 +48,13 @@ export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
     }
   };
 
-  // タイトル blur 保存ハンドラ
+  // タイトル blur 保存ハンドラ（空の場合は元の値に戻す）
   const handleTitleBlur = () => {
     const trimmed = title.trim();
     if (trimmed) {
       updateEpisode(episode.id, { title: trimmed });
+    } else {
+      setTitle(episode.title);
     }
   };
 
@@ -81,8 +83,9 @@ export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
     updateEpisode(episode.id, { properties: next });
   };
 
-  // 削除ハンドラ
+  // 削除ハンドラ（確認ダイアログ付き）
   const handleDelete = () => {
+    if (!window.confirm('このエピソードを削除しますか？')) return;
     deleteEpisode(episode.id);
     onClose();
   };
@@ -190,7 +193,6 @@ export function EpisodeEditForm({ episode, onClose }: EpisodeEditFormProps) {
           type="button"
           onClick={handleDelete}
           className="flex items-center gap-1.5 text-sm text-red-600 hover:text-red-800 transition-colors"
-          aria-label="エピソードを削除"
         >
           <Trash2 className="w-4 h-4" />
           削除

--- a/src/components/panel/EpisodeEditPanel.tsx
+++ b/src/components/panel/EpisodeEditPanel.tsx
@@ -1,0 +1,33 @@
+/**
+ * EpisodeEditPanelコンポーネント
+ * 選択中のエピソードIDからEpisodeを取得し、EpisodeEditFormに渡すコンテナ
+ */
+
+'use client';
+
+import { useGraphStore } from '@/stores/useGraphStore';
+import { EpisodeEditForm } from './EpisodeEditForm';
+
+/**
+ * エピソード編集パネルコンポーネント
+ * selectedEpisodeIds[0] に対応するEpisodeをストアから取得して編集フォームを表示する
+ */
+export function EpisodeEditPanel() {
+  const selectedEpisodeIds = useGraphStore((state) => state.selectedEpisodeIds);
+  const episodes = useGraphStore((state) => state.episodes);
+  const clearSelection = useGraphStore((state) => state.clearSelection);
+
+  const episodeId = selectedEpisodeIds[0];
+  const episode = episodes.find((e) => e.id === episodeId);
+
+  // 選択されたエピソードが見つからない場合は何も表示しない
+  if (!episode) return null;
+
+  return (
+    <EpisodeEditForm
+      key={episode.id}
+      episode={episode}
+      onClose={clearSelection}
+    />
+  );
+}

--- a/src/components/panel/EpisodeEditPanel.tsx
+++ b/src/components/panel/EpisodeEditPanel.tsx
@@ -5,6 +5,7 @@
 
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import { useGraphStore } from '@/stores/useGraphStore';
 import { EpisodeEditForm } from './EpisodeEditForm';
 
@@ -13,9 +14,13 @@ import { EpisodeEditForm } from './EpisodeEditForm';
  * selectedEpisodeIds[0] に対応するEpisodeをストアから取得して編集フォームを表示する
  */
 export function EpisodeEditPanel() {
-  const selectedEpisodeIds = useGraphStore((state) => state.selectedEpisodeIds);
-  const episodes = useGraphStore((state) => state.episodes);
-  const clearSelection = useGraphStore((state) => state.clearSelection);
+  const { selectedEpisodeIds, episodes, clearSelection } = useGraphStore(
+    useShallow((state) => ({
+      selectedEpisodeIds: state.selectedEpisodeIds,
+      episodes: state.episodes,
+      clearSelection: state.clearSelection,
+    }))
+  );
 
   const episodeId = selectedEpisodeIds[0];
   const episode = episodes.find((e) => e.id === episodeId);

--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -11,6 +11,7 @@ import { DefaultPanel } from './DefaultPanel';
 import { SingleSelectionPanel } from './SingleSelectionPanel';
 import { PairSelectionPanel } from './PairSelectionPanel';
 import { MultipleSelectionInfo } from './MultipleSelectionInfo';
+import { EpisodeEditPanel } from './EpisodeEditPanel';
 import { AuthorAttribution } from '@/components/graph/AuthorAttribution';
 import Footer from '@/components/layout/Footer';
 import { SettingsModal } from '@/components/ui/SettingsModal';
@@ -21,6 +22,7 @@ import { useGraphStore } from '@/stores/useGraphStore';
  */
 export function SidePanel() {
   const selectedPersonIds = useGraphStore((state) => state.selectedPersonIds);
+  const selectedEpisodeIds = useGraphStore((state) => state.selectedEpisodeIds);
   const persons = useGraphStore((state) => state.persons);
   const relationships = useGraphStore((state) => state.relationships);
   const editingRelationshipId = useGraphStore((state) => state.editingRelationshipId);
@@ -44,9 +46,12 @@ export function SidePanel() {
     );
   }, [editingRelationshipId, relationships, selectedPersonIds]);
 
-  // 選択数によってコンテンツを切り替え（selectedPersons.lengthを使用）
+  // 選択数によってコンテンツを切り替え
   let content;
-  if (selectedPersons.length === 0) {
+  if (selectedEpisodeIds.length === 1 && selectedPersonIds.length === 0) {
+    // エピソード単体選択時: エピソード編集パネル
+    content = <EpisodeEditPanel />;
+  } else if (selectedPersons.length === 0) {
     // 未選択時: デフォルトパネル
     content = <DefaultPanel />;
   } else if (selectedPersons.length === 1) {

--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -51,7 +51,7 @@ export function SidePanel() {
   if (selectedEpisodeIds.length === 1 && selectedPersonIds.length === 0) {
     // エピソード単体選択時: エピソード編集パネル
     content = <EpisodeEditPanel />;
-  } else if (selectedPersons.length === 0) {
+  } else if (selectedPersonIds.length === 0) {
     // 未選択時: デフォルトパネル
     content = <DefaultPanel />;
   } else if (selectedPersons.length === 1) {

--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -51,6 +51,9 @@ export function SidePanel() {
   if (selectedEpisodeIds.length === 1 && selectedPersonIds.length === 0) {
     // エピソード単体選択時: エピソード編集パネル
     content = <EpisodeEditPanel />;
+  } else if (selectedEpisodeIds.length > 1 && selectedPersonIds.length === 0) {
+    // エピソード複数選択時: デフォルトパネルにフォールバック（単一選択モデル外）
+    content = <DefaultPanel />;
   } else if (selectedPersonIds.length === 0) {
     // 未選択時: デフォルトパネル
     content = <DefaultPanel />;

--- a/src/lib/node-intersection.test.ts
+++ b/src/lib/node-intersection.test.ts
@@ -435,3 +435,94 @@ describe('getRectIntersection', () => {
     expect(intersection.y).toBeCloseTo(60, 1);
   });
 });
+
+describe('getEdgeIntersectionPoints（Episodeノード対応）', () => {
+  it('Episodeノード（180x72）の右方向の境界交点を計算する', () => {
+    // Episodeノード中心は (90, 36)、ターゲット中心が同じ高さ(y=36)にある場合
+    // → 右辺中点: x=180、y=36
+    const episodeNode = {
+      id: 'ep-1',
+      type: 'episode' as const,
+      position: { x: 0, y: 0 },
+      measured: { width: 180, height: 72 },
+    };
+    // ターゲットの中心y = position.y + PERSON_IMAGE_RADIUS(40) = 0 → Episodeと高さが同じになるように
+    // position.y = 36 - 40 = -4 にする
+    const targetNode = {
+      id: 'person-1',
+      position: { x: 400, y: -4 },
+      measured: { width: 80, height: 80 },
+    };
+
+    const { sourcePoint } = getEdgeIntersectionPoints(episodeNode, targetNode);
+
+    // Episodeノードは矩形。右方向なので右辺の中点: (90 + 90, 36) = (180, 36)
+    expect(sourcePoint.x).toBeCloseTo(180, 1);
+    expect(sourcePoint.y).toBeCloseTo(36, 1);
+  });
+
+  it('Episodeノード（180x72）の左方向の境界交点を計算する', () => {
+    // Episodeノード中心は (490, 36)、ターゲット中心が同じ高さにある場合
+    const episodeNode = {
+      id: 'ep-1',
+      type: 'episode' as const,
+      position: { x: 400, y: 0 },
+      measured: { width: 180, height: 72 },
+    };
+    const targetNode = {
+      id: 'person-1',
+      position: { x: 0, y: -4 },
+      measured: { width: 80, height: 80 },
+    };
+
+    const { sourcePoint } = getEdgeIntersectionPoints(episodeNode, targetNode);
+
+    // Episodeノード中心は (490, 36)、左方向なので左辺: (400, 36)
+    expect(sourcePoint.x).toBeCloseTo(400, 1);
+    expect(sourcePoint.y).toBeCloseTo(36, 1);
+  });
+
+  it('Person↔Episode の混在ペアで双方の境界上に交点が出る', () => {
+    // Personノードは円形、Episodeノードは矩形
+    const personNode = {
+      id: 'person-1',
+      position: { x: 0, y: 0 },
+      measured: { width: 80, height: 80 },
+    };
+    const episodeNode = {
+      id: 'ep-1',
+      type: 'episode' as const,
+      position: { x: 300, y: 0 },
+      measured: { width: 180, height: 72 },
+    };
+
+    const { sourcePoint, targetPoint } = getEdgeIntersectionPoints(personNode, episodeNode);
+
+    // Personノード（円形・半径40）の中心は(40, 40)→右方向の境界点はx >= 40
+    expect(sourcePoint.x).toBeGreaterThan(40);
+
+    // Episodeノード（矩形180x72）の左辺は x=300 → 左辺の交点はx ≤ 480
+    expect(targetPoint.x).toBeCloseTo(300, 1);
+  });
+
+  it('Episodeノードの measured が未定義のとき fallback サイズ（180x72）を使用する', () => {
+    const episodeNode = {
+      id: 'ep-1',
+      type: 'episode' as const,
+      position: { x: 0, y: 0 },
+      measured: undefined,
+    };
+    // ターゲット中心y=36 になるよう position.y=-4
+    const targetNode = {
+      id: 'person-1',
+      position: { x: 400, y: -4 },
+      measured: { width: 80, height: 80 },
+    };
+
+    const { sourcePoint } = getEdgeIntersectionPoints(episodeNode, targetNode);
+
+    // fallback: 180x72 → 中心(90, 36) → 右辺: x=180
+    expect(sourcePoint.x).toBeCloseTo(180, 1);
+    expect(sourcePoint.y).toBeCloseTo(36, 1);
+  });
+});

--- a/src/lib/node-intersection.test.ts
+++ b/src/lib/node-intersection.test.ts
@@ -120,15 +120,15 @@ describe('getEdgeIntersectionPoints', () => {
       targetNode
     );
 
-    // 新しい計算式:
+    // centerXはPERSON_IMAGE_SIZE/2（40px固定）で計算する
     // - centerY = position.y + PERSON_IMAGE_RADIUS (40px固定)
-    // - centerX = position.x + measured.width / 2
-    // - radius = PERSON_IMAGE_RADIUS (40px固定)
-    // ソースノードの中心(50, 40)、右方向に半径40 → (90, 40)
-    expect(sourcePoint.x).toBeCloseTo(90, 1);
+    // - centerX = position.x + PERSON_IMAGE_SIZE/2 = 0 + 40 = 40
+    // - radius = PERSON_IMAGE_SIZE/2 = 40
+    // ソースノードの中心(40, 40)、右方向に半径40 → (80, 40)
+    expect(sourcePoint.x).toBeCloseTo(80, 1);
     expect(sourcePoint.y).toBeCloseTo(40, 1);
-    // ターゲットノードの中心(250, 40)、左方向に半径40 → (210, 40)
-    expect(targetPoint.x).toBeCloseTo(210, 1);
+    // ターゲットノードの中心(240, 40)、左方向に半径40 → (200, 40)
+    expect(targetPoint.x).toBeCloseTo(200, 1);
     expect(targetPoint.y).toBeCloseTo(40, 1);
   });
 
@@ -498,10 +498,10 @@ describe('getEdgeIntersectionPoints（Episodeノード対応）', () => {
 
     const { sourcePoint, targetPoint } = getEdgeIntersectionPoints(personNode, episodeNode);
 
-    // Personノード（円形・半径40）の中心は(40, 40)→右方向の境界点はx >= 40
-    expect(sourcePoint.x).toBeGreaterThan(40);
+    // Personノード（円形・半径40）の中心は(40, 40)→右方向の境界点はx ≈ 80（中心40 + 半径40）
+    expect(sourcePoint.x).toBeCloseTo(80, 1);
 
-    // Episodeノード（矩形180x72）の左辺は x=300 → 左辺の交点はx ≤ 480
+    // Episodeノード（矩形180x72）の左辺は x=300 → 左辺の交点はx ≈ 300
     expect(targetPoint.x).toBeCloseTo(300, 1);
   });
 

--- a/src/lib/node-intersection.ts
+++ b/src/lib/node-intersection.ts
@@ -146,8 +146,15 @@ export function getRectIntersection(
 }
 
 /**
+ * Episodeノードのデフォルトサイズ（フォールバック用）
+ * EpisodeNodeComponentのカードサイズに対応
+ */
+export const EPISODE_DEFAULT_WIDTH = 180;
+export const EPISODE_DEFAULT_HEIGHT = 72;
+
+/**
  * ノードの情報（位置とサイズ）
- * data.labels から形状（円形/角丸四角形）を導出する
+ * type が 'episode' の場合は矩形として扱い、それ以外は labels から形状を導出する
  */
 interface NodeInfo {
   id: string;
@@ -156,6 +163,48 @@ interface NodeInfo {
   measured?: { width?: number; height?: number };
   /** ノードデータ（labels から形状を導出する） */
   data?: { labels?: string[] };
+}
+
+/**
+ * ノードのバウンディングボックス情報（中心座標・幅・高さ・形状）
+ */
+interface NodeBounds {
+  centerX: number;
+  centerY: number;
+  width: number;
+  height: number;
+  /** 'circle' = 円形（Personノード）、'rect' = 矩形（Episodeノード・物アイコン） */
+  shape: 'circle' | 'rect';
+}
+
+/**
+ * ノードのバウンディングボックスを計算する
+ * - Episodeノード（type='episode'）: 矩形 180x72、中心は左上 + (w/2, h/2)
+ * - Personノード（デフォルト）: labelsから形状を導出し、中心は position + (w/2, PERSON_IMAGE_RADIUS)
+ */
+function getNodeBounds(node: NodeInfo): NodeBounds {
+  if (node.type === 'episode') {
+    const width = node.measured?.width ?? EPISODE_DEFAULT_WIDTH;
+    const height = node.measured?.height ?? EPISODE_DEFAULT_HEIGHT;
+    return {
+      centerX: node.position.x + width / 2,
+      centerY: node.position.y + height / 2,
+      width,
+      height,
+      shape: 'rect',
+    };
+  }
+
+  // Personノード: measured.widthが画像サイズ相当、centerYは固定PERSON_IMAGE_RADIUS
+  const width = node.measured?.width ?? PERSON_IMAGE_SIZE;
+  const isRoundedRect = deriveNodeVisual(node.data?.labels ?? ['人物']).shape === 'rounded-rect';
+  return {
+    centerX: node.position.x + width / 2,
+    centerY: node.position.y + PERSON_IMAGE_RADIUS,
+    width: PERSON_IMAGE_SIZE,
+    height: PERSON_IMAGE_SIZE,
+    shape: isRoundedRect ? 'rect' : 'circle',
+  };
 }
 
 /**
@@ -171,58 +220,42 @@ export function getEdgeIntersectionPoints(
   sourcePoint: { x: number; y: number };
   targetPoint: { x: number; y: number };
 } {
-  // ノードの幅と高さを取得（名前ラベルはabsolute配置のため、measured.widthは画像サイズ相当）
-  // 注: sourceHeight/targetHeightは現在未使用（画像領域のPERSON_IMAGE_SIZEを使用）
-  const sourceWidth = sourceNode.measured?.width || PERSON_IMAGE_SIZE;
-  const _sourceHeight = sourceNode.measured?.height || PERSON_IMAGE_SIZE;
-  const targetWidth = targetNode.measured?.width || PERSON_IMAGE_SIZE;
-  const _targetHeight = targetNode.measured?.height || PERSON_IMAGE_SIZE;
-
-  // ノードの中心座標を計算
-  // centerX: 画像の中心X座標（position.x + sourceWidth / 2）
-  // centerY: 画像の中心Y座標（position.y + PERSON_IMAGE_RADIUS）
-  // 注: 名前ラベルはabsolute配置のため、positionは画像の左上を指す
-  const sourceCenterX = sourceNode.position.x + sourceWidth / 2;
-  const sourceCenterY = sourceNode.position.y + PERSON_IMAGE_RADIUS;
-  const targetCenterX = targetNode.position.x + targetWidth / 2;
-  const targetCenterY = targetNode.position.y + PERSON_IMAGE_RADIUS;
-
-  // ノードの形状に応じて交点を計算
-  // labels 配列から形状を導出する（data が未設定の場合はデフォルト: 円形）
-  const sourceIsRoundedRect = deriveNodeVisual(sourceNode.data?.labels ?? ['人物']).shape === 'rounded-rect';
-  const targetIsRoundedRect = deriveNodeVisual(targetNode.data?.labels ?? ['人物']).shape === 'rounded-rect';
+  const src = getNodeBounds(sourceNode);
+  const tgt = getNodeBounds(targetNode);
 
   // ソースノードの境界との交点を計算
-  const sourcePoint = sourceIsRoundedRect
-    ? getRectIntersection(
-        { x: sourceCenterX, y: sourceCenterY },
-        PERSON_IMAGE_SIZE,
-        PERSON_IMAGE_SIZE,
-        targetCenterX,
-        targetCenterY
-      )
-    : getCircleIntersection(
-        { x: sourceCenterX, y: sourceCenterY },
-        PERSON_IMAGE_RADIUS,
-        targetCenterX,
-        targetCenterY
-      );
+  const sourcePoint =
+    src.shape === 'rect'
+      ? getRectIntersection(
+          { x: src.centerX, y: src.centerY },
+          src.width,
+          src.height,
+          tgt.centerX,
+          tgt.centerY
+        )
+      : getCircleIntersection(
+          { x: src.centerX, y: src.centerY },
+          PERSON_IMAGE_RADIUS,
+          tgt.centerX,
+          tgt.centerY
+        );
 
   // ターゲットノードの境界との交点を計算
-  const targetPoint = targetIsRoundedRect
-    ? getRectIntersection(
-        { x: targetCenterX, y: targetCenterY },
-        PERSON_IMAGE_SIZE,
-        PERSON_IMAGE_SIZE,
-        sourceCenterX,
-        sourceCenterY
-      )
-    : getCircleIntersection(
-        { x: targetCenterX, y: targetCenterY },
-        PERSON_IMAGE_RADIUS,
-        sourceCenterX,
-        sourceCenterY
-      );
+  const targetPoint =
+    tgt.shape === 'rect'
+      ? getRectIntersection(
+          { x: tgt.centerX, y: tgt.centerY },
+          tgt.width,
+          tgt.height,
+          src.centerX,
+          src.centerY
+        )
+      : getCircleIntersection(
+          { x: tgt.centerX, y: tgt.centerY },
+          PERSON_IMAGE_RADIUS,
+          src.centerX,
+          src.centerY
+        );
 
   return {
     sourcePoint,

--- a/src/lib/node-intersection.ts
+++ b/src/lib/node-intersection.ts
@@ -195,11 +195,11 @@ function getNodeBounds(node: NodeInfo): NodeBounds {
     };
   }
 
-  // Personノード: measured.widthが画像サイズ相当、centerYは固定PERSON_IMAGE_RADIUS
-  const width = node.measured?.width ?? PERSON_IMAGE_SIZE;
+  // Personノード: 視覚的なバウンディングボックスはPERSON_IMAGE_SIZE固定
+  // centerX/centerY はノード内の円形アバター中心に合わせる
   const isRoundedRect = deriveNodeVisual(node.data?.labels ?? ['人物']).shape === 'rounded-rect';
   return {
-    centerX: node.position.x + width / 2,
+    centerX: node.position.x + PERSON_IMAGE_SIZE / 2,
     centerY: node.position.y + PERSON_IMAGE_RADIUS,
     width: PERSON_IMAGE_SIZE,
     height: PERSON_IMAGE_SIZE,
@@ -235,7 +235,7 @@ export function getEdgeIntersectionPoints(
         )
       : getCircleIntersection(
           { x: src.centerX, y: src.centerY },
-          PERSON_IMAGE_RADIUS,
+          src.width / 2,
           tgt.centerX,
           tgt.centerY
         );
@@ -252,7 +252,7 @@ export function getEdgeIntersectionPoints(
         )
       : getCircleIntersection(
           { x: tgt.centerX, y: tgt.centerY },
-          PERSON_IMAGE_RADIUS,
+          tgt.width / 2,
           src.centerX,
           src.centerY
         );

--- a/src/stores/useGraphStore.test.ts
+++ b/src/stores/useGraphStore.test.ts
@@ -49,7 +49,7 @@ describe('useGraphStore', () => {
     store.relationships.forEach((relationship) => {
       store.removeRelationship(relationship.id);
     });
-    // 選択状態もクリア
+    // 選択状態もクリア（Person・Episode両方）
     store.clearSelection();
     // forceParamsもリセット
     store.resetForceParams();
@@ -1000,6 +1000,30 @@ describe('useGraphStore', () => {
       });
 
       expect(result.current.selectedPersonIds).toEqual([]);
+    });
+
+    it('clearSelection は selectedEpisodeIds もクリアする', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      // エピソードを追加して選択
+      act(() => {
+        result.current.createEpisode({ title: '雨の日の記憶' });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+
+      act(() => {
+        result.current.selectEpisode(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toHaveLength(1);
+
+      // clearSelection でエピソード選択もクリアされる
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([]);
     });
   });
 
@@ -4459,6 +4483,188 @@ describe('useGraphStore', () => {
         expect(result.current.episodes[0].title).toBe('雨の日の記憶');
         expect(result.current.episodeParticipations).toHaveLength(1);
       });
+    });
+  });
+
+  describe('selectEpisode', () => {
+    it('エピソードを選択するとselectedEpisodeIdsに追加される', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      act(() => {
+        result.current.createEpisode({ title: '初めての出会い' });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+
+      act(() => {
+        result.current.selectEpisode(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+    });
+
+    it('エピソードを選択するとPersonの選択がクリアされる', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      // 人物を追加して先に選択
+      act(() => {
+        result.current.addPerson({
+          name: '山田太郎',
+          imageDataUrl: 'data:image/jpeg;base64,abc',
+          labels: ['人物'],
+          properties: {},
+        });
+      });
+
+      const personId = result.current.persons[0].id;
+
+      act(() => {
+        result.current.selectPerson(personId);
+      });
+
+      expect(result.current.selectedPersonIds).toEqual([personId]);
+
+      // エピソードを選択するとPersonの選択がクリアされる
+      act(() => {
+        result.current.createEpisode({ title: '波乱の展開' });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+
+      act(() => {
+        result.current.selectEpisode(episodeId);
+      });
+
+      expect(result.current.selectedPersonIds).toEqual([]);
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+    });
+
+    it('null を渡すと選択が解除される', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      act(() => {
+        result.current.createEpisode({ title: '別れの季節' });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+
+      act(() => {
+        result.current.selectEpisode(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+
+      act(() => {
+        result.current.selectEpisode(null);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([]);
+    });
+  });
+
+  describe('toggleEpisodeSelection', () => {
+    it('未選択のエピソードを選択できる', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      act(() => {
+        result.current.createEpisode({ title: '旅立ちの朝' });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+
+      act(() => {
+        result.current.toggleEpisodeSelection(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+    });
+
+    it('選択中のエピソードを再度トグルすると選択解除される', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      act(() => {
+        result.current.createEpisode({ title: '再会の喜び' });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+
+      act(() => {
+        result.current.toggleEpisodeSelection(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+
+      act(() => {
+        result.current.toggleEpisodeSelection(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([]);
+    });
+
+    it('トグル選択するとPersonの選択がクリアされる', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      act(() => {
+        result.current.addPerson({
+          name: '佐藤花子',
+          imageDataUrl: 'data:image/jpeg;base64,abc',
+          labels: ['人物'],
+          properties: {},
+        });
+        result.current.createEpisode({ title: '花火大会' });
+      });
+
+      const personId = result.current.persons[0].id;
+      const episodeId = result.current.episodes[0].id;
+
+      // まずPersonを選択
+      act(() => {
+        result.current.selectPerson(personId);
+      });
+
+      expect(result.current.selectedPersonIds).toEqual([personId]);
+
+      // Episodeをトグル選択するとPersonの選択がクリアされる
+      act(() => {
+        result.current.toggleEpisodeSelection(episodeId);
+      });
+
+      expect(result.current.selectedPersonIds).toEqual([]);
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+    });
+  });
+
+  describe('selectPerson', () => {
+    it('Personを選択するとselectedEpisodeIdsがクリアされる', () => {
+      const { result } = renderHook(() => useGraphStore());
+
+      act(() => {
+        result.current.createEpisode({ title: '試練の冬' });
+        result.current.addPerson({
+          name: '鈴木一郎',
+          imageDataUrl: 'data:image/jpeg;base64,abc',
+          labels: ['人物'],
+          properties: {},
+        });
+      });
+
+      const episodeId = result.current.episodes[0].id;
+      const personId = result.current.persons[0].id;
+
+      // まずEpisodeを選択
+      act(() => {
+        result.current.selectEpisode(episodeId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([episodeId]);
+
+      // Personを選択するとEpisode選択がクリアされる
+      act(() => {
+        result.current.selectPerson(personId);
+      });
+
+      expect(result.current.selectedEpisodeIds).toEqual([]);
+      expect(result.current.selectedPersonIds).toEqual([personId]);
     });
   });
 });

--- a/src/stores/useGraphStore.ts
+++ b/src/stores/useGraphStore.ts
@@ -77,6 +77,8 @@ type GraphState = {
   forceEnabled: boolean;
   /** 選択中の人物のIDリスト（複数選択対応） */
   selectedPersonIds: string[];
+  /** 選択中のエピソードのIDリスト */
+  selectedEpisodeIds: string[];
   /** force-directedレイアウトのパラメータ */
   forceParams: ForceParams;
   /** EGO Layoutのパラメータ */
@@ -134,6 +136,7 @@ const INITIAL_STATE: GraphState = {
   relationships: [],
   forceEnabled: false,
   selectedPersonIds: [],
+  selectedEpisodeIds: [],
   forceParams: DEFAULT_FORCE_PARAMS,
   egoLayoutParams: DEFAULT_EGO_LAYOUT_PARAMS,
   sidePanelOpen: true,
@@ -302,6 +305,20 @@ type GraphActions = {
    * @param personIds - 選択する人物のIDリスト
    */
   setSelectedPersonIds: (personIds: string[]) => void;
+
+  /**
+   * エピソードを選択または選択解除する（単一選択モード）
+   * Person選択と排他制御されるため、呼び出し時にselectedPersonIdsはクリアされる
+   * @param episodeId - 選択するエピソードのID（nullで選択解除）
+   */
+  selectEpisode: (episodeId: string | null) => void;
+
+  /**
+   * エピソードの選択をトグルする
+   * Person選択と排他制御されるため、呼び出し時にselectedPersonIdsはクリアされる
+   * @param episodeId - トグルするエピソードのID
+   */
+  toggleEpisodeSelection: (episodeId: string) => void;
 
   /**
    * ペア編集のために2人を選択し、特定の関係を編集対象として記録する
@@ -621,6 +638,8 @@ export const useGraphStore = create<GraphStore>()(
         selectPerson: (personId) =>
           set(() => ({
             selectedPersonIds: personId ? [personId] : [],
+            // Episodeとの排他制御
+            selectedEpisodeIds: [],
           })),
 
         togglePersonSelection: (personId) =>
@@ -632,9 +651,10 @@ export const useGraphStore = create<GraphStore>()(
                 selectedPersonIds: state.selectedPersonIds.filter((id) => id !== personId),
               };
             } else {
-              // 選択追加
+              // 選択追加（Episodeとの排他制御）
               return {
                 selectedPersonIds: [...state.selectedPersonIds, personId],
+                selectedEpisodeIds: [],
               };
             }
           }),
@@ -642,6 +662,7 @@ export const useGraphStore = create<GraphStore>()(
         clearSelection: () =>
           set(() => ({
             selectedPersonIds: [],
+            selectedEpisodeIds: [],
             editingRelationshipId: null,
           })),
 
@@ -655,7 +676,33 @@ export const useGraphStore = create<GraphStore>()(
           set(() => ({
             selectedPersonIds: [id1, id2],
             editingRelationshipId: relationshipId,
+            selectedEpisodeIds: [],
           })),
+
+        selectEpisode: (episodeId) =>
+          set(() => ({
+            selectedEpisodeIds: episodeId ? [episodeId] : [],
+            // Personとの排他制御
+            selectedPersonIds: [],
+            editingRelationshipId: null,
+          })),
+
+        toggleEpisodeSelection: (episodeId) =>
+          set((state) => {
+            const isSelected = state.selectedEpisodeIds.includes(episodeId);
+            if (isSelected) {
+              return {
+                selectedEpisodeIds: state.selectedEpisodeIds.filter((id) => id !== episodeId),
+              };
+            } else {
+              // Personとの排他制御
+              return {
+                selectedEpisodeIds: [...state.selectedEpisodeIds, episodeId],
+                selectedPersonIds: [],
+                editingRelationshipId: null,
+              };
+            }
+          }),
 
         addRelationship: (relationship) =>
           set((state) => {

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,10 +1,11 @@
 /**
  * テスト用ファクトリ関数
- * テスト全体で使用する Person / SnapshotPerson オブジェクトの生成ヘルパー
+ * テスト全体で使用する Person / SnapshotPerson / Episode オブジェクトの生成ヘルパー
  */
 
 import type { Person } from '@/types/person';
 import type { SnapshotPerson } from '@/types/snapshot';
+import type { Episode } from '@/types/episode';
 
 /**
  * Person オブジェクトを生成するファクトリ
@@ -19,6 +20,21 @@ export function makePerson(overrides: Partial<Person> & { id: string; name: stri
     tags: [],
     narrative: { summary: null, notes: null },
     colorOverride: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Episode オブジェクトを生成するファクトリ
+ *
+ * @param overrides - 上書きしたいフィールド（id と title は必須）
+ */
+export function makeEpisode(overrides: Partial<Episode> & { id: string; title: string }): Episode {
+  return {
+    relatedRelationshipIds: [],
+    properties: {},
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     ...overrides,


### PR DESCRIPTION
## Summary

- **選択**: ストアに `selectedEpisodeIds` / `selectEpisode` / `toggleEpisodeSelection` を追加し、Person選択と排他管理
- **編集**: `EpisodeEditPanel` / `EpisodeEditForm` を新設。title/description/occurredAt/relatedRelationshipIds/properties/削除をサポート（IME対応・削除確認ダイアログ付き）
- **接続**: `EpisodeNodeComponent` のHandleをカード中央1点に集約し、`getEdgeIntersectionPoints` で正確な境界交点を算出。Person↔Episode ドラッグ接続で `EpisodeParticipation` を直接生成
- **交点計算**: `node-intersection.ts` に `getNodeBounds` を追加し、Episode矩形（180×72）とPerson円形を統一APIで処理
- **サイドパネル**: Episode単体選択時に `EpisodeEditPanel` を表示する分岐を追加

## Test plan

- [ ] `npm run lint && npm run type-check && npm test` が全てパスすること（1336 tests passed）
- [ ] Episodeノードをクリック → サイドパネルが `EpisodeEditPanel` に切り替わる
- [ ] title / description / occurredAt を編集してEnter/blur → 即反映
- [ ] IME（日本語）変換確定Enterで保存が走らないこと
- [ ] 削除ボタン → 確認ダイアログ → Episodeが消える
- [ ] PersonノードからEpisodeノードへドラッグ接続 → `EpisodeParticipation` が作成される
- [ ] ParticipationEdgeの線端点がカード境界に吸着すること
- [ ] 背景クリック・Escで選択解除（Personと同じ挙動）
- [ ] 既存のPerson編集・Relationship登録フローが壊れていないこと

Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * エピソードの選択・編集機能を追加。エピソード詳細パネルで題目、説明、発生日時を編集可能に。
  * 人物とエピソード間の参加関係を直接作成可能に。エピソード-エピソード接続は防止。
  * エピソードの削除機能を追加。

* **Improvements**
  * ハンドル表示位置を最適化し、より自然なグラフインタラクションを実現。
  * エッジ計算ロジックを改善し、正確なノード間接続を実現。

* **Tests**
  * エピソード編集フォームのテストを追加。
  * グラフストア、ノード交差計算のテストを拡充。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->