### PR TITLE
fix: Azure strict mode 非互換の JSON Schema キーを除去して LLM 抽出 500 エラーを解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "dev": "next dev -p ${PORT:-4000}",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p ${PORT:-4000}",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/components/graph/ChatInputBar.test.tsx
+++ b/src/components/graph/ChatInputBar.test.tsx
@@ -122,8 +122,8 @@ describe('ChatInputBar', () => {
       error: null,
       extractionResult: {
         persons: [
-          { name: '田中太郎', labels: ['人物'], tags: null, narrative: null, properties: {} },
-          { name: '山田花子', labels: ['人物'], tags: null, narrative: null, properties: {} },
+          { name: '田中太郎', labels: ['人物'], tags: null, narrative: null },
+          { name: '山田花子', labels: ['人物'], tags: null, narrative: null },
         ],
         relationships: [
           {
@@ -169,8 +169,8 @@ describe('ChatInputBar', () => {
       error: null,
       extractionResult: {
         persons: [
-          { name: '新キャラA', labels: ['人物'], tags: null, narrative: null, properties: {} },
-          { name: '新キャラB', labels: ['人物'], tags: null, narrative: null, properties: {} },
+          { name: '新キャラA', labels: ['人物'], tags: null, narrative: null },
+          { name: '新キャラB', labels: ['人物'], tags: null, narrative: null },
         ],
         relationships: [
           {
@@ -221,8 +221,8 @@ describe('ChatInputBar', () => {
       error: null,
       extractionResult: {
         persons: [
-          { name: '田中太郎', labels: ['人物'], tags: null, narrative: null, properties: {} },
-          { name: '山田花子', labels: ['人物'], tags: null, narrative: null, properties: {} },
+          { name: '田中太郎', labels: ['人物'], tags: null, narrative: null },
+          { name: '山田花子', labels: ['人物'], tags: null, narrative: null },
         ],
         relationships: [],
         episodes: [

--- a/src/hooks/useExtractRelationships.test.ts
+++ b/src/hooks/useExtractRelationships.test.ts
@@ -33,7 +33,7 @@ vi.mock('@/stores/useAiSettingsStore', () => ({
 }));
 
 const validResult = {
-  persons: [{ name: '田中太郎', labels: ['人物'], tags: null, narrative: null, properties: {} }],
+  persons: [{ name: '田中太郎', labels: ['人物'], tags: null, narrative: null }],
   relationships: [],
   episodes: [],
 };

--- a/src/lib/llm-extraction-schema.test.ts
+++ b/src/lib/llm-extraction-schema.test.ts
@@ -66,8 +66,10 @@ describe('LlmPersonSchema', () => {
     }
   });
 
-  it('properties フィールドを含む人物データをパースできること', () => {
-    const valid = {
+  it('properties フィールドを含む入力でもパースが成功すること（properties フィールドは無視）', () => {
+    // Azure strict mode では z.record() を表現できないため LlmPersonSchema から properties を除外した。
+    // LLM が properties を出力しても、パース時に無視される（additionalProperties 相当の挙動）
+    const valid: unknown = {
       name: '光源氏',
       labels: ['人物'],
       properties: { 身分: '左大臣', 年齢: 20 },
@@ -75,7 +77,8 @@ describe('LlmPersonSchema', () => {
     const result = LlmPersonSchema.safeParse(valid);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.properties).toEqual({ 身分: '左大臣', 年齢: 20 });
+      // properties フィールドはスキーマに存在しないため、result.data に含まれない
+      expect(result.data).not.toHaveProperty('properties');
     }
   });
 
@@ -280,8 +283,8 @@ describe('LlmExtractionResultSchema', () => {
   it('有効な抽出結果（episodes含む）をパースできること', () => {
     const valid: LlmExtractionResult = {
       persons: [
-        { name: '田中太郎', labels: ['人物'], tags: null, narrative: null, properties: {} },
-        { name: '山田花子', labels: ['人物'], tags: null, narrative: null, properties: {} },
+        { name: '田中太郎', labels: ['人物'], tags: null, narrative: null },
+        { name: '山田花子', labels: ['人物'], tags: null, narrative: null },
       ],
       relationships: [
         {
@@ -404,33 +407,17 @@ describe('getLlmExtractionJsonSchema', () => {
     expect(propSchema?.additionalProperties).toBe(false);
   });
 
-  it('persons.items.properties.properties に propertyNames が含まれないこと（Azure strict mode 対応）', () => {
-    // Azure エラーログ: context=('properties','persons','items','properties','properties')
-    // で z.record() が生成した propertyNames が拒否された問題への対応。
-    // OpenAI / Azure strict mode は propertyNames キーをサポートしない。
+  it('persons.items.properties に properties キーが含まれないこと（Azure strict mode 対応）', () => {
+    // Azure エラーログ: context=('properties','persons','items') で z.record() 由来の
+    // properties フィールドが strict mode に非互換のため LlmPersonSchema から除外した。
+    // JSON Schema 上でも persons.items.properties に properties キーが存在しないことを確認する。
     type JsonSchemaObj = Record<string, unknown>;
     const schema = getLlmExtractionJsonSchema() as JsonSchemaObj;
     const schemaProps = schema.properties as JsonSchemaObj;
     const personItems = (schemaProps.persons as JsonSchemaObj).items as JsonSchemaObj;
     const personItemsProps = personItems.properties as JsonSchemaObj;
-    const propSchema = personItemsProps.properties as JsonSchemaObj;
 
-    // propertyNames が存在しないこと
-    expect(propSchema).not.toHaveProperty('propertyNames');
-  });
-
-  it('persons.items.properties.properties が strict mode 要件を満たすこと（Azure strict mode 対応）', () => {
-    // z.record() 由来の properties フィールドが additionalProperties と required を持つこと
-    type JsonSchemaObj = Record<string, unknown>;
-    const schema = getLlmExtractionJsonSchema() as JsonSchemaObj;
-    const schemaProps = schema.properties as JsonSchemaObj;
-    const personItems = (schemaProps.persons as JsonSchemaObj).items as JsonSchemaObj;
-    const personItemsProps = personItems.properties as JsonSchemaObj;
-    const propSchema = personItemsProps.properties as JsonSchemaObj;
-
-    // type が object であること
-    expect(propSchema?.type).toBe('object');
-    // additionalProperties が false であること（Azure strict mode 要件）
-    expect(propSchema?.additionalProperties).toBeDefined();
+    // z.record() フィールドを除外したため properties キーが存在しないこと
+    expect(personItemsProps).not.toHaveProperty('properties');
   });
 });

--- a/src/lib/llm-extraction-schema.test.ts
+++ b/src/lib/llm-extraction-schema.test.ts
@@ -377,6 +377,14 @@ describe('getLlmExtractionJsonSchema', () => {
     expect(() => JSON.stringify(schema)).not.toThrow();
   });
 
+  it('スキーマのどこにも propertyNames が含まれないこと（Azure strict mode 対応 回帰テスト）', () => {
+    // z.record() 由来の propertyNames は Azure / OpenAI strict mode で 400 エラーを引き起こす。
+    // makeStrictJsonSchema が再帰的に propertyNames を除去していることを検証する。
+    const schema = getLlmExtractionJsonSchema();
+    const serialized = JSON.stringify(schema);
+    expect(serialized).not.toContain('"propertyNames"');
+  });
+
   it('全オブジェクトに required が設定されていること（Azure/OpenAI strict mode 対応）', () => {
     // Azure strict mode は全 object に required 配列が必要
     type JsonSchemaObj = Record<string, unknown>;

--- a/src/lib/llm-extraction-schema.test.ts
+++ b/src/lib/llm-extraction-schema.test.ts
@@ -403,4 +403,34 @@ describe('getLlmExtractionJsonSchema', () => {
     expect((propSchema?.required as string[]).includes('closeness')).toBe(true);
     expect(propSchema?.additionalProperties).toBe(false);
   });
+
+  it('persons.items.properties.properties に propertyNames が含まれないこと（Azure strict mode 対応）', () => {
+    // Azure エラーログ: context=('properties','persons','items','properties','properties')
+    // で z.record() が生成した propertyNames が拒否された問題への対応。
+    // OpenAI / Azure strict mode は propertyNames キーをサポートしない。
+    type JsonSchemaObj = Record<string, unknown>;
+    const schema = getLlmExtractionJsonSchema() as JsonSchemaObj;
+    const schemaProps = schema.properties as JsonSchemaObj;
+    const personItems = (schemaProps.persons as JsonSchemaObj).items as JsonSchemaObj;
+    const personItemsProps = personItems.properties as JsonSchemaObj;
+    const propSchema = personItemsProps.properties as JsonSchemaObj;
+
+    // propertyNames が存在しないこと
+    expect(propSchema).not.toHaveProperty('propertyNames');
+  });
+
+  it('persons.items.properties.properties が strict mode 要件を満たすこと（Azure strict mode 対応）', () => {
+    // z.record() 由来の properties フィールドが additionalProperties と required を持つこと
+    type JsonSchemaObj = Record<string, unknown>;
+    const schema = getLlmExtractionJsonSchema() as JsonSchemaObj;
+    const schemaProps = schema.properties as JsonSchemaObj;
+    const personItems = (schemaProps.persons as JsonSchemaObj).items as JsonSchemaObj;
+    const personItemsProps = personItems.properties as JsonSchemaObj;
+    const propSchema = personItemsProps.properties as JsonSchemaObj;
+
+    // type が object であること
+    expect(propSchema?.type).toBe('object');
+    // additionalProperties が false であること（Azure strict mode 要件）
+    expect(propSchema?.additionalProperties).toBeDefined();
+  });
 });

--- a/src/lib/llm-extraction-schema.ts
+++ b/src/lib/llm-extraction-schema.ts
@@ -51,15 +51,9 @@ export const LlmPersonSchema = z.object({
     (v) => v ?? null,
     LlmPersonNarrativeSchema.nullable()
   ),
-  /**
-   * 人物固有のドメイン属性。省略・null の場合は空オブジェクトに正規化
-   * 値の型は string / number / boolean / null に限定（JSON Schema 互換のため）
-   */
-  properties: z.preprocess(
-    (v) => (v == null ? {} : v),
-    z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
-  ),
 });
+// NOTE: properties フィールド（z.record）は Azure / OpenAI strict mode と非互換のためスキーマから除外。
+//       LLM 抽出結果の Person.properties は常に {} として扱い、UI からの手動入力のみを受け付ける。
 
 /**
  * LLM が出力する関係の narrative スキーマ

--- a/src/lib/llm-extraction-schema.ts
+++ b/src/lib/llm-extraction-schema.ts
@@ -5,8 +5,8 @@
  * 主な特徴:
  *   - sourceId / targetId の代わりに sourcePersonName / targetPersonName（名前ベース）
  *   - id / createdAt / updatedAt / colorOverride は除外（ストア側で自動生成）
- *   - properties フィールドは z.preprocess で null/undefined を {} に正規化する
- *     （LLM が properties を省略・null 出力した場合の安全策）
+ *   - Person.properties は LlmPersonSchema に含まない（z.record が Azure strict mode 非互換のため）
+ *     LLM 抽出後の Person.properties は常に {} として扱い、UI からの手動入力のみを受け付ける
  *   - 時系列上の出来事は Relationship.narrative ではなく episodes に抽出する
  *
  * z.toJSONSchema() による JSON Schema 変換に対応している。

--- a/src/lib/llm-extraction-schema.ts
+++ b/src/lib/llm-extraction-schema.ts
@@ -173,9 +173,10 @@ export type LlmEpisode = z.infer<typeof LlmEpisodeSchema>;
  * strict mode の要件:
  * - 全オブジェクトに required（全プロパティキーの配列）が必要
  * - additionalProperties: false が必要
+ * - propertyNames キーは禁止（Azure はサポートしない）
  *
- * zod v4 の z.toJSONSchema() は optional フィールドを required に含めないため、
- * この関数で後処理として補完する。
+ * zod v4 の z.toJSONSchema() は optional フィールドを required に含めず、
+ * z.record() は propertyNames キーを生成するため、この関数で後処理として補完・除去する。
  */
 function makeStrictJsonSchema(schema: unknown): unknown {
   if (typeof schema !== 'object' || schema === null) return schema;
@@ -200,6 +201,12 @@ function makeStrictJsonSchema(schema: unknown): unknown {
     // 全プロパティキーを required に設定（既存の required は上書き）
     result.required = Object.keys(props);
     result.additionalProperties = false;
+  }
+
+  // z.record() は properties を持たず propertyNames を生成する。
+  // Azure / OpenAI strict mode は propertyNames をサポートしないため、type: object のすべてから除去する。
+  if (result.type === 'object' && 'propertyNames' in result) {
+    delete result.propertyNames;
   }
 
   return result;

--- a/src/lib/person-matching.test.ts
+++ b/src/lib/person-matching.test.ts
@@ -66,7 +66,7 @@ describe('matchPersonByName', () => {
 
 describe('resolveExtractionResult', () => {
   // v11 形式の抽出結果（type, label, symmetric: boolean, properties）
-  const llmPersonDefaults = { tags: null, narrative: null, properties: {} };
+  const llmPersonDefaults = { tags: null, narrative: null };
   const extractionResult: LlmExtractionResult = {
     persons: [
       { name: '田中太郎', labels: ['人物'], ...llmPersonDefaults },
@@ -297,7 +297,7 @@ describe('resolveExtractionResult', () => {
   describe('LLM 抽出人物の v15 フィールドフロースルー', () => {
     it('LLM が tags を出力した場合、新規人物に反映されること', () => {
       const extractionResult: LlmExtractionResult = {
-        persons: [{ name: '紫式部', labels: ['人物'], tags: ['作家', '貴族'], narrative: null, properties: {} }],
+        persons: [{ name: '紫式部', labels: ['人物'], tags: ['作家', '貴族'], narrative: null }],
         relationships: [],
         episodes: [],
       };
@@ -314,7 +314,6 @@ describe('resolveExtractionResult', () => {
             labels: ['人物'],
             tags: null,
             narrative: { summary: '平安時代の女流作家', notes: '枕草子の著者' },
-            properties: {},
           },
         ],
         relationships: [],
@@ -325,7 +324,9 @@ describe('resolveExtractionResult', () => {
       expect(newPerson?.narrative).toEqual({ summary: '平安時代の女流作家', notes: '枕草子の著者' });
     });
 
-    it('LLM が properties を出力した場合、新規人物に反映されること', () => {
+    it('LLM 抽出結果の新規人物は properties が常に {} になること', () => {
+      // Azure strict mode 非互換のため LlmPersonSchema から properties フィールドを除外した。
+      // LLM が properties を出力しても無視され、Person.properties は常に {} になる。
       const extractionResult: LlmExtractionResult = {
         persons: [
           {
@@ -333,7 +334,6 @@ describe('resolveExtractionResult', () => {
             labels: ['人物'],
             tags: null,
             narrative: null,
-            properties: { 身分: '左大臣', 年齢: 20, 主人公: true },
           },
         ],
         relationships: [],
@@ -341,12 +341,12 @@ describe('resolveExtractionResult', () => {
       };
       const result = resolveExtractionResult(extractionResult, [], new Map());
       const newPerson = result.newPersons.find((p) => p.name === '光源氏');
-      expect(newPerson?.properties).toEqual({ 身分: '左大臣', 年齢: 20, 主人公: true });
+      expect(newPerson?.properties).toEqual({});
     });
 
     it('LLM が tags・narrative・properties を省略（null）した場合はデフォルト値が使われること', () => {
       const extractionResult: LlmExtractionResult = {
-        persons: [{ name: '夕霧', labels: ['人物'], tags: null, narrative: null, properties: {} }],
+        persons: [{ name: '夕霧', labels: ['人物'], tags: null, narrative: null }],
         relationships: [],
         episodes: [],
       };

--- a/src/lib/person-matching.ts
+++ b/src/lib/person-matching.ts
@@ -135,7 +135,7 @@ export function resolveExtractionResult(
       tags: llmPerson.tags ?? [],
       narrative: llmPerson.narrative ?? { summary: null, notes: null },
       colorOverride: null,
-      properties: llmPerson.properties ?? {},
+      properties: {},
       updatedAt: new Date().toISOString(),
     });
   }

--- a/src/stores/useInterviewStore.test.ts
+++ b/src/stores/useInterviewStore.test.ts
@@ -20,7 +20,7 @@ function resetStore() {
 
 /** テスト用の最小限の抽出結果 */
 const mockExtractionResult: LlmExtractionResult = {
-  persons: [{ name: '山田太郎', labels: ['人物'], tags: null, narrative: null, properties: {} }],
+  persons: [{ name: '山田太郎', labels: ['人物'], tags: null, narrative: null }],
   relationships: [],
   episodes: [],
 };


### PR DESCRIPTION
## Summary

- `makeStrictJsonSchema` 関数に `propertyNames` キーの削除処理を追加（`z.record()` が生成するが Azure strict mode が非対応）
- `LlmPersonSchema` から `properties` フィールド（`z.record()`）を削除（`type:object` + `additionalProperties` の組み合わせが Azure strict mode で根本的に非互換）
- `person-matching.ts` でLLM抽出後の `Person.properties` を常に `{}` として扱うよう変更
- CodeRabbit指摘対応: ファイルヘッダー更新・`package.json` devスクリプトのポート柔軟化

## Background

`POST /api/extract-relationships` および `POST /api/interview-extract` が Azure (OpenRouter 経由) から 400 を受け取り 500 を返していた。

エラー1（修正済み）:
> `Invalid schema for response_format 'response': In context=('properties', 'persons', 'items', 'properties', 'properties'), 'propertyNames' is not permitted.`

エラー2（修正済み）:
> `In context=('properties', 'persons', 'items'), 'required' is required to be supplied and to be an array including every key in properties. Extra required key 'properties' supplied.`

**根本原因**: Zod v4 の `z.record(z.string(), ...)` が JSON Schema 変換時に `propertyNames` と `additionalProperties` を持つスキーマを生成するが、Azure の OpenAI strict mode は両者を受け付けない。

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/lib/llm-extraction-schema.ts` | `makeStrictJsonSchema` に `propertyNames` 削除ロジック追加 / `LlmPersonSchema` から `properties` フィールド削除 |
| `src/lib/person-matching.ts` | `llmPerson.properties ?? {}` → `{}` 固定 |
| `src/lib/llm-extraction-schema.test.ts` | Azure strict mode 非互換キーの回帰防止テスト追加・既存テスト更新 |
| テストファイル各種 | `LlmPerson` 型から `properties` フィールドを除去 |
| `package.json` | dev スクリプトの `--port 4000` → `${PORT:-4000}` に変更 |

## Trade-offs

- LLM が自動抽出できる Person の動的属性（`properties`）が失われる
- ただし `properties` は UI から手動で追加可能であり、既存ストアへの影響なし
- `interview-extract` エンドポイントも同じスキーマを共有するため副次的に修正される

🤖 Generated with [Claude Code](https://claude.com/claude-code)